### PR TITLE
feat(flow): enforce per-task verification gate and strict TDD default

### DIFF
--- a/plugins/flow/commands/commit.md
+++ b/plugins/flow/commands/commit.md
@@ -48,7 +48,9 @@ git log --oneline -10
 
 **Grep** — search branch diff and issue body for task-related context.
 
-## Phase 2: CLASSIFY
+## Phase 2: CLASSIFY (cross-check)
+
+**Note**: When running after `/flow:start`, per-task change classification already happened during the CODE phase (step 8 of the per-task verification gate). Commit-time classification is a **final cross-check**, not the primary gate. Out-of-context files should have been flagged and resolved during CODE. If new out-of-context files appear here, it indicates a gap in the per-task gate that should be investigated.
 
 Apply change-classification skill knowledge:
 

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -270,27 +270,53 @@ Display task plan. Proceed unless user objects.
 
 ## Phase 3: CODE
 
-**TDD guidance**: Apply `tdd-patterns` knowledge during implementation:
-- For each task: write failing test → implement → verify test passes → refactor
-- Check `settings.json` → `testing.tddMode` for enforcement level
+**TDD enforcement**: Check `settings.json` → `testing.tddMode`:
+- `enforce` (default) — write a failing test FIRST. Implementation without a preceding RED test is blocked.
+- `suggest` — recommend TDD but allow override. Only active when `testing.tddModeOptOut` is `true`.
+- `off` — no TDD guidance; tests still run in verification.
 
-Execute tasks following the task-driven loop:
+Execute tasks following the per-task verification gate loop:
 
 ```
 For each task (in dependency order):
   1. TaskUpdate(taskId, status: "in_progress")
   2. Read relevant files (follow existing patterns)
-  3. Implement the change
-  4. Write or update tests that verify the change:
-     - Follow existing test patterns (co-located files, same framework)
+  3. TDD enforcement (when tddMode=enforce):
+     a. RED: Write the failing test FIRST — the test MUST fail before any implementation
+     b. Verify it fails for the right reason (not syntax error, not wrong import)
+  4. GREEN: Implement the change — simplest code to make the test pass
+     - Follow existing patterns (co-located files, same framework)
      - At minimum, one test per acceptance criterion or behavior
      - Test edge cases, not just the happy path
      - For bug fixes: write a test that would have caught the original bug
-  5. Run related tests — new tests must pass, existing tests must not break
-  6. TaskUpdate(testTaskId, status: "completed")
-  7. Incremental commit (Tier 1: autonomous)
-  8. TaskUpdate(taskId, status: "completed")
+  5. Run tests (existing + new):
+     IF tests FAIL → enter debug-fix-retest loop:
+       - Read failure output, identify root cause
+       - Fix the failing code (not the test, unless the test is wrong)
+       - Re-run tests
+       - Repeat until all tests pass (bounded by closedLoop.maxDebugIterations)
+       - Do NOT proceed to step 6. Do NOT call TaskUpdate(completed).
+       - After max iterations without resolution, escalate to user via AskUserQuestion.
+     IF tests PASS → continue to step 6
+  6. REFACTOR: Clean up implementation and tests. Re-run tests — they must still pass.
+  7. Capture verification evidence:
+     - Run the verification command from the task description
+     - Record the output as evidence for this task's acceptance criterion
+     - IF verification command fails → enter debug-fix-retest loop (same rules as step 5)
+  8. Per-task change classification:
+     - Classify all files modified during this task using change-classification signals
+     - Flag any out-of-context files NOW — do not accumulate until commit time
+     - If out-of-context files found, use AskUserQuestion to resolve before proceeding
+  9. Incremental commit (Tier 1: autonomous)
+  10. ONLY after ALL of the following are true may TaskUpdate(completed) be called:
+      - All tests pass (existing + new)
+      - Verification evidence captured for this task's acceptance criterion
+      - No unresolved out-of-context files from this task
+      - TDD cycle completed (RED → GREEN → REFACTOR) when tddMode=enforce
+      TaskUpdate(taskId, status: "completed")
 ```
+
+**Critical gate**: Step 5 is a HARD GATE. If tests fail, the task CANNOT be marked completed. The loop stays on the current task until tests pass or the user is escalated to. Skipping ahead to the next task with failing tests is explicitly prohibited.
 
 **Parallel task detection**: If tasks have no overlapping files and agent teams are enabled, suggest parallel execution via agent team.
 

