### PR TITLE
feat(flow): require testable criteria, non-goals, and failure modes in plan phase

### DIFF
--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -212,37 +212,59 @@ Write journal header to `.decisions/issue-$ARGUMENTS.md`.
 
 **Task decomposition** — dispatch implementation-planner agent:
 
+Each implementation task is an **atomic unit** that bundles three responsibilities, not three separate tasks:
+
+1. **Implementation** — the code change
+2. **Test** — the test(s) that verify the behavior the code change introduces
+3. **Verification-evidence collection** — the exact command that will be run in Phase 4 to prove this task's acceptance criterion is met, and the captured output that becomes evidence
+
+A task is not "done" until all three are complete. Splitting them into three sibling tasks (one for code, one for test, one for verify) is explicitly prohibited — it causes implementation to ship before tests catch up and verification to happen after the author has lost context.
+
 ```
 Agent(implementation-planner):
-  "Parse acceptance criteria from issue #$ARGUMENTS and create tasks.
+  "Parse acceptance criteria from issue #$ARGUMENTS and create atomic tasks.
    Issue context: {pre-fetched issue title, body, comments}
+   Specification (from EXPLORE): {non-goals, failure modes, interface contracts}
+   Spec Validation Gate results: {criterion -> verification command mapping}
 
-   For each acceptance criterion, use TaskCreate with:
-   - subject: imperative description
-   - description: criterion text + likely files + verification method
+   For each acceptance criterion, use TaskCreate with a single atomic task:
+   - subject: imperative description of the behavior
+   - description: |
+       Criterion: {full criterion text}
+       Non-goals touched: {which non-goals this task must respect}
+       Failure modes covered: {which failure modes this task implements handling for}
+       Interface contract: {schema/signature this task must honor}
+       Implementation outline: {files + approach}
+       Test plan: {test file + cases + assertions}
+       Verification command: {exact command from Spec Validation Gate}
+       Expected evidence: {what success output looks like}
 
    Set dependencies with TaskUpdate(addBlockedBy).
    Identify parallel execution opportunities.
    Return: task list, dependency graph, suggested order."
 ```
 
-For each implementation task, also create a corresponding test task:
-```
-TaskCreate("Test: {behavior}", "Write or update tests verifying {behavior}. Follow existing test patterns.")
-```
-Set dependency: test task is blocked by its implementation task.
+Each atomic task flows through implementation → test → evidence collection within the same task lifecycle in Phase 3 (CODE). Phase 4 (VERIFY) still runs the full evidence bundle assembly and independent verdict judge, but per-task evidence is captured at the moment the task completes, not weeks after the author has context-switched.
 
-**Verification task creation** — for each acceptance criterion, create a verification task using `criterion-verification-map` classification:
+**Stranger Test check** (mandatory PLAN gate):
 
-```
-TaskCreate(
-  subject: "Verify: {criterion short description}",
-  description: "Criterion: {full criterion text}\n\nVerification method: {type}\nVerification command: {specific command}\nExpected evidence: {what success looks like}",
-  activeForm: "Verifying {short description}"
-)
-```
+Before proceeding to Phase 3 (CODE), the agent MUST run the Stranger Test against the assembled plan:
 
