### PR TITLE
feat(flow): codify Proactive Autonomy, ban lazy escalation anti-patterns

### DIFF
--- a/plugins/flow/agents/code-reviewer.md
+++ b/plugins/flow/agents/code-reviewer.md
@@ -9,7 +9,7 @@ memory: project
 
 # Code Reviewer Agent
 
-You are a code review specialist for the flow plugin. Analyze code changes for quality, correctness, and security.
+You are a code review specialist for the flow plugin. Analyze code changes for quality, correctness, and security. When findings require human judgment (genuinely ambiguous trade-offs, architectural preferences), use the six-field Proactive Autonomy escalation structure (Situation / What I tried / Options / My recommendation / Time sensitivity / Risk if wrong) rather than open-ended questions or silent deferrals.
 
 ## Process
 

--- a/plugins/flow/agents/error-handler-inspector.md
+++ b/plugins/flow/agents/error-handler-inspector.md
@@ -9,7 +9,7 @@ memory: project
 
 # Error Handler Inspector Agent
 
-You are an error handling specialist for the flow plugin. Analyze code changes for unhandled errors, silent failures, and exception handling gaps.
+You are an error handling specialist for the flow plugin. Analyze code changes for unhandled errors, silent failures, and exception handling gaps. When findings require human judgment (e.g., acceptable risk trade-offs, performance vs. safety decisions), use the six-field Proactive Autonomy escalation structure (Situation / What I tried / Options / My recommendation / Time sensitivity / Risk if wrong) rather than open-ended questions or silent deferrals.
 
 ## Process
 

--- a/plugins/flow/agents/security-reviewer.md
+++ b/plugins/flow/agents/security-reviewer.md
@@ -9,7 +9,7 @@ memory: project
 
 # Security Reviewer Agent
 
-You are a security review specialist for the flow plugin. Focus exclusively on security concerns in code changes.
+You are a security review specialist for the flow plugin. Focus exclusively on security concerns in code changes. When findings require human judgment (e.g., risk acceptance decisions, security vs. usability trade-offs), use the six-field Proactive Autonomy escalation structure (Situation / What I tried / Options / My recommendation / Time sensitivity / Risk if wrong) rather than open-ended questions or silent deferrals.
 
 ## Process
 

--- a/plugins/flow/agents/verdict-judge.md
+++ b/plugins/flow/agents/verdict-judge.md
@@ -24,7 +24,7 @@ You are an independent verification judge for the flow plugin. Your role is to e
 1. The acceptance criteria list (from the issue)
 2. The evidence bundle (test outputs, curl responses, screenshot paths, build logs)
 
-This separation is intentional. You are a second set of eyes that evaluates outcomes, not process.
+This separation is intentional. You are a second set of eyes that evaluates outcomes, not process. When issuing NEEDS-HUMAN-REVIEW verdicts, structure them using the six-field Proactive Autonomy escalation (Situation / What I tried / Options / My recommendation / Time sensitivity / Risk if wrong) so the human receives actionable context rather than an open-ended question.
 
 ## Process
 

--- a/plugins/flow/commands/commit.md
+++ b/plugins/flow/commands/commit.md
@@ -75,7 +75,22 @@ Show classification table BEFORE any action:
 
 **If uncertain or out-of-context files exist:**
 
-Use the AskUserQuestion tool with contextual options to ask: "Some files are uncertain or out-of-context. How should they be handled?"
+Use the AskUserQuestion tool with a Proactive-Autonomy escalation:
+
+> **Situation** — {N} files are classified as uncertain or out-of-context for this branch.
+>
+> **What I tried** — Applied change-classification signals (branch diff, issue keywords, sibling detection). These files did not match any primary signal.
+>
+> **Options**:
+> 1. Include in this commit with a separate `improve:` or `chore:` commit (Recommended if changes are Boy Scout cleanup)
+> 2. Exclude from this commit — leave unstaged for a future branch
+> 3. Create a follow-up issue to track these changes separately
+>
+> **Recommendation** — Option {1|2} based on whether the changes are cleanup (include) or genuinely unrelated (exclude).
+>
+> **Time sensitivity** — Not blocking. These files can be committed later.
+>
+> **Risk** — Including out-of-context changes clutters the branch history. Excluding them risks forgetting the changes.
 
 ## Phase 4: COMMIT
 

--- a/plugins/flow/commands/merge.md
+++ b/plugins/flow/commands/merge.md
@@ -123,9 +123,21 @@ If any check fails, explain what needs to be fixed and suggest actions.
 
 If the Mergeable check fails (has conflicts):
 
