### PR TITLE
feat(flow): merge gate blocks on unresolved findings

### DIFF
--- a/plugins/flow/commands/address.md
+++ b/plugins/flow/commands/address.md
@@ -219,6 +219,21 @@ For cosmetic P3 findings in untouched files that the team agrees to track separa
       ```bash
       gh pr edit $ARGUMENTS --add-reviewer @{reviewer}
       ```
-    - If cycle >= `reviewCycleLimit` → use the AskUserQuestion tool: "Review cycle {N}. Options: re-request same reviewer, request fresh reviewer, or merge as-is?"
+    - If cycle >= `reviewCycleLimit` → use the AskUserQuestion tool with the following Proactive-Autonomy escalation:
+
+      **Situation**: Review cycle {N} reached the configured limit (`reviewCycleLimit`). {remaining_count} finding(s) remain unresolved.
+      **Tried**: {N} cycles of review-and-address with the current reviewer.
+      **Options**:
+        1. Re-request the same reviewer for another cycle
+        2. Request a fresh reviewer for an independent perspective
+        3. Explicit override — accept risk of open findings (requires written justification that will be recorded in the PR)
+      **Recommendation**: Option 2 (fresh reviewer) — breaks potential deadlock while maintaining quality gate integrity.
+      **Time sensitivity**: Blocking — PR cannot merge until findings are resolved or explicitly overridden with justification.
+      **Risk**: Merging with unresolved findings violates the "no incomplete shipments" hard boundary. Open findings become production defects owned by the team.
+
+      Present via AskUserQuestion: "Review cycle {N} has reached the limit with {remaining_count} unresolved finding(s). Choose a path forward:"
+        - Option 1: "Re-request same reviewer"
+        - Option 2: "Request fresh reviewer"
+        - Option 3: "Override with written risk acceptance (will be recorded on PR)"
 
 Display summary: fixes applied, Boy Scout improvements, questions answered, pushback items, cycle count.

--- a/plugins/flow/commands/merge.md
+++ b/plugins/flow/commands/merge.md
@@ -34,7 +34,70 @@ gh pr view $ARGUMENTS --json reviews,commits --jq '{
   last_approval: [.reviews[] | select(.state == "APPROVED")] | sort_by(.submittedAt) | last | .submittedAt,
   last_commit: .commits | last | .committedDate
 }'
