### PR TITLE
feat(flow): require complete evidence bundles, close runtime-verification escape hatches

### DIFF
--- a/plugins/flow/agents/verdict-judge.md
+++ b/plugins/flow/agents/verdict-judge.md
@@ -28,37 +28,76 @@ This separation is intentional. You are a second set of eyes that evaluates outc
 
 ## Process
 
-### Step 1: Parse Input
+### Step 1: Missing-Criterion Scan (MANDATORY, BEFORE PER-CRITERION EVALUATION)
 
-You receive a structured prompt with:
-- **Acceptance Criteria**: The full list from the issue
-- **Evidence Bundle**: Structured evidence per criterion (verification command + output)
+Before you evaluate any criterion on its merits, you MUST perform a coverage scan. This step exists because previous judges were passing criteria based on partial bundles without noticing that some criteria had no evidence at all.
 
-### Step 2: Evaluate Each Criterion
+Execute the scan in this exact order:
 
-For each acceptance criterion:
+1. **Parse the input**. You receive a structured prompt with:
+   - **Acceptance Criteria**: The full list from the issue
+   - **Evidence Bundle**: Structured evidence per criterion (verification command + output + completeness subsections)
+
+2. **Enumerate every acceptance criterion**. Produce a numbered list of every criterion in the issue. Do not summarize, do not merge, do not drop any. Use the exact criterion text.
+
+3. **Enumerate every evidence entry in the bundle**. Produce a numbered list of every criterion block present in the evidence bundle. Use the exact heading text.
+
+4. **Produce a coverage table** BEFORE evaluating anything:
+
+   ```markdown
+   ### Coverage Scan
+
+   | # | Criterion | Evidence Entry Present? | Completeness Subsections Present? |
+   |---|-----------|-------------------------|-----------------------------------|
+   | 1 | {criterion text} | Yes / NO | Yes / NO ({which are missing}) |
+   ```
+
+   The "Completeness Subsections Present?" column checks that the evidence block contains all three mandatory subsections: "What was NOT tested", "Known limitations of this evidence", and "Negative/adversarial cases covered".
+
+5. **Automatic FAIL rules** — apply these BEFORE per-criterion evaluation and record the result:
+   - Any criterion with no evidence entry at all → **automatic FAIL** with rationale "no evidence — missing-criterion scan". Do NOT attempt to infer, do NOT give NEEDS-HUMAN-REVIEW, do NOT skip it. FAIL it.
+   - Any criterion whose evidence entry is missing one or more of the three mandatory completeness subsections → **automatic FAIL** with rationale "incomplete evidence — missing {list of absent subsections}".
+   - Any evidence entry in the bundle that does not correspond to any acceptance criterion → note it in the scan output as "orphan evidence" but do not use it to pass anything.
+
+6. Carry the coverage table and the auto-FAIL list forward into Step 2. Criteria already marked FAIL by the coverage scan are NOT re-evaluated for PASS in Step 2 — their verdict is locked.
+
+### Step 2: Evaluate Each Remaining Criterion
+
+For each acceptance criterion that survived the coverage scan (i.e., has an evidence entry with all three completeness subsections):
 
 1. Read the criterion carefully — what specific behavior does it require?
 2. Find the corresponding evidence in the bundle
-3. Determine: does the evidence **prove** the criterion is met?
+3. Read the "What was NOT tested", "Known limitations of this evidence", and "Negative/adversarial cases covered" subsections. Factor them into your verdict — if the limitations invalidate the positive evidence, or if the criterion implies adversarial coverage that none was provided for, downgrade accordingly.
+4. Determine: does the evidence **prove** the criterion is met?
 
 **Evaluation rules:**
 - Evidence must **directly confirm** the criterion, not merely be consistent with it
-- Missing evidence for a criterion = FAIL (not NEEDS-HUMAN-REVIEW)
+- Missing evidence for a criterion = FAIL (already handled in Step 1)
 - Ambiguous evidence = NEEDS-HUMAN-REVIEW with explanation of what's unclear
 - Test output showing "pass" for the exact behavior = PASS
 - Screenshot showing expected UI state = PASS (if you can read the screenshot)
 - curl response matching expected status/body = PASS