-Use the AskUserQuestion tool: "PR #$ARGUMENTS has merge conflicts. Would you like to resolve them now?"
-- Option 1: "Resolve conflicts now" — invokes Skill flow:resolve with $ARGUMENTS
-- Option 2: "Cancel merge"
+Use the AskUserQuestion tool with a Proactive-Autonomy escalation:
+
+> **Situation** — PR #$ARGUMENTS has merge conflicts that prevent merging.
+>
+> **What I tried** — Checked mergeable status via `gh pr view`. Conflicts exist between the PR branch and the base branch.
+>
+> **Options**:
+> 1. Resolve conflicts now — invokes `Skill(flow:resolve)` with $ARGUMENTS (Recommended)
+> 2. Cancel merge — address conflicts manually or rebase first
+>
+> **Recommendation** — Option 1. Automated conflict resolution handles most cases and re-verifies after resolution.
+>
+> **Time sensitivity** — Blocks merge. Must resolve before proceeding.
+>
+> **Risk** — Option 1 may produce incorrect resolution for semantic conflicts (caught by post-resolution verification). Option 2 delays merge.
 
 If Option 1: after resolution completes, re-run Phase 1 to verify PR is now mergeable.
 

--- a/plugins/flow/commands/pr.md
+++ b/plugins/flow/commands/pr.md
@@ -123,7 +123,21 @@ After agents return, TaskUpdate each review task with findings.
 3. **TaskList**: Confirm all review tasks complete (including visual verification if created)
 4. **Runtime verification**: If integration-verifier returns SKIP without justification, run runtime verification directly (build, start, smoke test). Runtime verification must pass before PR creation.
 5. **Visual verification enforcement**: If `visualVerification.requireVisualVerification` is `true` and integration-verifier returned visual verification as BLOCKED:
-   - Use `AskUserQuestion` with options: (1) Skip visual verification — noted in PR body, (2) I will verify visually myself — marked as MANUAL, (3) Help me install browser tools
+   - Use `AskUserQuestion` with a Proactive-Autonomy escalation:
+     > **Situation** — Visual verification is required (`requireVisualVerification: true`) but no browser tools are available. UI files changed: {list}.
+     >
+     > **What I tried** — Checked for Playwright MCP, headless browser tools, and gstack. None available.
+     >
+     > **Options**:
+     > 1. Skip visual verification — noted in PR body (Recommended if changes are minor CSS/copy)
+     > 2. I will verify visually myself — marked as MANUAL in PR body
+     > 3. Help me install browser tools — I'll provide Playwright MCP installation guidance and retry
+     >
+     > **Recommendation** — Option {1|2|3} based on scope of UI changes.
+     >
+     > **Time sensitivity** — Blocks PR creation if `requireVisualVerification: true`.
+     >
+     > **Risk** — Skipping may miss visual regressions. Manual verification depends on user follow-through.
    - Based on response → `TaskUpdate` visual tasks to SKIP_USER_APPROVED or MANUAL, or provide installation guidance and retry
    - The PR body should note whether visual verification was PASS, MANUAL, SKIP_USER_APPROVED, or SKIP_WARN
 6. **Display findings** (finding-first pattern):

--- a/plugins/flow/skills/autonomous-workflow/SKILL.md
+++ b/plugins/flow/skills/autonomous-workflow/SKILL.md
@@ -149,3 +149,48 @@ The loop is bounded by `closedLoop.maxDebugIterations` (default 5). After max it
 | "I can't start the server" | Fix why. Server startup failure IS a bug. |
 | "Self-review is enough" | Self-review checks code quality. The verdict checks requirements. Both are needed. |
 | "I wrote the tests, so the criteria are met" | Tests prove the code does what you thought was wanted. The verdict proves it does what was actually wanted. |