-Verification tasks execute during Phase 4 (VERIFY), not during CODE. They are separate from implementation and test tasks.
+> **Could a zero-context agent — one that has never seen this repo, this issue, or this plan conversation — execute every task in this plan and produce acceptable output?**
+
+Check each task for these failure modes:
+
+- **Implicit file references** — "update the auth module" without the path
+- **Undefined terms** — uses project jargon without definition
+- **Missing preconditions** — assumes setup, env vars, or state that is not written down
+- **Vague success criteria** — "make it work", "fix the issue", "handle it correctly"
+- **Unspecified verification command** — a zero-context agent would not know what to run to prove the task is done
+- **Missing interface contracts** — schema/signature/shape is not written in the task
+- **Missing failure-mode coverage** — the task does not reference which failure modes it must handle
+
+If ANY task fails the Stranger Test, the plan is incomplete. The agent must either rewrite the task to close the gap, or issue a Proactive-Autonomy escalation asking the user to fill in the missing context. Only after every task passes the Stranger Test can the workflow proceed to Phase 3.
+
+Record the Stranger Test result to `.decisions/issue-$ARGUMENTS.md` under a `## Stranger Test` heading with either "PASS — {N} tasks reviewed" or "BLOCK — {task id}: {failure mode}".
 
 Display task plan. Proceed unless user objects.
 

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -117,14 +117,73 @@ If zero acceptance criteria found and `specFirst.requireAcceptanceCriteria` is `
 - Option 2: Only available if issue labels include any of `specFirst.allowSpecFreeLabels` (default: `documentation`, `chore`). Log to decision journal: "Spec-free task: {justification}"
 - Option 3: Stop workflow
 
-If acceptance criteria are found, output a **Spec Validation Table**:
+**Specification capture** (before Spec Validation Gate):
+
+Acceptance criteria alone do not describe the full specification. Before building the Spec Validation Gate, the agent MUST extract or author three additional specification elements. If the issue body states them, extract verbatim. If the issue does not state them, the agent proposes them and confirms with the user via `AskUserQuestion` before proceeding.
+
+Capture all three into the decision journal under a `## Specification` heading:
+
+1. **Non-goals** — what this change explicitly does NOT do. Scope fences that prevent the implementation from sprawling. Example: "Does not add retry logic", "Does not change the public API", "Does not touch the auth flow".
+
+2. **Failure modes** — how the change is expected to behave under failure conditions. Minimum coverage:
+   - **Timeouts** — what happens when an upstream call takes longer than expected?
+   - **Partial failures** — what happens when some operations succeed and others fail?
+   - **Invalid input** — what happens when input violates the contract (wrong type, missing field, out of range)?
+   - **Missing context** — what happens when required config/env/state is absent?
+   For each, record the expected behavior (error type, fallback, user-visible message, log signal).
+
+3. **Interface contracts** — concrete schemas, types, or tool APIs that the change must honor or produce. Examples: request/response JSON shape, function signature, CLI flags, event payload schema, database column types. If the change is internal-only, record the internal module boundary contract.
+
+**When the issue is silent on any of these three**, use `AskUserQuestion`:
+
+> Issue #$ARGUMENTS does not specify {non-goals | failure modes | interface contracts}. I need these before planning so the implementation has a clear fence.
+>
+> Proposed {element}:
+> {agent-drafted proposal of 3-5 items based on issue context}
+>
+> Options:
+> 1. Accept proposal as written
+> 2. Accept with edits (I will prompt you for changes)
+> 3. Reject — specification is incomplete, update the issue first
+
+Only proceed to the Spec Validation Gate once all three specification elements are captured. Log the captured specification to `.decisions/issue-$ARGUMENTS.md` so downstream phases can reference it.
+
+**Spec Validation Gate** (blocking):
+
+If acceptance criteria are found, build a **Spec Validation Table** and treat it as a gate, NOT a display. Every criterion MUST map to a concrete automated verification command before proceeding to Phase 2 (PLAN). This gate blocks progression when any criterion is vague, untestable, or marked `manual` without proper escalation.
 
 ```markdown
-### Spec Validation
-| # | Acceptance Criterion | Verification Method |
-|---|---------------------|-------------------|
-| 1 | {criterion text} | {test/curl/visual/manual} |
+### Spec Validation Gate
+| # | Acceptance Criterion | Verification Command | Gate Status |
+|---|---------------------|----------------------|-------------|
+| 1 | {criterion text} | `{exact command, e.g. npm test -- --grep "auth"}` | PASS |
+| 2 | {vague criterion} | (none — cannot automate) | BLOCK |
 ```