+
+# 5. Finding-ledger check
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+COMMENTS=$(gh api "repos/$REPO/issues/$ARGUMENTS/comments" --jq '.[] | select(.body | test("FLOW_RESOLUTION_CYCLE|FLOW_REVIEW_CYCLE")) | {id: .id, body: .body}')
 ```
+
+### Finding-Ledger Check
+
+Parse the latest `FLOW_RESOLUTION_CYCLE` and `FLOW_REVIEW_CYCLE` comments to verify all findings are resolved before merge.
+
+```bash
+# Extract the latest FLOW_RESOLUTION_CYCLE comment
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+RESOLUTION_BODY=$(gh api "repos/$REPO/issues/$ARGUMENTS/comments" \
+  --jq '[.[] | select(.body | test("FLOW_RESOLUTION_CYCLE:"))] | last | .body // ""')
+
+# Extract ESCALATED array contents
+ESCALATED=$(echo "$RESOLUTION_BODY" | grep -oP 'ESCALATED:\[\K[^\]]*' || echo "")
+
+# Extract the latest FLOW_REVIEW_CYCLE comment
+REVIEW_BODY=$(gh api "repos/$REPO/issues/$ARGUMENTS/comments" \
+  --jq '[.[] | select(.body | test("FLOW_REVIEW_CYCLE:"))] | last | .body // ""')
+
+# Extract all finding IDs from FINDINGS array (comma-separated, pipe-delimited fields, first field is the ID)
+REVIEW_FINDINGS=$(echo "$REVIEW_BODY" | grep -oP 'FINDINGS:\[\K[^\]]*' | tr ',' '\n' | sed 's/|.*//' | sort || echo "")
+
+# Extract RESOLVED finding IDs from resolution comment
+RESOLVED_FINDINGS=$(echo "$RESOLUTION_BODY" | grep -oP 'RESOLVED:\[\K[^\]]*' | tr ',' '\n' | sort || echo "")
+
+# Check 1: ESCALATED must be empty
+if [ -n "$ESCALATED" ]; then
+  echo "FINDING_LEDGER_BLOCK: ESCALATED array is non-empty: [$ESCALATED]"
+fi
+
+# Check 2: Every finding in REVIEW_FINDINGS must have a matching RESOLVED entry
+UNRESOLVED=$(comm -23 <(echo "$REVIEW_FINDINGS") <(echo "$RESOLVED_FINDINGS") | grep -v '^$' || true)
+if [ -n "$UNRESOLVED" ]; then
+  echo "FINDING_LEDGER_BLOCK: Unresolved findings: $UNRESOLVED"
+fi
+```
+
+**If the finding-ledger check fails**, stop immediately and display:
+
+```markdown
+## BLOCKED: Unresolved Findings
+
+PR #$ARGUMENTS cannot be merged — the finding ledger has unresolved items.
+
+| Issue | Details |
+|-------|---------|
+| Non-empty ESCALATED | {list of escalated finding IDs, if any} |
+| Unmatched FINDINGS | {list of finding IDs with no RESOLVED entry, if any} |
+
+### Remediation
+
+1. Run `/flow:address $ARGUMENTS` to resolve remaining findings
+2. Ensure every finding in `FLOW_REVIEW_CYCLE:FINDINGS` has a matching `RESOLVED` entry in `FLOW_RESOLUTION_CYCLE`
+3. Ensure `ESCALATED:[]` is empty (all escalated items must be resolved or have explicit human override)
+4. Re-run `/flow:merge $ARGUMENTS`
+
+This gate enforces the "no incomplete shipments" hard boundary.
+```
+
+Do NOT proceed to Phase 2. Exit here.
 
 ## Phase 2: Display Assessment
 
@@ -48,6 +111,7 @@ gh pr view $ARGUMENTS --json reviews,commits --jq '{
 | Mergeable | {Pass/Fail} | {No conflicts / Has conflicts} |
 | Conversations | {Pass/Fail} | {All resolved / N unresolved} |
 | Stale Approval | {OK/Warning} | {Fresh / Commits after approval} |
+| Finding Ledger | {Pass/Fail} | {All resolved / N unresolved, M escalated} |
 
 **Merge strategy**: {from settings.merge.strategy, default: squash}
 **Delete branch**: {from settings.merge.deleteBranch, default: true}

--- a/plugins/flow/skills/pr-lifecycle/SKILL.md
+++ b/plugins/flow/skills/pr-lifecycle/SKILL.md
@@ -121,6 +121,33 @@ gh pr view --json number,url,state,title
 
 Display PR URL and suggest: `/flow:review {number}` for self-review or share with team.
 
+## Merge Prerequisite: Finding-Ledger Check
+
+Before a PR can be merged via `/flow:merge`, the finding ledger is checked to ensure all review findings have been resolved.
+
+### What it does
+
+Parses PR comments for `FLOW_RESOLUTION_CYCLE` and `FLOW_REVIEW_CYCLE` markers:
+
+- **`FLOW_REVIEW_CYCLE:{N} FINDINGS:[...]`** — the finding IDs emitted during review
+- **`FLOW_RESOLUTION_CYCLE:{N} RESOLVED:[...] ESCALATED:[...] DISPUTED:[...]`** — the disposition of each finding after `/flow:address`
+
+The check extracts the latest of each marker and compares them.
+
+### What triggers a block
+
+1. **Non-empty ESCALATED array** — `ESCALATED:[F3]` means at least one finding was escalated but not resolved. The merge gate blocks until every escalated item is resolved or the ESCALATED array is empty.
+2. **Unmatched FINDINGS** — any finding ID present in `FLOW_REVIEW_CYCLE:FINDINGS` that has no corresponding entry in `FLOW_RESOLUTION_CYCLE:RESOLVED` is considered unresolved. The merge gate blocks until every finding has a matching RESOLVED entry.
+
+### How to resolve
+
+1. Run `/flow:address {pr_number}` to address remaining findings
+2. Fix or respond to each unresolved finding until all are in the RESOLVED array
+3. Ensure the ESCALATED array is empty in the latest resolution comment
+4. Re-run `/flow:merge {pr_number}`
+
+This gate enforces the "no incomplete shipments" hard boundary from organizational governance.
+
 ## Rationalization Prevention
 
 | Excuse | Response |


### PR DESCRIPTION
## Summary

Adds a finding-ledger check to `/flow:merge` that blocks merge when review findings remain unresolved, and replaces the "merge as-is" escape hatch in `/flow:address` with a structured Proactive-Autonomy escalation.

Closes #39

## Changes

**Merge gate (`commands/merge.md`)**
- Phase 1 now includes a finding-ledger check (check #5) that parses `FLOW_RESOLUTION_CYCLE` and `FLOW_REVIEW_CYCLE` comment markers
- Blocks merge when `ESCALATED` array is non-empty
- Blocks merge when any finding in `FINDINGS` lacks a matching `RESOLVED` entry
- Displays a structured remediation message listing unresolved findings
- Added "Finding Ledger" row to the Phase 2 assessment table

**Address escalation (`commands/address.md`)**
- Removed the literal "merge as-is" option from the cycle-3+ fallback
- Replaced with a six-field Proactive-Autonomy escalation (Situation, Tried, Options, Recommendation, Time sensitivity, Risk)
- Three explicit options via AskUserQuestion: re-request same reviewer, request fresh reviewer, or explicit override with written risk acceptance

**Skill documentation (`skills/pr-lifecycle/SKILL.md`)**
- Added "Merge Prerequisite: Finding-Ledger Check" section documenting what the check does, what triggers a block, and how to resolve

## Verification

- `grep -r "merge as-is" plugins/flow/` returns zero hits
- `merge.md` contains finding-ledger check with grep/comm parsing of ESCALATED and FINDINGS markers
- `pr-lifecycle/SKILL.md` has the new documentation section
- All changes traced to issue #39 acceptance criteria