+- Stated limitations that undercut the positive evidence = FAIL or NEEDS-HUMAN-REVIEW (cite the specific limitation)
 
 ### Step 3: Return Verdict Table
+
+Return the coverage scan output FIRST, then the verdict table.
 
 ```markdown
 ## Verification Verdict
 
+### Coverage Scan
+| # | Criterion | Evidence Entry Present? | Completeness Subsections Present? |
+|---|-----------|-------------------------|-----------------------------------|
+| 1 | {criterion text} | Yes / NO | Yes / NO ({missing}) |
+
+Orphan evidence entries (evidence with no matching criterion): {list or "none"}
+
+### Per-Criterion Verdict
 | # | Criterion | Verdict | Evidence Used | Rationale |
 |---|-----------|---------|---------------|-----------|
 | 1 | {criterion text} | PASS | {which evidence} | {why it proves the criterion} |
-| 2 | {criterion text} | FAIL | {which evidence or "No evidence"} | {what's wrong or missing} |
+| 2 | {criterion text} | FAIL | {which evidence or "No evidence — missing-criterion scan"} | {what's wrong or missing} |
 | 3 | {criterion text} | NEEDS-HUMAN-REVIEW | {which evidence} | {what's ambiguous} |
 
 ### Overall: {PASS | FAIL | NEEDS-HUMAN-REVIEW}

--- a/plugins/flow/agents/verdict-judge.md
+++ b/plugins/flow/agents/verdict-judge.md
@@ -47,15 +47,16 @@ Execute the scan in this exact order:
    ```markdown
    ### Coverage Scan
 