+
+**Gate rules:**
+
+- **PASS** — criterion has a concrete, runnable verification command (test command, curl, script invocation, build check, lint rule). The command must be specific enough that a zero-context agent could run it and collect evidence without further interpretation.
+- **BLOCK** — criterion is vague ("handle errors gracefully", "improve performance", "be user-friendly"), has no automatable check, or the verification method is unknown. Progression to PLAN is blocked.
+- **MANUAL (escalation only)** — `manual` verification is ONLY permitted when flagged as a Proactive-Autonomy escalation with the full six-field structure. Default behavior treats `manual` as BLOCK.
+
+**When any criterion BLOCKS**, the agent MUST NOT proceed to PLAN. Instead, issue a Proactive-Autonomy escalation via `AskUserQuestion` with all six fields:
+
+> **Situation** — Criterion #{n} "{vague text}" has no automatable verification. Shipping with this criterion means the plan cannot define what "done" looks like.
+>
+> **Tried** — I attempted to classify the criterion via `criterion-verification-map`. No verification type matched. Searched the codebase for existing tests covering similar behavior: {found|not found}.
+>
+> **Options**:
+> 1. Rewrite criterion as "{concrete measurable rewording}" with verification command `{specific command}`
+> 2. Rewrite criterion as "{alternative measurable rewording}" with verification command `{alternative command}`
+> 3. Mark as `manual` — I (the user) will verify this step myself at VERIFY phase. The plan will record manual evidence collection.
+>
+> **Recommendation** — Option {1|2} — measurable criteria produce better verdicts and prevent vague implementations.
+>
+> **Time sensitivity** — Blocks planning. Must resolve before Phase 2.
+>
+> **Risk** — Choosing Option 3 (`manual`) means no automated verdict for this criterion and requires a human-in-the-loop at VERIFY phase.
+
+Only after every criterion shows PASS or user-approved MANUAL can the workflow proceed to Phase 2.
 
 **Assign the issue:**
 

--- a/plugins/flow/skills/architecture-patterns/SKILL.md
+++ b/plugins/flow/skills/architecture-patterns/SKILL.md
@@ -91,6 +91,49 @@ UI → Application → Domain → Infrastructure
 
 TaskUpdate("Coupling analysis", status: "completed")
 
+## Failure Modes and Non-Goals
+
+Architecture decisions are incomplete without an explicit fence. Every design proposal MUST capture failure modes and non-goals alongside the happy-path component diagram. A design that only describes the success path is a design that will fail under the first unexpected condition.
+
+### Non-Goals (What This Design Does NOT Do)
+
+Non-goals are scope fences. They prevent the design from sprawling into adjacent problems and prevent reviewers from rejecting the design because it "doesn't handle X" when X was never its job. Capture non-goals as a bulleted list in the decision record:
+
+- What this design explicitly does NOT cover (features, flows, or actors out of scope)
+- What it does NOT guarantee (consistency levels, durability, isolation, ordering)
+- What it does NOT replace (existing components that stay untouched)
+- What it does NOT optimize for (latency, throughput, cost, developer ergonomics — pick what matters and name what is deprioritized)
+
+Non-goals must be written as declarative negations, not hedges. "Does not support multi-region writes" is a non-goal. "May eventually support multi-region writes" is a hedge and is not useful.
+
+### Failure Modes (How This Design Behaves Under Failure)
+
+Every component in the design must have documented behavior for at least these failure modes:
+
+| Failure Mode | Design Question | Record |
+|--------------|-----------------|--------|
+| **Timeouts** | What happens when a downstream call exceeds the deadline? | Error type, fallback, caller-visible outcome |
+| **Partial failures** | What happens when some operations in a batch succeed and others fail? | Rollback / compensate / surface partial result / retry policy |
+| **Invalid input** | What happens when input violates the contract (wrong type, missing field, out of range)? | Validation boundary, error shape, rejection vs. coercion |
+| **Missing context** | What happens when required config, env vars, or upstream state is absent? | Fail-fast at startup / degrade gracefully / specific error |
+| **Dependency outage** | What happens when a required external service is unreachable? | Circuit break / cache / queue / hard fail |
+| **Resource exhaustion** | What happens under memory pressure, connection-pool exhaustion, or rate limits? | Backpressure / shed load / error shape |
+
+Record each failure mode's expected behavior in the decision record. If the design has no answer for a failure mode, that is a gap to close before proceeding — not a detail to defer to implementation.
+
+### Integration With the Decision Record
+
+Extend the Decision Framework table (below) with two new fields when documenting architectural decisions:
+
+- **Non-goals** — bulleted list of what this decision does NOT do
+- **Failure modes** — table of failure mode → expected behavior for each component touched
+
+These fields are NOT optional. A decision record missing them is incomplete and should not ship.
+
+### Why This Belongs at Design Time
+
+Failure modes discovered at implementation time force backtracking: the author has to redesign mid-build to handle a case the design ignored. Failure modes discovered at verify time force fix-forward loops or rework. Failure modes captured at design time become test cases, verification commands, and explicit non-goals that prevent scope creep. The cost of capturing them early is minutes; the cost of discovering them late is days.
+
 ## Decision Framework
 
 TaskUpdate("Decision documentation", status: "in_progress")