--- a/plugins/flow/settings.json
+++ b/plugins/flow/settings.json
@@ -47,10 +47,11 @@
   },
   "verdict": {
     "enabled": true,
-    "requireAllPass": false
+    "requireAllPass": true
   },
   "testing": {
-    "tddMode": "suggest"
+    "tddMode": "enforce",
+    "tddModeOptOut": false
   },
   "debugging": {
     "maxHypotheses": 3

--- a/plugins/flow/skills/autonomous-workflow/SKILL.md
+++ b/plugins/flow/skills/autonomous-workflow/SKILL.md
@@ -41,6 +41,23 @@ Use Task tools as first-class workflow primitives:
 
 Tasks have clear subjects (imperative form) and descriptions with acceptance criteria.
 
+## Per-Task Verification Gate
+
+A task may NOT be marked completed (`TaskUpdate(taskId, status: "completed")`) until ALL of the following conditions are met:
+
+1. **All tests pass** — both existing tests and any new tests written for this task. If any test fails, the task enters the debug-fix-retest loop and remains `in_progress` until tests pass or the user is escalated to.
+
+2. **Verification evidence captured** — the verification command from the task description has been run and its output recorded as evidence for this task's acceptance criterion. Evidence must be collected at task-completion time, not deferred to VERIFY phase.
+
+3. **No out-of-context files** — all files modified during this task have been classified. Any out-of-context files must be resolved (moved to a separate commit, removed, or explicitly approved by the user) before the task completes.
+
+4. **TDD cycle completed** — when `settings.json` → `testing.tddMode` is `enforce` (the default), the full RED-GREEN-REFACTOR cycle must be observed:
+   - RED: A failing test was written before implementation
+   - GREEN: The simplest code was written to make the test pass
+   - REFACTOR: Code was cleaned up with tests still passing
+
+If any condition is not met, `TaskUpdate(completed)` is blocked. The workflow must not advance to the next task. This gate is the primary quality enforcement point — the VERIFY phase provides independent confirmation, not first-pass verification.
+
 ## Three-Tier Action Classification
 
 | Tier | Actions | Behavior |

--- a/plugins/flow/skills/tdd-patterns/SKILL.md
+++ b/plugins/flow/skills/tdd-patterns/SKILL.md
@@ -123,11 +123,26 @@ Test names should read as specifications:
 
 Check `settings.json` → `testing.tddMode`:
 
-| Mode | Behavior |
-|------|----------|
-| `enforce` | Block implementation without a failing test. No exceptions. |
-| `suggest` (default) | Recommend TDD. Allow override with explicit user decision. |
-| `off` | No TDD guidance. Tests still run in verification. |
+| Mode | Default? | Behavior |
+|------|----------|----------|
+| `enforce` | **Yes** | Block implementation without a failing test. No exceptions. The RED phase must produce a failing test before any production code is written. |
+| `suggest` | No (opt-in) | Recommend TDD. Allow override with explicit user decision. |
+| `off` | No (opt-in) | No TDD guidance. Tests still run in verification. |
+
+### Opt-out mechanism
+
+`enforce` is the default because skipping the RED phase is the #1 source of tests that pass for the wrong reason. Teams that need the old `suggest` behavior can opt out:
+
+```json
+{
+  "testing": {
+    "tddMode": "suggest",
+    "tddModeOptOut": true
+  }
+}
+```
+
+Set `testing.tddModeOptOut` to `true` in `settings.json` to switch `tddMode` back to `suggest`. When `tddModeOptOut` is `false` (the default), `tddMode` must remain `enforce`. This two-field design ensures the opt-out is an explicit, auditable decision rather than a silent default change.
 
 ## Coverage Targets
 


### PR DESCRIPTION
## Summary

- **settings.json**: Flip `tddMode` from `suggest` to `enforce` and `verdict.requireAllPass` from `false` to `true`. Add `tddModeOptOut: false` for teams needing the old behavior.
- **start.md CODE loop**: Rewrite as a hard per-task verification gate — tests must pass AND verification evidence must be captured before `TaskUpdate(completed)`. If tests fail, the loop enters debug-fix-retest and does NOT proceed. Per-task change classification flags out-of-context files at task completion time.
- **autonomous-workflow/SKILL.md**: Add "Per-Task Verification Gate" section listing four required conditions (all tests pass, evidence captured, no out-of-context files, TDD cycle completed).
- **tdd-patterns/SKILL.md**: Document `enforce` as the new default with `tddModeOptOut` mechanism for teams that need `suggest`.
- **commit.md**: De-duplicate change classification — commit-time is now a final cross-check, not the primary gate (per-task classification in CODE is primary).

## Verification

1. `settings.json` has `tddMode: "enforce"` and `verdict.requireAllPass: true` -- confirmed
2. `start.md` CODE loop has explicit "IF tests fail -> enter debug loop, do NOT TaskUpdate(completed)" -- confirmed (line 293)
3. `autonomous-workflow/SKILL.md` has "Per-Task Verification Gate" section -- confirmed (line 44)
4. `tdd-patterns/SKILL.md` documents `enforce` as default with opt-out -- confirmed (lines 128, 132)
5. `commit.md` references per-task classification as primary -- confirmed (line 53)

Closes #41