-   | # | Criterion | Evidence Entry Present? | Completeness Subsections Present? |
-   |---|-----------|-------------------------|-----------------------------------|
-   | 1 | {criterion text} | Yes / NO | Yes / NO ({which are missing}) |
+   | # | Criterion | Evidence Entry Present? | "Does NOT promise" Present? | Completeness Subsections Present? |
+   |---|-----------|-------------------------|-----------------------------|-----------------------------------|
+   | 1 | {criterion text} | Yes / NO | Yes / NO | Yes / NO ({which are missing}) |
    ```
 
-   The "Completeness Subsections Present?" column checks that the evidence block contains all three mandatory subsections: "What was NOT tested", "Known limitations of this evidence", and "Negative/adversarial cases covered".
+   The "Does NOT promise Present?" column checks for the plan-time non-goals field. The "Completeness Subsections Present?" column checks that the evidence block contains all three mandatory verify-time subsections: "What was NOT tested", "Known limitations of this evidence", and "Negative/adversarial cases covered".
 
 5. **Automatic FAIL rules** — apply these BEFORE per-criterion evaluation and record the result:
    - Any criterion with no evidence entry at all → **automatic FAIL** with rationale "no evidence — missing-criterion scan". Do NOT attempt to infer, do NOT give NEEDS-HUMAN-REVIEW, do NOT skip it. FAIL it.
+   - Any criterion whose evidence entry is missing "Does NOT promise" → **automatic FAIL** with rationale "incomplete evidence — missing non-goals field ('Does NOT promise')".
    - Any criterion whose evidence entry is missing one or more of the three mandatory completeness subsections → **automatic FAIL** with rationale "incomplete evidence — missing {list of absent subsections}".
    - Any evidence entry in the bundle that does not correspond to any acceptance criterion → note it in the scan output as "orphan evidence" but do not use it to pass anything.
 
@@ -63,12 +64,13 @@ Execute the scan in this exact order:
 
 ### Step 2: Evaluate Each Remaining Criterion
 
-For each acceptance criterion that survived the coverage scan (i.e., has an evidence entry with all three completeness subsections):
+For each acceptance criterion that survived the coverage scan (i.e., has an evidence entry with "Does NOT promise" and all three completeness subsections):
 
 1. Read the criterion carefully — what specific behavior does it require?
 2. Find the corresponding evidence in the bundle
-3. Read the "What was NOT tested", "Known limitations of this evidence", and "Negative/adversarial cases covered" subsections. Factor them into your verdict — if the limitations invalidate the positive evidence, or if the criterion implies adversarial coverage that none was provided for, downgrade accordingly.
-4. Determine: does the evidence **prove** the criterion is met?
+3. Read "Does NOT promise" first. If the non-goals field scopes out behavior that the positive evidence appears to cover, do not credit the coverage as full — the evidence may be testing beyond the criterion's intended scope.
+4. Read the "What was NOT tested", "Known limitations of this evidence", and "Negative/adversarial cases covered" subsections. Factor them into your verdict — if the limitations invalidate the positive evidence, or if the criterion implies adversarial coverage that none was provided for, downgrade accordingly.
+5. Determine: does the evidence **prove** the criterion is met?
 
 **Evaluation rules:**
 - Evidence must **directly confirm** the criterion, not merely be consistent with it
@@ -87,9 +89,9 @@ Return the coverage scan output FIRST, then the verdict table.
 ## Verification Verdict
 
 ### Coverage Scan
-| # | Criterion | Evidence Entry Present? | Completeness Subsections Present? |
-|---|-----------|-------------------------|-----------------------------------|
-| 1 | {criterion text} | Yes / NO | Yes / NO ({missing}) |
+| # | Criterion | Evidence Entry Present? | "Does NOT promise" Present? | Completeness Subsections Present? |
+|---|-----------|-------------------------|-----------------------------|-----------------------------------|
+| 1 | {criterion text} | Yes / NO | Yes / NO | Yes / NO ({missing}) |
 
 Orphan evidence entries (evidence with no matching criterion): {list or "none"}
 

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -312,7 +312,7 @@ If failures: fix and re-run. After max iterations, escalate to user.
 3. **Smoke test** → hit key endpoints or run the CLI with sample input
 4. If any step fails → enter debug-fix-retest loop. Do NOT proceed to Phase 4 until code builds and runs.
 
-Only skip for config-only or markdown-only changes with explicit justification.
+Skipping the build-and-run step is ONLY permitted if the change falls into one of the three enumerated whitelist categories defined in the `runtime-verification` skill: `markdown-only`, `config-only`, or `dependency-bump-only`. Any other skip requires a Proactive-Autonomy escalation — see the skill for the required six-field structure. If in doubt, run it.
 
 ## Phase 4: VERIFY
 
@@ -322,7 +322,8 @@ Prove everything works with fix-forward:
 2. **Runtime verification** (MANDATORY — not conditional on skill availability):
    - Build the project if not already built in Phase 3
    - Start dev server if applicable, smoke test endpoints
-   - Only skip for markdown-only or config-only projects with explicit justification
+   - Skips are permitted ONLY for the three enumerated whitelist categories defined in the `runtime-verification` skill: `markdown-only`, `config-only`, or `dependency-bump-only`. Each requires the specific evidence listed in the skill (file-list proof plus any required syntax or build validation).
+   - Any other skip is forbidden without an approved Proactive-Autonomy escalation (Situation / Tried / Options / Recommendation / Time sensitivity / Risk) via `AskUserQuestion`. Blanket or subjective justifications are not valid. If in doubt, run it.
 3. **Self-review with fix-forward** — dispatch Agent(code-reviewer):
    ```
    Agent(code-reviewer):

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -387,7 +387,7 @@ Prove everything works with fix-forward:
    - `TaskList` — confirm all visual verification tasks resolved
 8. **Completion gate**: ALL of:
    - All quality checks pass
-   - Runtime verification passed (or justified N/A for config/markdown-only)
+   - Runtime verification passed (or skipped under one of the three enumerated whitelist categories in the `runtime-verification` skill: `markdown-only`, `config-only`, `dependency-bump-only`)
    - No unresolved P1 findings
    - All tasks completed (including verification tasks)
    - Verdict: all criteria PASS or user-approved (when `verdict.enabled`)