--- a/plugins/flow/skills/criterion-verification-map/SKILL.md
+++ b/plugins/flow/skills/criterion-verification-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: criterion-verification-map
-description: "Map each acceptance criterion to a specific verification method, collect evidence during verification, and produce a structured evidence bundle for the verdict judge. Use when verifying implementation completeness against issue acceptance criteria."
+description: "Treat each acceptance criterion as an eval source that produces a runnable verification command at plan time, then collect evidence and assemble a structured bundle for the verdict judge at verify time. Use when planning implementation against issue acceptance criteria and when verifying completeness."
 allowed-tools: Bash, Read, Grep, Glob, TaskCreate, TaskList, TaskUpdate, TaskGet
 context: fork
 agent: general-purpose
@@ -8,15 +8,24 @@ agent: general-purpose
 
 # Criterion Verification Map
 
-Domain skill that formalizes the mapping from acceptance criteria to verification methods and structures evidence collection.
+Domain skill that treats acceptance criteria as **eval sources**. Each criterion produces a concrete, runnable check at plan time — not at verify time. Planning a criterion without a runnable command is a blocking error.
 
 ## Iron Law
 
-**EVERY ACCEPTANCE CRITERION GETS A VERIFICATION METHOD AND AN INDIVIDUAL VERDICT.** No criterion passes by assumption. No criterion is "too obvious to verify."
+**EVERY ACCEPTANCE CRITERION IS AN EVAL SOURCE.** At plan time, each criterion must produce a runnable verification command. No criterion is deferred to verify time with "we'll figure out how to test this later." No criterion passes by assumption. No criterion is "too obvious to verify."
 
-## Criterion Classification
+## Criteria as Eval Sources (Plan Time)
 
