### PR TITLE
docs(flow): excellence overhaul documentation and v2.0.0 bump

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -108,8 +108,8 @@
     {
       "name": "flow",
       "source": "./plugins/flow",
-      "description": "Skill-driven workflow plugin for GitHub development. Encodes team knowledge as composable skills, enforces safety through hooks, and compounds learning across sessions.",
-      "version": "1.5.0",
+      "description": "Skill-driven workflow plugin for GitHub development with excellence-by-default quality gates. Encodes team knowledge as composable skills, enforces safety through hooks, and compounds learning across sessions.",
+      "version": "2.0.0",
       "author": {
         "name": "Daniel Bentes"
       },

--- a/plugins/flow/.claude-plugin/plugin.json
+++ b/plugins/flow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flow",
-  "version": "1.5.0",
-  "description": "Skill-driven workflow plugin for GitHub development. Encodes team knowledge as composable skills, enforces safety through hooks, and compounds learning across sessions. Alternative to gh-workflow with autonomous execution and agent team support.",
+  "version": "2.0.0",
+  "description": "Skill-driven workflow plugin for GitHub development with excellence-by-default quality gates. Encodes team knowledge as composable skills, enforces safety through hooks, and compounds learning across sessions. Strict TDD, Stranger Test, holdout validation, and evidence-based verification built in.",
   "author": {
     "name": "Synapti AI",
     "url": "https://github.com/synaptiai"

--- a/plugins/flow/CHANGELOG.md
+++ b/plugins/flow/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+## 2.0.0 (2026-04-16)
+
+### Breaking Changes
+
+- `tddMode` default changed from `suggest` to `enforce`
+- `verdict.requireAllPass` default changed from `false` to `true`
+- P3 findings are no longer deferrable -- fix in-PR or file a Proactive-Autonomy escalation
+- Pre-existing findings in touched files keep natural priority (no longer capped at P3)
+- Merge gate now blocks on unresolved findings in FLOW_RESOLUTION_CYCLE markers
+- "DEFERRED" markers renamed to "ESCALATED" in FLOW_RESOLUTION_CYCLE comments
+
+### New Features
+
+- Spec Validation Gate: acceptance criteria must have concrete automated verification commands before PLAN phase
+- Specification capture: non-goals, failure modes, and interface contracts required in EXPLORE phase
+- Stranger Test: mandatory end-of-PLAN gate ensuring zero-context executability
+- Per-task verification gate: tests must pass and evidence captured before TaskUpdate(completed)
+- Holdout-validation skill: cross-references agent self-review claims against actual file state
+- Evidence bundle completeness: "What was NOT tested", "Known limitations", "Negative/adversarial cases" required per criterion
+- Missing-criterion scan: verdict-judge Step 1 checks every criterion has evidence before evaluation
+- Proactive Autonomy with Prepared Escalation: codified six-field structure, anti-pattern list
+- Finding-ledger merge gate: blocks merge on non-empty ESCALATED array
+
+### Migration Guide
+
+- To keep old TDD behavior: set `testing.tddMode: "suggest"` and `testing.tddModeOptOut: true` in settings.json
+- To keep old verdict behavior: set `verdict.requireAllPass: false` in settings.json
+- "DEFERRED" markers renamed to "ESCALATED" in FLOW_RESOLUTION_CYCLE comments

--- a/plugins/flow/README.md
+++ b/plugins/flow/README.md
@@ -2,6 +2,71 @@
 
 A Claude Code plugin that replaces command-driven GitHub workflow automation with a skill-driven, agent-team-powered approach. Skills encode reusable team knowledge that compounds across sessions.
 
+## Excellence Principles
+
+Flow v2.0 enforces six guiding principles that shift the quality bar from "good enough" to "provably correct." These principles emerged from observed failure patterns in agent-driven development and are now structural defaults.
+
+### 1. Stranger Test
+
+Every plan must be executable by someone with zero prior context. If an instruction requires unstated assumptions, implicit knowledge, or "you know what I mean" reasoning, it fails the Stranger Test and the PLAN phase blocks until rewritten.
+
+### 2. Spec-as-Eval-Suite
+
+Acceptance criteria are not documentation -- they are the eval suite. Each criterion must have a concrete, automated verification command defined before the PLAN phase begins. Vague criteria like "works correctly" are rejected by the Spec Validation Gate.
+
+### 3. Proactive Autonomy
+
+Agents resolve ambiguity themselves first. When escalation is unavoidable, it follows a structured six-field format (context, options considered, tradeoffs, recommendation, risk of inaction, decision needed) -- never open-ended questions. Anti-patterns like "what should I do?" are blocked.
+
+### 4. Quality > Speed
+
+TDD mode defaults to `enforce`, meaning tests must exist and pass before task completion. The verdict judge requires all acceptance criteria to pass (`verdict.requireAllPass: true`). P3 findings are no longer deferrable -- they must be fixed in the PR or escalated with a Proactive Autonomy structure.
+
+### 5. No Lazy Verification
+
+Evidence bundles must include "What was NOT tested," "Known limitations," and "Negative/adversarial cases" for every criterion. The missing-criterion scan (verdict-judge Step 1) checks that every acceptance criterion has evidence before evaluation begins. Holdout validation cross-references self-review claims against actual file state.
+
+### 6. No Incomplete Shipments
+
+Pre-existing findings in touched files keep their natural priority (no longer capped at P3). The finding-ledger merge gate blocks merges when `FLOW_RESOLUTION_CYCLE` markers contain unresolved or escalated items. "DEFERRED" markers have been renamed to "ESCALATED" to signal that deferral is not an option.
+
+### Strict Defaults
+
+| Setting | Old Default | New Default |
+|---------|-------------|-------------|
+| `testing.tddMode` | `"suggest"` | `"enforce"` |
+| `verdict.requireAllPass` | `false` | `true` |
+
+### Opting Out
+
+Teams not ready for strict defaults can restore previous behavior:
+
+```json
+{
+  "testing": {
+    "tddMode": "suggest",
+    "tddModeOptOut": true
+  },
+  "verdict": {
+    "requireAllPass": false
+  }
+}
+```
+
+Set these in `.claude/settings.flow.json` or `.claude/settings.flow.local.json`.
+
+### What Changed (Summary)
+
+- Pre-existing findings keep natural priority instead of being capped at P3
+- P3 findings are fix-or-escalate, no longer deferrable
+- Merge gate blocks on unresolved findings in `FLOW_RESOLUTION_CYCLE` markers
+- Plans must pass the Stranger Test before exiting PLAN phase
+- Evidence bundles require completeness subsections (not tested, limitations, adversarial cases)
+- Holdout validation runs inline during VERIFY, review, and address phases
+- Spec Validation Gate requires automated verification commands for every acceptance criterion
+
+See [gate-configuration.md](references/gate-configuration.md) for full gate details.
+
 ## Quick Start
 
 ```bash
@@ -141,7 +206,8 @@ Settings in `.claude/settings.flow.json`:
   "lsp": { "enabled": true, "timeout": 5000, "diagnosticsAsQuality": true },
   "visualVerification": { "enabled": true, "screenshotDir": ".screenshots", "maxIterations": 3 },
   "debugging": { "maxHypotheses": 3 },
-  "testing": { "tddMode": "suggest" }
+  "testing": { "tddMode": "enforce", "tddModeOptOut": false },
+  "verdict": { "requireAllPass": true }
 }
 ```
 

--- a/plugins/flow/references/gate-configuration.md
+++ b/plugins/flow/references/gate-configuration.md
@@ -101,6 +101,79 @@ Settings are read in cascading order (first found wins):
 }
 ```
 
+## Quality Gates
+
+Flow enforces eight quality gates across the workflow lifecycle. Gates are structural -- they block progression until satisfied.
+
+### 1. Spec Validation Gate (EXPLORE phase)
+
+Validates that every acceptance criterion has a concrete, automated verification command before the workflow transitions to PLAN. Rejects vague criteria (e.g., "works correctly") and requires specification of non-goals, failure modes, and interface contracts.
+
+**Blocks:** EXPLORE -> PLAN transition
+**Override:** None. Fix the spec.
+
+### 2. Stranger Test Gate (end of PLAN)
+
+Ensures the plan is executable by someone with zero prior context. Every task must have explicit inputs, expected outputs, and verification steps. Implicit assumptions, undefined references, and "you know what I mean" instructions fail the gate.
+
+**Blocks:** PLAN -> CODE transition
+**Override:** None. Rewrite until zero-context executable.
+
+### 3. Per-Task Verification Gate (CODE phase)
+
+Tests must pass and evidence must be captured before `TaskUpdate(completed)` is accepted. When `tddMode: "enforce"`, tests must exist before the implementation is written.
+
+**Blocks:** Individual task completion
+**Override:** Set `testing.tddMode: "suggest"` and `testing.tddModeOptOut: true`
+
+### 4. Runtime Verification Whitelist (VERIFY phase)
+
+Executes dev server startup, API smoke tests, E2E tests, and browser checks. Only whitelisted commands are allowed to run. Diagnostics from LSP servers are treated as quality signals (errors -> P1, warnings -> P2).
+
+**Blocks:** VERIFY phase completion
+**Configuration:** `verification.whitelist` in settings, `lsp.diagnosticsAsQuality`
+
+### 5. Evidence Completeness (VERIFY phase)
+
+Every criterion's evidence bundle must include three completeness subsections: "What was NOT tested," "Known limitations," and "Negative/adversarial cases." Missing subsections block the evidence bundle from being submitted to the verdict judge.
+
+**Blocks:** Evidence bundle submission
+**Override:** None. Add the missing subsections.
+
+### 6. Missing-Criterion Scan (verdict-judge)
+
+Step 1 of verdict evaluation checks that every acceptance criterion from the issue has a corresponding evidence entry. Criteria without evidence are flagged as `FAIL` before any evaluation begins. `verdict.requireAllPass: true` means a single missing criterion blocks the verdict.
+
+**Blocks:** Verdict evaluation
+**Override:** Set `verdict.requireAllPass: false` (all criteria still evaluated, but missing ones do not block)
+
+### 7. Holdout Validation (VERIFY + review + address phases)
+
+Cross-references agent self-review claims against actual file state. Runs inline during verification, code review, and feedback resolution. Detects claims that are not grounded in the codebase (e.g., "all edge cases handled" when error paths are uncovered).
+
+**Blocks:** Self-review acceptance
+**Override:** None. Fix the claims or fix the code.
+
+### 8. Finding-Ledger Merge Gate (merge)
+
+Scans for `FLOW_RESOLUTION_CYCLE` markers in the codebase. Blocks merge when the markers contain unresolved or escalated items. Previously used "DEFERRED" status; now uses "ESCALATED" to signal that deferral without structured escalation is not permitted.
+
+**Blocks:** `gh pr merge` / `/flow:merge`
+**Override:** Resolve all findings or complete Proactive Autonomy escalation for each.
+
+## Gate Summary
+
+| # | Gate | Phase | Blocks |
+|---|------|-------|--------|
+| 1 | Spec Validation | EXPLORE | PLAN transition |
+| 2 | Stranger Test | PLAN | CODE transition |
+| 3 | Per-Task Verification | CODE | Task completion |
+| 4 | Runtime Verification | VERIFY | Phase completion |
+| 5 | Evidence Completeness | VERIFY | Evidence submission |
+| 6 | Missing-Criterion Scan | Verdict | Verdict evaluation |
+| 7 | Holdout Validation | VERIFY/review/address | Self-review acceptance |
+| 8 | Finding-Ledger Merge | Merge | PR merge |
+
 ## Hook Override
 
 Hooks cannot be disabled via settings — they are structural safety mechanisms. To modify hook behavior, edit the hook scripts directly in `plugins/flow/hooks/scripts/`.


### PR DESCRIPTION
## Summary

- Add "Excellence Principles" section to `plugins/flow/README.md` documenting the six guiding principles, strict defaults (`tddMode: enforce`, `verdict.requireAllPass: true`), opt-out mechanism, and what changed
- Create `plugins/flow/CHANGELOG.md` with full 2.0.0 entry covering breaking changes, new features, and migration guide
- Bump flow version to 2.0.0 in `plugin.json` and `marketplace.json`
- Document all 8 quality gates in `gate-configuration.md`: Spec Validation, Stranger Test, Per-Task Verification, Runtime Verification Whitelist, Evidence Completeness, Missing-Criterion Scan, Holdout Validation, Finding-Ledger Merge Gate

## Verification

- [x] README has "Excellence Principles" section with all 6 principles
- [x] CHANGELOG.md exists with 2.0.0 entry, breaking changes, new features, migration guide
- [x] `plugin.json` version is 2.0.0
- [x] `marketplace.json` flow entry version is 2.0.0
- [x] `gate-configuration.md` lists all 8 gates with override details
- [x] No old version strings (1.5.0) remain in flow plugin version fields

Closes #45