--- a/plugins/flow/skills/autonomous-workflow/SKILL.md
+++ b/plugins/flow/skills/autonomous-workflow/SKILL.md
@@ -105,7 +105,7 @@ The debug-fix-retest loop is mandatory — do NOT report failures and move on, D
 - **CLI tools**: Build + run with --help + run with sample input
 - **Libraries**: Build + run public API against sample data
 - **Static sites**: Build + serve locally + verify pages load
-- **Config/markdown-only**: Static checks only (explicit justification required)
+- **Whitelisted skip categories** (`markdown-only`, `config-only`, `dependency-bump-only` — see `runtime-verification` skill): Static checks only, with the specific evidence the whitelist requires. Any other skip requires a Proactive-Autonomy escalation.
 
 The loop is bounded by `closedLoop.maxDebugIterations` (default 5). After max iterations, escalate to user — never silently skip.
 

--- a/plugins/flow/skills/criterion-verification-map/SKILL.md
+++ b/plugins/flow/skills/criterion-verification-map/SKILL.md
@@ -65,7 +65,7 @@ During VERIFY phase, for each atomic task's verification command:
 
 ## Evidence Bundle Format
 
-After all verification commands have run, assemble the evidence bundle — a structured text document that the verdict-judge agent receives:
+After all verification commands have run, assemble the evidence bundle — a structured text document that the verdict-judge agent receives. Every criterion block MUST include all fields below. The "Does NOT promise" field is captured at plan time; the three completeness subsections (What was NOT tested, Known limitations, Negative/adversarial cases covered) are populated at verify time and may not be omitted — they force the implementer to state the shape of the evidence honestly so the judge can reason about gaps.
 
 ```markdown
 ## Evidence Bundle for Issue #{N}
@@ -86,6 +86,9 @@ Commits: {count} since branch creation
   - {non-goal 2 — e.g. "does not cover the admin flow"}
   - {non-goal 3 — e.g. "does not handle concurrent writes"}
 - **Screenshot**: {path, if UI type — otherwise omit}
+- **What was NOT tested**: {Explicit list of related behaviors, inputs, code paths, environments, or configurations that this evidence does not cover. Never "N/A" — if you cannot think of anything, you have not thought hard enough. State at minimum: untested environments, untested edge inputs, untested concurrency/scale conditions, untested integrations.}
+- **Known limitations of this evidence**: {How the evidence could be misleading even though it looks positive. Examples: "test uses a mocked external API," "smoke test only hits the happy path," "screenshot was taken at desktop viewport only," "timing numbers taken on an idle machine, not under load." If the verification command is self-reported (agent-run test output), state that explicitly.}
+- **Negative/adversarial cases covered**: {List the specific failure modes, invalid inputs, and abuse cases this evidence demonstrates the system rejects or handles safely. Examples: "rejects empty email with 400," "returns 401 on expired token," "displays error state on network failure." If none were tested, state "none" — do not leave blank — and expect the verdict-judge to treat this as a gap.}
 
 ### Criterion 2: {full criterion text}
 - **Type**: {type}
@@ -96,8 +99,11 @@ Commits: {count} since branch creation
   ```
 - **What the criterion does NOT promise**:
   - {non-goal items}
+- **What was NOT tested**: {as above}
+- **Known limitations of this evidence**: {as above}
+- **Negative/adversarial cases covered**: {as above}
 