-Each acceptance criterion maps to a verification type:
+An acceptance criterion is useful only if it can be evaluated mechanically. At plan time, the criterion must be transformed into:
+
+1. **A verification type** (classification — see table below)
+2. **A runnable command** (the exact bash/test/curl/script invocation that will be executed at verify time)
+3. **Expected evidence shape** (what the command's output must contain to count as PASS)
+4. **What the criterion does NOT promise** (non-goals scoped to this criterion — prevents scope creep and false-positive verdicts)
+
+If any of the four cannot be filled in at plan time, the criterion is not ready. Escalate through the Spec Validation Gate in the `start.md` EXPLORE phase, not here.
+
+### Criterion Classification Table
 
 | Criterion Type | Signal Words | Verification Method | Evidence Format |
 |---------------|-------------|-------------------|-----------------|
@@ -27,33 +36,36 @@ Each acceptance criterion maps to a verification type:
 | Performance | "within N ms", "rate limit", "timeout" | Benchmark/timing command | Timing output |
 | Configuration | "config", "environment", "setting" | Build/load test | Build success log |
 | Data processing | "transforms", "converts", "output matches" | Run with test data | Input/output comparison |
+| Contract (schema/type) | "schema", "type", "interface", "signature", "shape" | Schema validator / type-check | Validator output or type-check diagnostic |
 
-## Creating Verification Tasks
+## Plan-Time Task Creation
 
-During the PLAN phase, after the implementation-planner creates implementation tasks, create a matching verification task for each acceptance criterion:
+Per `commands/start.md` Phase 2 (PLAN), tasks are **atomic**: implementation, test, and evidence collection are bundled into one task. This skill's role at plan time is to produce the verification command and expected evidence shape that gets embedded into that atomic task's description.
+
+For each acceptance criterion, the atomic task description must include:
 
 ```
-TaskCreate(
-  subject: "Verify: {criterion short description}",
-  description: "Criterion: {full criterion text}\n\nVerification method: {type from classification}\nVerification command: {specific command to run}\nExpected evidence: {what success looks like}",
-  activeForm: "Verifying {short description}"
-)
+Criterion: {full criterion text}
+Verification type: {type from classification table}
+Verification command: {exact runnable command}
+Expected evidence: {what successful output looks like}
+Does NOT promise: {non-goals scoped to this criterion}
 ```
 
-Verification tasks execute during the VERIFY phase, NOT during CODE. They are separate from implementation tasks.
+The atomic task flows through implementation → test → evidence collection within Phase 3 (CODE). Evidence is captured at task-completion time.
 
 ## Evidence Collection Protocol
 
-During VERIFY phase, for each verification task:
+During VERIFY phase, for each atomic task's verification command:
 
-1. `TaskUpdate(verifyTaskId, status: "in_progress")`
-2. Execute the verification command
+1. `TaskUpdate(taskId, status: "in_progress")`
+2. Execute the verification command captured at plan time
 3. Capture output as evidence
-4. `TaskUpdate(verifyTaskId, status: "completed", result: "EVIDENCE_COLLECTED")`
+4. `TaskUpdate(taskId, status: "completed", result: "EVIDENCE_COLLECTED")`
 
 ## Evidence Bundle Format
 
-After all verification tasks complete, assemble the evidence bundle — a structured text document that the verdict-judge receives:
+After all verification commands have run, assemble the evidence bundle — a structured text document that the verdict-judge agent receives:
 
 ```markdown
 ## Evidence Bundle for Issue #{N}
@@ -63,12 +75,16 @@ Branch: {branch name}
 Commits: {count} since branch creation
 
 ### Criterion 1: {full criterion text}
-- **Type**: {behavioral|api|ui|error|performance|config|data}
+- **Type**: {behavioral|api|ui|error|performance|config|data|contract}
 - **Verification command**: `{command that was run}`
 - **Evidence**:
   ```
   {raw output from verification command}
   ```
+- **What the criterion does NOT promise**:
+  - {non-goal 1 — e.g. "does not guarantee idempotency across retries"}
+  - {non-goal 2 — e.g. "does not cover the admin flow"}
+  - {non-goal 3 — e.g. "does not handle concurrent writes"}
 - **Screenshot**: {path, if UI type — otherwise omit}
 
 ### Criterion 2: {full criterion text}
@@ -78,9 +94,27 @@ Commits: {count} since branch creation
   ```
   {output}
   ```
+- **What the criterion does NOT promise**:
+  - {non-goal items}
 
 {repeat for all criteria}
 ```
+
+### Why "Does NOT Promise" Is a First-Class Field
+
+A verdict judge receiving only criterion text and evidence tends to over-credit passing commands — e.g., a passing unit test is treated as proof the whole behavior is correct, when the test only covered one path. The "does NOT promise" field explicitly fences each criterion's scope so the judge does not inflate a narrow PASS into a broad guarantee. It also gives reviewers and future readers a shared understanding of what was intentionally out of scope.
+
+Populate this field at **plan time** from the non-goals captured in the EXPLORE phase Specification capture sub-step. Each criterion inherits the global non-goals plus any criterion-specific non-goals discovered during planning.
+
+<!--
+SECTION BOUNDARY — VERIFY-TIME EXTENSIONS
+
+Issue #42 (verify phase evidence completeness) will extend this file
+below this boundary with verify-time evidence completeness fields such
+as "What was NOT tested", "Known limitations", and "Negative cases
+covered". Keep the plan-time contract above this line stable. Do not
+inline verify-time fields into the plan-time sections above.
+-->
 
 ## What the Evidence Bundle Does NOT Include
 
@@ -120,9 +154,16 @@ Visual analysis: Login form visible with email and password fields, submit butto
 npm run test -- --grep "invalid credentials" 2>&1 | tail -10
 ```
 
+**Contract (schema/type)**:
+```bash
+npx tsc --noEmit 2>&1 | tail -20
+# or
+npx ajv validate -s schemas/payload.json -d fixtures/sample.json
+```
+
 ## Integration with Start Command
 
 The criterion-verification-map skill is invoked in two phases of `/flow:start`:
 
-1. **PLAN phase**: Classify criteria and create verification tasks
-2. **VERIFY phase**: Execute verification tasks and assemble evidence bundle
+1. **EXPLORE / PLAN phase (plan time)** — Classify each criterion, produce a runnable verification command, and capture "does NOT promise" non-goals. These become the `Verification command` and `Does NOT promise` fields of the atomic task created in PLAN.
+2. **VERIFY phase (verify time)** — Execute the verification commands captured at plan time and assemble the evidence bundle.


### PR DESCRIPTION
## Summary

Closes #40.

The `/flow:start` EXPLORE and PLAN phases parsed acceptance criteria but never required them to be testable. Vague criteria like "handle errors gracefully" passed through unchallenged, non-goals and failure modes were never captured, and the plan did not have to pass the Stranger Test. This PR closes those gaps at plan time — before implementation begins — so vague plans stop producing vague implementations and vague verdicts.

## Changes

- **`plugins/flow/commands/start.md` EXPLORE phase** — adds a "Specification capture" sub-step that requires extracting or authoring non-goals, failure modes (timeouts, partial failures, invalid input, missing context), and interface contracts before planning. Agent proposes them via `AskUserQuestion` when the issue is silent.
- **`plugins/flow/commands/start.md` Spec Validation Gate** — converts the old display-only Spec Validation Table into a blocking gate. Every acceptance criterion must map to a concrete automated verification command. `manual` is only permitted as a Proactive-Autonomy escalation with the full six-field structure (Situation / Tried / Options / Recommendation / Time sensitivity / Risk). Vague criteria block progression to PLAN.
- **`plugins/flow/commands/start.md` PLAN task decomposition** — replaces the three-sibling pattern (implementation + test + verify as separate tasks) with a single atomic task bundling implementation outline, test plan, verification command, and expected evidence. Per-task evidence is captured while the author still has context.
- **`plugins/flow/commands/start.md` Stranger Test check** — mandatory PLAN gate that scans every task for implicit file references, undefined terms, missing preconditions, vague success criteria, unspecified verification commands, missing interface contracts, and missing failure-mode coverage. Any failure blocks progression to CODE.
- **`plugins/flow/skills/criterion-verification-map/SKILL.md`** — rewritten to treat criteria as eval sources that produce a runnable verification command at plan time. Adds "What the criterion does NOT promise" as a first-class field in the evidence bundle so the verdict judge does not inflate a narrow PASS into a broad guarantee. Includes a SECTION BOUNDARY marker so issue #42 (verify-time evidence completeness) can extend the file without conflicting with the plan-time contract.
- **`plugins/flow/skills/architecture-patterns/SKILL.md`** — adds a "Failure Modes and Non-Goals" section requiring every design proposal to capture non-goals (as declarative negations) and failure modes (timeouts, partial failures, invalid input, missing context, dependency outage, resource exhaustion) alongside the happy-path component diagram. Decision Framework is extended to require both as non-optional fields.

## Commits

- `583d67f` feat(flow): require specification capture and spec validation gate in explore phase
- `7b3056c` feat(flow): bundle implementation, test, and evidence collection into atomic plan tasks
- `175d4b2` refactor(flow): rewrite criterion-verification-map to treat criteria as plan-time eval sources
- `8a48823` feat(flow): capture failure modes and non-goals at architecture design time

## Verification

Plan-time gates are markdown instructions consumed by the agent at runtime — there is no runnable test suite for this plugin. Verification is by reading the new sections and confirming each acceptance criterion has a concrete anchor:

| # | Acceptance criterion | Verified by |
|---|---------------------|-------------|
| 1 | EXPLORE "Specification capture" sub-step requires non-goals, failure modes, interface contracts | `plugins/flow/commands/start.md` lines 120-149 — `## Specification capture` section with `AskUserQuestion` escalation when issue is silent |
| 2 | PLAN Spec Validation Gate requires concrete automated verification command; `manual` only via six-field escalation | `plugins/flow/commands/start.md` lines 151-194 — `### Spec Validation Gate` with PASS/BLOCK/MANUAL rules and six-field Proactive-Autonomy escalation template |
| 3 | PLAN ends with Stranger Test check | `plugins/flow/commands/start.md` lines 249-267 — `**Stranger Test check** (mandatory PLAN gate)` with zero-context executability check and `.decisions/issue-N.md` logging |
| 4 | Task decomposition bundles implementation + test + evidence collection as one atomic unit | `plugins/flow/commands/start.md` lines 213-247 — atomic task description template replaces prior three-sibling pattern |
| 5 | criterion-verification-map treats criteria as eval sources at plan time | `plugins/flow/skills/criterion-verification-map/SKILL.md` lines 11, 14, 17-25 — Iron Law rewritten and `## Criteria as Eval Sources (Plan Time)` section |
| 6 | criterion-verification-map evidence bundle has "What the criterion does NOT promise" section | `plugins/flow/skills/criterion-verification-map/SKILL.md` lines 84-89 and 97-99 — first-class field in bundle format, plus rationale section |
| 7 | architecture-patterns has "Failure modes and non-goals" section | `plugins/flow/skills/architecture-patterns/SKILL.md` lines 94-142 — `## Failure Modes and Non-Goals` with non-goals guidance, failure-mode table (6 modes), and decision-record integration |

## Coordination note

Issue #42 (verify phase evidence completeness) will extend `criterion-verification-map/SKILL.md` with verify-time fields ("What was NOT tested", "Known limitations", "Negative cases covered"). This PR leaves an explicit `SECTION BOUNDARY` HTML comment in the file at the point where those fields slot in, so the later PR can extend below the boundary without conflicting with the plan-time contract above it.

## Test plan

- [ ] Read the `Specification capture` section in `plugins/flow/commands/start.md` and confirm it requires non-goals, failure modes (timeouts, partial failures, invalid input, missing context), and interface contracts.
- [ ] Read the `Spec Validation Gate` section and confirm it blocks progression when any criterion lacks a concrete verification command, and that `manual` requires a six-field escalation.
- [ ] Read the atomic task template and confirm implementation + test + evidence collection are bundled, not split.
- [ ] Read the `Stranger Test check` section and confirm it runs at end of PLAN with a zero-context executability standard.
- [ ] Read `criterion-verification-map/SKILL.md` and confirm the Iron Law treats criteria as eval sources and the evidence bundle includes "What the criterion does NOT promise".
- [ ] Read `architecture-patterns/SKILL.md` and confirm the new "Failure Modes and Non-Goals" section requires both as non-optional fields in the decision record.