### PR TITLE
feat(flow): stop deferring findings, remove P3 cap on pre-existing issues

### DIFF
--- a/plugins/flow/agents/code-reviewer.md
+++ b/plugins/flow/agents/code-reviewer.md
@@ -41,11 +41,13 @@ This provides semantic accuracy that grep-based searches cannot — it resolves 
 
 For each finding, classify its scope:
 
-| Scope | Definition | Priority Cap |
-|-------|-----------|--------------|
-| **Introduced** | Code added or modified on this branch | Full P1/P2/P3 |
-| **Pre-existing** | Issue in unchanged lines of touched files | P3 max, prefix with "pre-existing" |
+| Scope | Definition | Priority |
+|-------|-----------|----------|
+| **Introduced** | Code added or modified on this branch | Natural P1/P2/P3 based on impact |
+| **Pre-existing** | Issue in unchanged lines of touched files | Natural P1/P2/P3 based on impact, prefix description with "pre-existing" |
 | **Adjacent** | Issue in untouched files | Do not report |
+
+Pre-existing findings keep their natural priority. A SQL injection in unchanged code of a touched file is P1, not P3 — the "pre-existing" prefix labels the source, it does not cap severity. If you're modifying a file, you own the known defects in it: excellence means fixing them, not shipping them forward.
 
 Only report findings in **Introduced** and **Pre-existing** scope. Never report issues in files the branch hasn't touched.
 

--- a/plugins/flow/agents/error-handler-inspector.md
+++ b/plugins/flow/agents/error-handler-inspector.md
@@ -74,11 +74,13 @@ LSP diagnostics provide higher confidence than pattern matching because they com
 
 For each finding, classify its scope:
 
-| Scope | Definition | Priority Cap |
-|-------|-----------|--------------|
-| **Introduced** | New code error handling gaps in added/modified code | Full P1/P2/P3 |
-| **Pre-existing** | Error handling gaps in unchanged lines of touched files | P3 max, prefix with "pre-existing" |
+| Scope | Definition | Priority |
+|-------|-----------|----------|
+| **Introduced** | New code error handling gaps in added/modified code | Natural P1/P2/P3 based on impact |
+| **Pre-existing** | Error handling gaps in unchanged lines of touched files | Natural P1/P2/P3 based on impact, prefix description with "pre-existing" |
 | **Adjacent** | Error handling gaps in untouched files | Do not report |
+
+Pre-existing findings keep their natural priority. An unhandled exception that crashes the process is P1 whether it was introduced on this branch or already living in the file — the "pre-existing" prefix labels provenance, it does not cap severity. Touching a file means owning its known defects.
 
 Only report findings in **Introduced** and **Pre-existing** scope.
 

--- a/plugins/flow/commands/address.md
+++ b/plugins/flow/commands/address.md
@@ -136,13 +136,24 @@ For **Question** items: prepare a response comment (no code change needed).
 
 For **Pushback** items: explain reasoning in response comment.
 
-For **Out-of-scope** items — only items that FAIL the proximity test are out-of-scope:
+For **Out-of-scope** items — the proximity test is NOT a deferral mechanism for P1/P2 findings:
 
-A finding in a file the PR already modifies is NOT out-of-scope if it passes the proximity test — it should be fixed under the Boy Scout Rule.
+A finding in a file the PR already modifies is NEVER out-of-scope — it must be fixed in this PR (Boy Scout Rule + ownership of known defects in touched files).
 
-If a finding truly fails the proximity test (untouched files, architecture changes, new tests required):
+Only **cosmetic P3 findings in truly untouched files** may become follow-up issues by default. P1 or P2 findings in untouched files must either:
 