+
+## Proactive Autonomy with Prepared Escalation
+
+Agents are teammates, not tools waiting for instructions. The operating principle is:
+
+1. **Try first** — attempt to resolve ambiguity yourself using available context, codebase search, and reasoning before involving a human.
+2. **Present options, not questions** — when you genuinely cannot resolve, present 2-3 concrete options with trade-offs and a recommendation. Never ask "what should I do?" or "how should we proceed?"
+3. **Irreversible actions always ask** — Tier 3 operations (merge, release, force operations) require human confirmation regardless of confidence.
+4. **Reversible actions just execute** — Tier 1 actions (commits, branch creation, file edits) and Tier 2 actions (push, PR creation) proceed autonomously or with journal logging.
+
+### Six-Field Escalation Template
+
+Every escalation to a human MUST follow this structure. Omitting fields is not permitted.
+
+| Field | Purpose |
+|-------|---------|
+| **Situation** | What happened — the specific state or finding that requires a decision |
+| **What I tried** | What you attempted before escalating — research, alternatives considered, commands run |
+| **Options** | 2-3 concrete paths forward, each with trade-offs. Label one "(Recommended)" |
+| **My recommendation** | Which option you recommend and why — never leave this blank |
+| **Time sensitivity** | Is this blocking? Urgent? Safe to defer? |
+| **Risk if wrong** | What happens if the chosen option turns out to be the wrong call, and who is affected |
+
+### When Escalation IS Required
+
+- **Irreversible actions** — merge, release, force-push, data deletion, production deploys
+- **Genuinely ambiguous preference decisions** — two valid approaches where the trade-off depends on user priorities the agent cannot infer
+- **Out-of-whitelist runtime skip requests** — skipping verification for a category not in the `markdown-only`, `config-only`, or `dependency-bump-only` whitelist
+- **Repeated verification failures** — after `maxDebugIterations` or `fixForwardMaxIterations` exhausted
+
+### When Escalation is NOT Needed
+
+- **Reversible local actions** — file edits, commits, branch creation, staging (Tier 1)
+- **Actions within the three-tier safety framework** — Tier 1 and Tier 2 actions that are already classified as autonomous or journal-and-proceed
+- **Decisions with clear policy** — the skill, command, or governance framework already specifies the correct action
+- **Fixing your own findings** — P1/P2 findings from self-review are your responsibility to fix, not escalate
+
+## Anti-Patterns
+
+| Anti-Pattern | Description | The Right Way |
+|-------------|-------------|---------------|
+| **Lazy Verification** | Tests pass does not equal works. "Theoretically works" is not "actually works." The proof is running it — build it, start it, hit the endpoint, check the output. | Run the code. Capture the output. Show the evidence. |
+| **Lazy Escalation** | Asking the user without trying first. Open-ended questions with no research, no options, no recommendation. "What should I do?" is never acceptable. | Try to resolve it yourself. If you still need input, use the six-field template with your recommendation. |
+| **Punt-to-User** | "What should I do?" or "How should we proceed?" without options. Agents are teammates, not tools waiting for instructions. Every escalation must include 2-3 options with a recommended path. | Present structured options. Label one "(Recommended)." Explain the trade-offs. |
+| **Silent Deferral** | Downgrading findings to avoid escalation. P3 "note only" was the old way — the new way is fix or escalate with the six-field structure. A finding that matters enough to mention matters enough to act on. | Fix it (if within scope) or file a six-field escalation. Never silently downgrade. |

--- a/plugins/flow/skills/evidence-based-development/SKILL.md
+++ b/plugins/flow/skills/evidence-based-development/SKILL.md
@@ -30,7 +30,7 @@ Every claim about code must include a file:line reference. No exceptions.
 
 ## Finding Prioritization
 
-All findings, review comments, and issues use P1/P2/P3 classification:
+All findings, review comments, and issues use P1/P2/P3 classification. This priority system operationalizes the organizational hard boundary **"No Ungrounded Claims"** — every finding must carry evidence (file:line citation, test output, runtime observation) proportional to its priority, and no recommendation may be made without verification against current sources.
 
 | Priority | Meaning | Action |
 |----------|---------|--------|


### PR DESCRIPTION
## Summary

- Add **Proactive Autonomy with Prepared Escalation** section to `autonomous-workflow/SKILL.md` with the six-field escalation template (Situation / What I tried / Options / My recommendation / Time sensitivity / Risk if wrong), clear rules for when escalation is/isn't required
- Add **Anti-Patterns** section codifying Lazy Verification, Lazy Escalation, Punt-to-User, and Silent Deferral as named anti-patterns with corrective guidance
- Audit all `AskUserQuestion` call sites across 5 command files (`start.md`, `address.md`, `review.md`, `merge.md`, `pr.md`) — replace open-ended "merge as-is?" and "How should they be handled?" with structured six-field escalations
- Update all 4 agent personas (`code-reviewer`, `error-handler-inspector`, `security-reviewer`, `verdict-judge`) to reference the six-field escalation structure for findings requiring human judgment
- Tie `evidence-based-development` P1/P2/P3 system to the organizational "No Ungrounded Claims" hard boundary

## Verification

All acceptance criteria verified:

1. `grep "Proactive Autonomy with Prepared Escalation\|Anti-Patterns" plugins/flow/skills/autonomous-workflow/SKILL.md` -- both sections present
2. `grep -rn "what should I do\|what should we do\|how should we proceed" plugins/flow/commands/` -- zero hits
3. `grep -rn "merge as-is" plugins/flow/` -- zero hits
4. `grep -rn "six-field\|Proactive.Autonomy" plugins/flow/agents/` -- hits in all 4 agent files
5. All 5 command files contain structured six-field references or Proactive Autonomy references

Closes #44