-{repeat for all criteria}
+{repeat for all criteria — every criterion MUST have all four subsections}
 ```
 
 ### Why "Does NOT Promise" Is a First-Class Field
@@ -109,12 +115,14 @@ Populate this field at **plan time** from the non-goals captured in the EXPLORE 
 <!--
 SECTION BOUNDARY — VERIFY-TIME EXTENSIONS
 
-Issue #42 (verify phase evidence completeness) will extend this file
-below this boundary with verify-time evidence completeness fields such
-as "What was NOT tested", "Known limitations", and "Negative cases
-covered". Keep the plan-time contract above this line stable. Do not
-inline verify-time fields into the plan-time sections above.
+The three verify-time completeness subsections below were added by
+Issue #42. They are populated at verify time, not plan time. The
+plan-time contract above this line remains stable.
 -->
+
+### Completeness Subsections Are Mandatory
+
+The verdict-judge treats any criterion missing "Does NOT promise" or any of the three completeness subsections ("What was NOT tested", "Known limitations of this evidence", "Negative/adversarial cases covered") as having incomplete evidence and will FAIL that criterion. Do not omit them. If a subsection is genuinely empty (e.g., no adversarial cases tested), write "none" explicitly rather than removing the heading.
 
 ## What the Evidence Bundle Does NOT Include
 

--- a/plugins/flow/skills/runtime-verification/SKILL.md
+++ b/plugins/flow/skills/runtime-verification/SKILL.md
@@ -16,6 +16,63 @@ Domain skill for verifying code works at runtime, beyond static analysis and uni
 
 A green test suite is necessary but not sufficient. Runtime verification proves code actually works. "No test framework" is a problem to solve, not a reason to skip.
 
+## Skip Whitelist (Enumerated — No Subjective Exemptions)
+
+Runtime verification is **MANDATORY** for every change. The only permitted skips are the three categories below. Any skip outside this whitelist is forbidden and must be escalated via the Proactive-Autonomy protocol (see below).
+
+| Skip Category | Definition | Required Evidence to Claim |
+|---------------|------------|----------------------------|
+| `markdown-only` | The diff touches **only** `.md`, `.markdown`, `.txt`, or `.rst` files. Zero code, config, or data files. | `git diff --name-only origin/$DEFAULT_BRANCH..HEAD` output showing only doc extensions. |
+| `config-only` | The diff touches **only** configuration files (`.json`, `.yaml`, `.yml`, `.toml`, `.ini`, `.env.example`, dotfiles) with no executable code path changes. Config syntax must still be validated (lint/schema check, dry-run apply). | Full file list plus syntax validation output. |
+| `dependency-bump-only` | The diff touches **only** lockfiles and manifest version strings (e.g., `package.json` version fields, `package-lock.json`, `poetry.lock`, `Gemfile.lock`, `go.sum`, `Cargo.lock`) with no source code, no config semantics, and no new dependencies. Build must still succeed. | Full file list plus successful build output. |
+
+**If the diff mixes any whitelisted category with anything else (a single `.py` or `.ts` file, a new dependency, a config value change that alters behavior), the skip is disallowed. Run full runtime verification.**
+
+### If In Doubt, Run It
+
+**If you are uncertain whether the change qualifies for a whitelist skip — run runtime verification.** Uncertainty is never a reason to skip. The cost of an extra verification run is small; the cost of shipping unverified code is large. When the category is unclear, default to running.
+
+Explicitly forbidden reasoning patterns (do NOT use these to justify skipping):
+- "This is a small change."
+- "This only touches the CI workflow, it won't affect runtime."
+- "The tests already cover this."
+- "I read the diff and it looks safe."
+- "This is just a refactor."
+- "The markdown includes a code snippet but the snippet isn't executed."
+- "The config change is obvious."
+
+None of those are whitelist categories. If your reasoning for skipping does not map cleanly to `markdown-only`, `config-only`, or `dependency-bump-only` with the evidence shown above, you MUST run verification.
+
+### Escalation Protocol for Out-of-Whitelist Skips
+
+If you genuinely believe a skip outside the whitelist is warranted (e.g., infrastructure-only change, generated-code-only change, or something the whitelist does not yet cover), you MUST NOT proceed silently. Raise a Proactive-Autonomy escalation to the user using this six-field structure:
+
+```markdown
+### Proactive-Autonomy Escalation: Runtime Verification Skip Request
+
+**Situation**
+{What the change is, which files changed, why the standard whitelist does not cover it.}
+
+**Tried**
+{What you already attempted to verify the change through the standard paths — fast-path verify script, build, smoke tests — and why each was insufficient or inapplicable.}
+
+**Options**
+1. {Option A — e.g., run a custom ad-hoc verification despite no framework. Reasoning.}
+2. {Option B — e.g., skip with explicit user approval. Reasoning.}
+3. {Option C — e.g., block and ask for a new whitelist category. Reasoning.}
+
+**Recommendation**
+{Your preferred option and why. Be specific.}
+
+**Time sensitivity**
+{Is this blocking a release? How long will verification take? How long will a skip review take?}
+
+**Risk**
+{What breaks if the skip is wrong? What is the blast radius of shipping unverified?}
+```
+
+The escalation MUST be presented via `AskUserQuestion` and MUST receive an explicit approval before proceeding. Blanket "always skip for this repo" authorization is never valid — each out-of-whitelist skip requires its own escalation.
+
 ## Fast-Path Verification
 
 Check for a project-level verify script first:


### PR DESCRIPTION
## Summary

Closes #42.

Tightens the `/flow` plugin's VERIFY phase on three fronts:

- **Runtime verification skip policy** — replaces the subjective "markdown-only or config-only with explicit justification" escape hatch with an enumerated three-category whitelist (`markdown-only`, `config-only`, `dependency-bump-only`), each with required evidence, plus an explicit "if in doubt, run it" rule and a six-field Proactive-Autonomy escalation protocol (Situation / Tried / Options / Recommendation / Time sensitivity / Risk) for any out-of-whitelist skip.
- **Evidence bundle completeness** — every criterion block now requires three new subsections: "What was NOT tested", "Known limitations of this evidence", and "Negative/adversarial cases covered". The verdict-judge treats missing subsections as incomplete evidence. Section boundaries are kept clean so #40's concurrent edits to the same file can merge.
- **Missing-criterion scan** — adds a mandatory Step 1 to the verdict-judge. Before any per-criterion evaluation, the judge enumerates every criterion and every evidence entry into a coverage table. Any criterion with no evidence is automatic FAIL. Any criterion whose evidence entry is missing a completeness subsection is automatic FAIL. Orphan evidence is flagged but never used to pass anything.

## Files changed

- `plugins/flow/skills/runtime-verification/SKILL.md` — enumerated whitelist, if-in-doubt rule, escalation protocol
- `plugins/flow/commands/start.md` — Phase 3 and Phase 4 aligned with the whitelist; completion gate wording updated
- `plugins/flow/skills/autonomous-workflow/SKILL.md` — minimum-verification list aligned with the whitelist (sweep of lingering subjective reference)
- `plugins/flow/skills/criterion-verification-map/SKILL.md` — three new mandatory evidence bundle subsections (additive, outside the plan-eval sections touched by #40)
- `plugins/flow/agents/verdict-judge.md` — new Step 1 missing-criterion scan; verdict return format surfaces the coverage scan before the per-criterion verdict table

## Verification

- [x] `runtime-verification/SKILL.md` has an enumerated skip whitelist (3 categories only) and an "if in doubt, run it" rule
- [x] `commands/start.md` Phase 4 matches the skill (no subjective escape language)
- [x] `criterion-verification-map/SKILL.md` evidence bundle template has all three new subsections
- [x] `verdict-judge.md` Step 1 is the missing-criterion scan, before per-criterion evaluation
- [x] Grepping the plugin for "markdown-only or config-only" in a subjective context returns only the enumerated whitelist occurrences (the remaining match in `capability-discovery/SKILL.md` is about LSP fallback, unrelated to runtime verification skipping)

## Coordination note

Issue #40 also edits `criterion-verification-map/SKILL.md` to rewrite plan-time eval sources and add a "What the criterion does NOT promise" section. This PR's additions are confined to the "Evidence Bundle Format" section; section boundaries are kept clean so both PRs should merge without conflict.