-1. Use the AskUserQuestion tool with contextual options: "This finding is valid but out-of-scope (fails proximity test). Create a follow-up issue to track it?"
+1. Be addressed in-PR (expand scope with an `improve:` commit if the fix is bounded), OR
+2. Be filed as a six-field Proactive-Autonomy escalation:
+   - **Situation**: what the finding is and where (file:line)
+   - **Tried**: what you considered and why it didn't resolve in-PR
+   - **Options**: 2–3 concrete paths forward with trade-offs
+   - **Recommendation**: your recommended option with reasoning
+   - **Time sensitivity**: is this blocking? urgent? safe to wait?
+   - **Risk**: what happens if we defer, and to whom
+
+For cosmetic P3 findings in untouched files that the team agrees to track separately:
+
+1. Use the AskUserQuestion tool with contextual options: "This cosmetic P3 finding is in an untouched file. Create a follow-up issue to track it?"
 2. If yes, create a GitHub issue using issue-crafting skill knowledge:
    - Title: concise, solution-agnostic description
    - Body: Context, Current State (file:line), Objective, Acceptance Criteria
@@ -169,7 +180,8 @@ If a finding truly fails the proximity test (untouched files, architecture chang
 3. **Convergence check** (max 3 self-review-fix iterations):
    - Self-review finds P1 → fix NOW (don't re-request with known P1s)
    - P2 in touched files → fix NOW
-   - P3 → note only
+   - P3 in touched files → fix NOW (same disposition as P1/P2 — the proximity test is not a deferral mechanism)
+   - Only truly cosmetic P3 findings in untouched files may become follow-up issues; P1/P2 in untouched files must be addressed in-PR or filed as a six-field Proactive-Autonomy escalation (Situation / Tried / Options / Recommendation / Time sensitivity / Risk)
    - After fixes: re-run quality commands, re-review changed files
 4. **Verify Boy Scout cleanup** passes proximity test (no scope creep)
 5. **Change classification** — verify no out-of-context changes introduced
@@ -195,7 +207,7 @@ If a finding truly fails the proximity test (untouched files, architecture chang
    - TaskUpdate(postCommentTaskId, status: "completed", result: "PASS — resolution comment posted to PR")
 9. **Update PR body review cycle state** (if `### Review Cycle History` exists in the PR body):
    - Fetch current body: `gh pr view $ARGUMENTS --json body --jq '.body'`
-   - If the body contains `### Review Cycle History`, replace content between that heading and the next `##` heading with the cycle metrics table (received/fixed/discussed/deferred)
+   - If the body contains `### Review Cycle History`, replace content between that heading and the next `##` heading with the cycle metrics table (received/fixed/discussed/escalated)
    - If the heading does not exist, append a `### Review Cycle History` section under `## Review Findings`
    - Update: `gh pr edit $ARGUMENTS --body "$UPDATED_BODY"`
 10. **TaskList**: Confirm ALL tasks complete including "Post resolution comment". Do NOT proceed until verified.

--- a/plugins/flow/commands/review.md
+++ b/plugins/flow/commands/review.md
@@ -58,7 +58,7 @@ gh api repos/$REPO/issues/$ARGUMENTS/comments --jq '
   [.[] | select(.body | test("FLOW_RESOLUTION_CYCLE")) | {
     cycle: (.body | capture("FLOW_RESOLUTION_CYCLE:(?<n>[0-9]+)") | .n),
     resolved: (.body | capture("RESOLVED:\\[(?<r>[^\\]]*?)\\]") | .r),
-    deferred: (.body | capture("DEFERRED:\\[(?<d>[^\\]]*?)\\]") | .d)
+    escalated: (.body | capture("ESCALATED:\\[(?<e>[^\\]]*?)\\]") | .e)
   }]'
 ```
 
@@ -149,24 +149,26 @@ TaskUpdate each review task as agents complete.
    Fix-forward approach (max `fixForwardMaxIterations`, default 2):
    - P1 findings → fix immediately
    - P2 findings → fix immediately
-   - P3 findings → fix if contained (<10 lines, same file)
-   - TaskCreate("Test coverage for fix-forward", "Write or update tests for each P1/P2 fix applied during self-review")
+   - P3 findings → fix immediately (the proximity test is not a deferral mechanism — P3 in touched files gets the same disposition as P1/P2)
+   - TaskCreate("Test coverage for fix-forward", "Write or update tests for each P1/P2/P3 fix applied during self-review")
    - For each fix: write or update a test that covers the fixed behavior
    - After fixes: run targeted re-review of only changed files
    - TaskUpdate(testCoverageTaskId, status: "completed", result: "Tests written/updated for {N} fixes")
    - No follow-up issue creation for fixable items — just fix them
+   - If any P1/P2 finding cannot be fixed in-PR, file a six-field Proactive-Autonomy escalation (Situation / Tried / Options / Recommendation / Time sensitivity / Risk) rather than deferring silently
    - TaskCreate("Post self-review comment", "Post review findings summary to PR via gh pr review --comment")
 
 6. **External review (someone else's PR — PR_AUTHOR != CURRENT_USER)**:
 
    - TaskCreate("Post review comment", "Post structured review findings to PR via gh pr review")
-   - P2 in already-touched files → include fix suggestion in review comment
-   - P2/P3 in untouched files → follow-up issue workflow:
+   - P1/P2/P3 in already-touched files → REQUEST_CHANGES (P1/P2) or COMMENT with fix-expected language (P3) — the author must fix or file an escalation
+   - Cosmetic P3 in untouched files → follow-up issue workflow
+   - P1/P2 in untouched files → REQUEST_CHANGES; author must address in-PR or file a six-field Proactive-Autonomy escalation
 
-   Issues in files the PR already modifies are NOT out-of-scope — they should have been fixed under the Boy Scout Rule. Only flag them as informational.
+   Findings in files the PR already modifies are NEVER out-of-scope — the author owns the known defects in any file they touch. Do NOT flag them as informational; flag them as blocking.
 
-   For findings in untouched files that warrant follow-up:
-   Present the out-of-scope findings and use the AskUserQuestion tool with contextual options: "These findings are valid but out-of-scope for this PR. Which ones should become follow-up issues?"
+   For cosmetic P3 findings in untouched files that warrant follow-up:
+   Present the findings and use the AskUserQuestion tool with contextual options: "These cosmetic P3 findings are in untouched files. Which ones should become follow-up issues?"
 
    For each selected finding, create a GitHub issue using issue-crafting skill knowledge:
    - Title: concise, solution-agnostic description of the finding
@@ -199,8 +201,9 @@ TaskUpdate each review task as agents complete.
    Post the review:
    - Self-review → `gh pr review $ARGUMENTS --comment --body "$BODY"`
    - External + P1 findings → `gh pr review $ARGUMENTS --request-changes --body "$BODY"`
-   - External + P2 only (no P1) → `gh pr review $ARGUMENTS --comment --body "$BODY"`
-   - External + Clean (P3 only or none) → `gh pr review $ARGUMENTS --approve --body "$BODY"`
+   - External + P2 findings (no P1) → `gh pr review $ARGUMENTS --request-changes --body "$BODY"`
+   - External + P3 only → `gh pr review $ARGUMENTS --comment --body "$BODY"` (fix-expected, not approve-with-nits)
+   - External + No findings → `gh pr review $ARGUMENTS --approve --body "$BODY"`
 
    TaskUpdate(postCommentTaskId, status: "completed", result: "PASS — review posted as {approve/request-changes/comment}")
 

--- a/plugins/flow/skills/code-quality-principles/SKILL.md
+++ b/plugins/flow/skills/code-quality-principles/SKILL.md
@@ -26,23 +26,27 @@ Answer these questions first. If you can't, return to EXPLORE:
 
 ## Boy Scout Rule
 
-Leave every file you touch better than you found it. Apply the **proximity test** to decide if a cleanup belongs:
+Leave every file you touch better than you found it. Fixing known defects in touched files is not optional scope creep — it is the baseline of Quality-First Completionism. Touching a file means owning its known issues.
 
-**A cleanup PASSES the proximity test if ALL true:**
+**The proximity test is NOT a deferral mechanism for P1/P2 findings.** It decides *how* a cleanup is committed (alongside the feature fix vs. as a separate `improve:` commit), not *whether* it gets fixed. If a P1 or P2 finding exists in a file the PR modifies, it is fixed in this PR, full stop.
+
+**A cleanup is committed as a standalone `improve:` commit when ALL true:**
 1. The file is already being modified for the current task
 2. The fix is self-evidently correct (lint, format, typo, obvious bug, missing error handling)
 3. The fix is small (under ~10 lines of cleanup)
 4. The fix does not change public API signatures or behavior semantics
 5. The fix needs no explanation beyond "Boy Scout cleanup"
 
-**A cleanup FAILS the proximity test if ANY true:**
+**A finding requires expanded scope (still fixed, but may need a design note or additional tests) when ANY true:**
 1. Requires modifying files NOT already touched by the task
 2. Changes architecture, module boundaries, or public APIs
 3. Requires new tests to validate
-4. Would need its own issue to explain motivation
-5. Is a subjective style preference, not objective improvement
+4. Would benefit from its own issue to explain motivation
+5. Is a subjective style preference (in which case it is P3 at most, not a fix-blocker)
 
-Passing cleanups use `improve:` commits. Failing cleanups get logged as follow-up issues.
+For P1/P2 findings that fall into the "expanded scope" bucket: fix them in-PR with an appropriate commit message, or file a six-field Proactive-Autonomy escalation (Situation / Tried / Options / Recommendation / Time sensitivity / Risk) to escalate the decision. "Disagree to fix" is not an option — the escalation forces a human judgment call.
+
+Only **cosmetic P3 findings in truly untouched files** may be logged as follow-up issues by default.
 
 ## No Secrets in Code
 
@@ -65,7 +69,7 @@ Code that ships must be complete:
 
 ## Quality Command Execution
 
-Run independent quality commands (lint, test, typecheck) as parallel Bash calls, never chained with `&&`. After quality checks: P1 failures fix immediately, P2 fix before PR, P3 note and proceed.
+Run independent quality commands (lint, test, typecheck) as parallel Bash calls, never chained with `&&`. After quality checks: P1 failures fix immediately, P2 fix before PR, P3 fix in-PR unless a six-field Proactive-Autonomy escalation is filed.
 
 ## Anti-Patterns
 
@@ -108,8 +112,8 @@ Before marking any task complete:
 
 | Excuse | Response |
 |--------|----------|
-| "I'll clean this up while I'm here" | Does it pass the proximity test? If yes, fix it with an `improve:` commit. If no, log it. |
+| "I'll clean this up while I'm here" | If it's a P1/P2 in a touched file, you must fix it. If it's small and self-evident, use an `improve:` commit. If it's cosmetic and in an untouched file, you may log it. |
 | "This TODO is temporary" | TODOs in commits are permanent. Create an issue instead. |
 | "The tests pass, it's fine" | Tests passing is necessary, not sufficient. Run the self-review checklist. |
 | "This debug log helps with development" | Remove it. Development aids don't ship. |
-| "It's just a small formatting fix" | If the file is already touched for the task and the fix passes the proximity test, use an `improve:` commit. Otherwise, it's not in your commit. |
+| "It's just a small formatting fix" | If the file is already touched for the task and the fix is self-evident, use an `improve:` commit. If the file is untouched and the fix is cosmetic, log it as a follow-up issue. |

--- a/plugins/flow/skills/code-review-methodology/SKILL.md
+++ b/plugins/flow/skills/code-review-methodology/SKILL.md
@@ -133,7 +133,7 @@ gh api repos/$REPO/issues/$PR_NUM/comments --jq '
   [.[] | select(.body | test("FLOW_RESOLUTION_CYCLE")) | {
     cycle: (.body | capture("FLOW_RESOLUTION_CYCLE:(?<n>[0-9]+)") | .n),
     resolved: (.body | capture("RESOLVED:\\[(?<r>[^\\]]*?)\\]") | .r),
-    deferred: (.body | capture("DEFERRED:\\[(?<d>[^\\]]*?)\\]") | .d)
+    escalated: (.body | capture("ESCALATED:\\[(?<e>[^\\]]*?)\\]") | .e)
   }]'
 ```
 
@@ -161,9 +161,11 @@ If a finding was claimed resolved but the code at that location is unchanged, fl
 | Findings | Decision |
 |----------|----------|
 | P1 findings (any) | REQUEST_CHANGES |
-| P2 findings only | COMMENT (suggest fixes) |
-| P3 findings only | APPROVE with comments |
+| P2 findings (any) | REQUEST_CHANGES |
+| P3 findings only | COMMENT (fix-expected — author must fix in-PR or file a six-field Proactive-Autonomy escalation; P3 is not a free pass) |
 | No findings | APPROVE |
+
+Note: P3 → COMMENT is NOT "approve with nits." The PR author is expected to fix every P3 in-PR unless they file an escalation justifying deferral. Reviewers should not approve PRs with unaddressed P3s.
 
 ## Adversarial Protocol (Agent Teams)
 

--- a/plugins/flow/skills/evidence-based-development/SKILL.md
+++ b/plugins/flow/skills/evidence-based-development/SKILL.md
@@ -36,7 +36,7 @@ All findings, review comments, and issues use P1/P2/P3 classification:
 |----------|---------|--------|
 | **P1** | Must fix — blocks merge, security issue, data loss risk, broken functionality | Fix before proceeding |
 | **P2** | Should fix — logic error, missing edge case, test gap, convention violation | Fix in this PR |
-| **P3** | Consider — style preference, optimization opportunity, future improvement | Note for later |
+| **P3** | Consider — style preference, optimization opportunity, future improvement | Fix in-PR unless a Proactive-Autonomy escalation is filed (six-field structure: Situation / Tried / Options / Recommendation / Time sensitivity / Risk) |
 
 ## ASSERTION/EVIDENCE/VERIFIED Pattern
 

--- a/plugins/flow/skills/feedback-resolution/SKILL.md
+++ b/plugins/flow/skills/feedback-resolution/SKILL.md
@@ -96,14 +96,15 @@ When feedback is unclear:
 
 ## Pushback Criteria
 
-It's acceptable to push back on feedback when:
+Pushback is a narrow, evidence-backed response — not a general "I disagree" escape hatch. Pushback is valid only when one of the following holds, and the response must cite the specific evidence:
 
-- The suggestion would break existing tests
-- The suggested approach contradicts project conventions (cite CLAUDE.md)
-- The feedback is based on a misunderstanding of the requirements
-- The suggested change would introduce a regression
+- **Factually incorrect feedback** — the reviewer's claim about the code is wrong. Response must cite `file:line` showing the current state and explain why the feedback does not apply.
+- **Would break existing tests** — the suggested change would cause a regression. Response must show the failing test (name and `file:line`) that the suggestion would break.
+- **Contradicts a CLAUDE.md rule** — the suggestion violates a project convention documented in CLAUDE.md. Response must quote the rule and cite its location in CLAUDE.md.
 
-Always explain the reasoning when pushing back. Never ignore feedback silently.
+"I disagree" alone is NOT valid pushback. Subjective preference differences resolve in favor of the reviewer — if you don't have factual evidence, a broken test, or a CLAUDE.md citation, apply the fix.
+
+Always explain the reasoning when pushing back. Never ignore feedback silently. If pushback would require a judgment call beyond the three valid categories above, file a six-field Proactive-Autonomy escalation instead (Situation / Tried / Options / Recommendation / Time sensitivity / Risk).
 
 ## Rationalization Prevention
 

--- a/plugins/flow/templates/resolution-comment.md
+++ b/plugins/flow/templates/resolution-comment.md
@@ -7,7 +7,7 @@
 | Received | {total_feedback_items} |
 | Fixed | {fixed_count} |
 | Discussed | {discussed_count} |
-| Deferred | {deferred_count} |
+| Escalated | {escalated_count} |
 
 ### Changes Made
 
@@ -21,22 +21,30 @@
 
 {Response or explanation}
 
-### Not Addressed (if any)
+### Escalated for Human Judgment (if any)
 
-- **{Item}**: {Reason — out of scope / needs clarification / disagree}
-- Follow-up issues created: #{issue_number}
+For each item the author believes requires a judgment call beyond autonomous resolution, provide the six-field Proactive-Autonomy structure:
+
+**{Item summary}**
+- **Situation**: {what the finding is, file:line, why it surfaced}
+- **Tried**: {what was considered and why it did not resolve in-PR}
+- **Options**: {2–3 concrete paths forward with trade-offs}
+- **Recommendation**: {recommended option and reasoning}
+- **Time sensitivity**: {blocking / urgent / safe to wait — with justification}
+- **Risk**: {what happens if we defer, and to whom}
+- Follow-up issue (if created): #{issue_number}
 
 ### Thread Status
 
 | Comment ID | Thread | Status |
 |------------|--------|--------|
-| {comment_id} | {Comment summary} | {Resolved / Addressed / Needs discussion} |
+| {comment_id} | {Comment summary} | {Resolved / Addressed / Escalated} |
 
 ### Verification
 
 - [x] All quality checks pass
 - [x] Self-reviewed fix commits
 - [x] No new issues introduced
-- [x] Boy Scout improvements pass proximity test
+- [x] All P1/P2/P3 findings in touched files addressed in-PR (or escalated with six-field structure)
 
-<!-- FLOW_RESOLUTION_CYCLE:{N} RESOLVED:[{F1},{F2}] DEFERRED:[{F3}] DISPUTED:[] -->
+<!-- FLOW_RESOLUTION_CYCLE:{N} RESOLVED:[{F1},{F2}] ESCALATED:[{F3}] DISPUTED:[] -->

--- a/plugins/flow/templates/self-review-comment.md
+++ b/plugins/flow/templates/self-review-comment.md
@@ -28,9 +28,18 @@ Verdict: N/A (independent verdict not enabled)
 |---|----------|----------|-------|-------------|
 | {n} | {P1/P2/P3} | {file:line} | {issue} | {fix description} |
 
-### Remaining Items
-- P3 noted but not fixed: {list, or 'None'}
+### Escalated for Human Judgment
+{Only populated if findings could not be fixed in-PR. Each escalation uses the six-field Proactive-Autonomy structure.}
+
+**{Item summary}**
+- **Situation**: {what, file:line}
+- **Tried**: {what was considered, why it didn't resolve in-PR}
+- **Options**: {2–3 concrete paths}
+- **Recommendation**: {recommended option}
+- **Time sensitivity**: {blocking / urgent / safe to wait}
+- **Risk**: {consequence of deferring}
 
 ### Verification
 - [x] Quality commands pass after fixes
 - [x] No new issues introduced
+- [x] All P1/P2/P3 findings in touched files fixed in-PR or escalated


### PR DESCRIPTION
## Summary

Closes #38.

The `/flow` plugin's review and address phases were architected to defer quality issues rather than resolve them. Three mechanisms combined to let known issues ship:

1. **P3 was "note only"** — convergence checks and skills treated P3 as deferrable by default.
2. **Pre-existing findings were capped at P3** — code-reviewer and error-handler-inspector forced any finding in unchanged lines of a touched file to P3 max, so a SQL injection in pre-existing code of a touched file would ship as "note for later."
3. **The resolution-comment template normalized deferral** — `Deferred` was a first-class metric and `Not Addressed` was a first-class section.

This PR removes all three mechanisms. The rule is now: if you touch a file, you own its known defects. Excellence means fixing, not shipping forward.

## Changes

**Agents** — `plugins/flow/agents/code-reviewer.md`, `plugins/flow/agents/error-handler-inspector.md`
- Scope classification tables no longer cap pre-existing findings at P3.
- Pre-existing findings keep their natural P1/P2/P3 priority based on impact. The "pre-existing" prefix labels provenance, it does not cap severity.

**Commands** — `plugins/flow/commands/address.md`, `plugins/flow/commands/review.md`
- Convergence loop in `address.md`: P1/P2/P3 in touched files all get the "fix NOW" disposition. The proximity test is explicitly NOT a deferral mechanism.
- Out-of-scope section: only cosmetic P3 findings in truly untouched files may become follow-up issues. P1/P2 in untouched files must be addressed in-PR or filed as a six-field Proactive-Autonomy escalation (Situation / Tried / Options / Recommendation / Time sensitivity / Risk).
- Self-review in `review.md`: P3 now fixed immediately (no "fix if contained" escape hatch).
- External review posting: P2 → REQUEST_CHANGES (was COMMENT), P3 only → COMMENT with fix-expected language (was APPROVE).
- DEFERRED marker parsing replaced with ESCALATED to match the template.

**Skills**
- `code-quality-principles/SKILL.md` — Boy Scout Rule rewritten. The proximity test now decides *how* a cleanup is committed (`improve:` commit vs. merged), not *whether* it gets fixed. Added explicit rule: "the proximity test is NOT a deferral mechanism for P1/P2 findings."
- `evidence-based-development/SKILL.md` — P3 action changed from "Note for later" to "Fix in-PR unless a Proactive-Autonomy escalation is filed (six-field structure)."
- `code-review-methodology/SKILL.md` — Review decision table: P1 → REQUEST_CHANGES, P2 → REQUEST_CHANGES (was COMMENT), P3 → COMMENT (fix-expected, was APPROVE-with-comments). Added explicit note that P3 → COMMENT is not "approve with nits."
- `feedback-resolution/SKILL.md` — Pushback criteria tightened to three narrow evidence-backed categories: factually incorrect feedback (cite file:line), would break existing tests (show the test), contradicts a CLAUDE.md rule (cite the rule). "Disagree" alone is explicitly not valid.

**Templates**
- `resolution-comment.md` — Removed `Deferred` metric row and `Not Addressed` section. Replaced with `Escalated for Human Judgment` section requiring the six-field Proactive-Autonomy structure. Trailing marker `DEFERRED:[]` replaced with `ESCALATED:[]`.
- `self-review-comment.md` — Removed "P3 noted but not fixed" row. Added "Escalated for Human Judgment" section with six-field structure. Verification checklist now asserts all findings fixed-in-PR or escalated.

## Verification

Ran each acceptance-criteria grep from the issue and confirmed zero hits in `commands/`, `skills/`, and `agents/`:

```
$ rg "P3 → note only|P3 max|note for later" plugins/flow/
(no matches)

$ rg "Deferred" plugins/flow/templates/resolution-comment.md
(no matches)
```

Review decision table in `plugins/flow/skills/code-review-methodology/SKILL.md` now shows:
- P1 findings (any) → REQUEST_CHANGES
- P2 findings (any) → REQUEST_CHANGES
- P3 findings only → COMMENT (fix-expected)
- No findings → APPROVE

## Test plan

- [ ] Review affected files once the PR is up to confirm language is clear and actionable.
- [ ] End-to-end: confirm a synthetic PR with a seeded P3 finding in a touched file is fixed during `/flow:address` convergence and the resolution comment shows no "Deferred" count (acceptance criterion 7).
- [ ] End-to-end: confirm a seeded SQL-injection-severity bug in pre-existing code of a touched file is reported as P1 by code-reviewer and blocks the PR (acceptance criterion 8).

## Judgment calls

- `commands/review.md` and `commands/learn.md` both had `deferred` references the issue did not call out. The `review.md` references were resolution-cycle parsing that had to change to `ESCALATED` to match the new template marker; included in this PR. The `learn.md` reference is about learning-pattern deferral ("additional patterns detected but deferred"), a different domain — left alone.
- `templates/self-review-comment.md` had a "P3 noted but not fixed" row that the issue did not explicitly name but that directly contradicted the new disposition rules. Updated it in the template commit.
- `skills/code-review-methodology/SKILL.md` "Not Addressed" status entry (line 61) is about acceptance-criterion coverage, not finding disposition — left alone.