### PR TITLE
feat(flow): add holdout-validation skill with inline invocation during verify, review, and address

### DIFF
--- a/plugins/flow/agents/verdict-judge.md
+++ b/plugins/flow/agents/verdict-judge.md
@@ -23,6 +23,7 @@ You are an independent verification judge for the flow plugin. Your role is to e
 **You ONLY receive:**
 1. The acceptance criteria list (from the issue)
 2. The evidence bundle (test outputs, curl responses, screenshot paths, build logs)
+3. The holdout-validation output (P1/P2/P3 findings from cross-referencing self-review claims against actual file state)
 
 This separation is intentional. You are a second set of eyes that evaluates outcomes, not process. When issuing NEEDS-HUMAN-REVIEW verdicts, structure them using the six-field Proactive Autonomy escalation (Situation / What I tried / Options / My recommendation / Time sensitivity / Risk if wrong) so the human receives actionable context rather than an open-ended question.
 
@@ -37,6 +38,7 @@ Execute the scan in this exact order:
 1. **Parse the input**. You receive a structured prompt with:
    - **Acceptance Criteria**: The full list from the issue
    - **Evidence Bundle**: Structured evidence per criterion (verification command + output + completeness subsections)
+   - **Holdout Validation Output**: P1/P2/P3 findings from the holdout-validation skill, listing any conflicts between self-review claims and actual file state
 
 2. **Enumerate every acceptance criterion**. Produce a numbered list of every criterion in the issue. Do not summarize, do not merge, do not drop any. Use the exact criterion text.
 
@@ -47,24 +49,25 @@ Execute the scan in this exact order:
    ```markdown
    ### Coverage Scan
 
-   | # | Criterion | Evidence Entry Present? | "Does NOT promise" Present? | Completeness Subsections Present? |
-   |---|-----------|-------------------------|-----------------------------|-----------------------------------|
-   | 1 | {criterion text} | Yes / NO | Yes / NO | Yes / NO ({which are missing}) |
+   | # | Criterion | Evidence Entry Present? | "Does NOT promise" Present? | Completeness Subsections Present? | Holdout Validation Status |
+   |---|-----------|-------------------------|-----------------------------|-----------------------------------|---------------------------|
+   | 1 | {criterion text} | Yes / NO | Yes / NO | Yes / NO ({which are missing}) | PASS / CONFLICT / N/A |
    ```
 
-   The "Does NOT promise Present?" column checks for the plan-time non-goals field. The "Completeness Subsections Present?" column checks that the evidence block contains all three mandatory verify-time subsections: "What was NOT tested", "Known limitations of this evidence", and "Negative/adversarial cases covered".
+   The "Does NOT promise Present?" column checks for the plan-time non-goals field. The "Completeness Subsections Present?" column checks that the evidence block contains all three mandatory verify-time subsections: "What was NOT tested", "Known limitations of this evidence", and "Negative/adversarial cases covered". The "Holdout Validation Status" column checks whether the holdout-validation skill found a conflict between self-reported evidence and actual file state for this criterion: PASS (no conflict), CONFLICT (holdout-validation found a P1/P2 for this criterion), or N/A (no holdout scenarios applied to this criterion type).
 
 5. **Automatic FAIL rules** — apply these BEFORE per-criterion evaluation and record the result:
    - Any criterion with no evidence entry at all → **automatic FAIL** with rationale "no evidence — missing-criterion scan". Do NOT attempt to infer, do NOT give NEEDS-HUMAN-REVIEW, do NOT skip it. FAIL it.
    - Any criterion whose evidence entry is missing "Does NOT promise" → **automatic FAIL** with rationale "incomplete evidence — missing non-goals field ('Does NOT promise')".
    - Any criterion whose evidence entry is missing one or more of the three mandatory completeness subsections → **automatic FAIL** with rationale "incomplete evidence — missing {list of absent subsections}".
+   - Any criterion where the holdout-validation output reports a P1 or P2 conflict → **automatic FAIL** with rationale "holdout-validation conflict — self-reported evidence contradicted by file state: {holdout finding summary}". This rule exists because if the holdout-validation skill found that a self-review claim does not match the actual files, the evidence for that criterion is unreliable regardless of what the evidence bundle says.
    - Any evidence entry in the bundle that does not correspond to any acceptance criterion → note it in the scan output as "orphan evidence" but do not use it to pass anything.
 
 6. Carry the coverage table and the auto-FAIL list forward into Step 2. Criteria already marked FAIL by the coverage scan are NOT re-evaluated for PASS in Step 2 — their verdict is locked.
 
 ### Step 2: Evaluate Each Remaining Criterion
 
-For each acceptance criterion that survived the coverage scan (i.e., has an evidence entry with "Does NOT promise" and all three completeness subsections):
+For each acceptance criterion that survived the coverage scan (i.e., has an evidence entry with "Does NOT promise", all three completeness subsections, and no holdout-validation CONFLICT):
 
 1. Read the criterion carefully — what specific behavior does it require?
 2. Find the corresponding evidence in the bundle
@@ -89,9 +92,9 @@ Return the coverage scan output FIRST, then the verdict table.
 ## Verification Verdict
 
 ### Coverage Scan
-| # | Criterion | Evidence Entry Present? | "Does NOT promise" Present? | Completeness Subsections Present? |
-|---|-----------|-------------------------|-----------------------------|-----------------------------------|
-| 1 | {criterion text} | Yes / NO | Yes / NO | Yes / NO ({missing}) |
+| # | Criterion | Evidence Entry Present? | "Does NOT promise" Present? | Completeness Subsections Present? | Holdout Validation Status |
+|---|-----------|-------------------------|-----------------------------|-----------------------------------|---------------------------|
+| 1 | {criterion text} | Yes / NO | Yes / NO | Yes / NO ({missing}) | PASS / CONFLICT / N/A |
 
 Orphan evidence entries (evidence with no matching criterion): {list or "none"}
 

--- a/plugins/flow/commands/address.md
+++ b/plugins/flow/commands/address.md
@@ -19,6 +19,7 @@ Systematic feedback resolution. Follows Explore > Plan > Code > Verify loop.
 - `change-classification` — verify no out-of-context changes
 - `capability-discovery` — quality commands for verification
 - `tdd-patterns` — test-first for fixes, test quality standards
+- `holdout-validation` — cross-reference self-review claims against file state (Phase 4)
 
 ## Phase 1: EXPLORE
 
@@ -177,19 +178,32 @@ For cosmetic P3 findings in untouched files that the team agrees to track separa
       Check for: logic errors, security issues, missing edge cases.
       Return P1/P2/P3 findings with file:line."
    ```
-3. **Convergence check** (max 3 self-review-fix iterations):
+3. **Holdout validation** — after self-review, invoke `holdout-validation` to cross-reference claims against file state:
+   ```
+   Skill(holdout-validation):
+     Inputs:
+     - Self-review findings: {P1/P2/P3 findings from step 2}
+     - Evidence bundle draft: {per-criterion evidence from feedback fixes}
+     - File list: {all files modified on this branch}
+   ```
+   **Blocking treatment** (same as start.md):
+   - P1/P2 holdout findings → fix immediately before proceeding
+   - After fixes: re-run holdout-validation to confirm resolution
+   - P3 findings → note, do not block
+4. **Convergence check** (max 3 self-review-fix iterations):
    - Self-review finds P1 → fix NOW (don't re-request with known P1s)
+   - Holdout-validation finds P1/P2 → fix NOW (same blocking treatment as self-review P1)
    - P2 in touched files → fix NOW
    - P3 in touched files → fix NOW (same disposition as P1/P2 — the proximity test is not a deferral mechanism)
    - Only truly cosmetic P3 findings in untouched files may become follow-up issues; P1/P2 in untouched files must be addressed in-PR or filed as a six-field Proactive-Autonomy escalation (Situation / Tried / Options / Recommendation / Time sensitivity / Risk)
-   - After fixes: re-run quality commands, re-review changed files
-4. **Verify Boy Scout cleanup** passes proximity test (no scope creep)
-5. **Change classification** — verify no out-of-context changes introduced
-6. **Push** (Tier 2: journal-and-proceed):
+   - After fixes: re-run quality commands, re-review changed files, re-run holdout-validation
+5. **Verify Boy Scout cleanup** passes proximity test (no scope creep)
+6. **Change classification** — verify no out-of-context changes introduced
+7. **Push** (Tier 2: journal-and-proceed):
    ```bash
    git push
    ```
-7. **Reply to individual review comments** inline:
+8. **Reply to individual review comments** inline:
    ```bash
    REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
    # For each fixed item, reply to the original review comment:
@@ -200,18 +214,18 @@ For cosmetic P3 findings in untouched files that the team agrees to track separa
    gh api repos/$REPO/pulls/$ARGUMENTS/comments/{comment_id}/replies \
      -f body="{response text}"
    ```
-8. **Post resolution comment** (MANDATORY) using the template structure from `templates/resolution-comment.md`:
+9. **Post resolution comment** (MANDATORY) using the template structure from `templates/resolution-comment.md`:
    ```bash
    gh pr comment $ARGUMENTS --body "$BODY"
    ```
    - TaskUpdate(postCommentTaskId, status: "completed", result: "PASS — resolution comment posted to PR")
-9. **Update PR body review cycle state** (if `### Review Cycle History` exists in the PR body):
+10. **Update PR body review cycle state** (if `### Review Cycle History` exists in the PR body):
    - Fetch current body: `gh pr view $ARGUMENTS --json body --jq '.body'`
    - If the body contains `### Review Cycle History`, replace content between that heading and the next `##` heading with the cycle metrics table (received/fixed/discussed/escalated)
    - If the heading does not exist, append a `### Review Cycle History` section under `## Review Findings`
    - Update: `gh pr edit $ARGUMENTS --body "$UPDATED_BODY"`
-10. **TaskList**: Confirm ALL tasks complete including "Post resolution comment". Do NOT proceed until verified.
-11. **Conditional re-request review**:
+11. **TaskList**: Confirm ALL tasks complete including "Post resolution comment". Do NOT proceed until verified.
+12. **Conditional re-request review**:
 
     ONLY after TaskList confirms "Post resolution comment" is completed:
     - If self-review found 0 findings → do NOT re-request (nothing changed that needs re-review beyond the feedback fixes)

--- a/plugins/flow/commands/review.md
+++ b/plugins/flow/commands/review.md
@@ -16,6 +16,7 @@ Multi-faceted code review with parallel analysis. Follows Explore > Plan > Code 
 ## Required Skills
 
 - `code-review-methodology` — 5-facet review, finding synthesis, adversarial protocol
+- `holdout-validation` — cross-reference self-review claims against file state (Phase 3)
 
 ## Phase 1: EXPLORE
 
@@ -73,6 +74,7 @@ TaskCreate("Convention review", "Commit format, branch naming, code patterns")
 TaskCreate("Test review", "Run quality commands, assess test coverage")
 TaskCreate("Requirements review", "Map acceptance criteria to implementation")
 TaskCreate("Error handling review", "Check for unhandled exceptions, silent failures, missing edge cases")
+TaskCreate("Holdout validation", "Cross-reference self-review claims against actual file state using holdout scenarios")
 ```
 
 ## Phase 3: CODE (Review Execution)
@@ -109,6 +111,12 @@ Agent(test-runner):
 Agent(error-handler-inspector):
   "Inspect changed files in PR #$ARGUMENTS for error handling gaps,
    silent failures, unhandled exceptions. Return P1/P2/P3 findings."
+
+Skill(holdout-validation):
+  Inputs:
+  - Self-review findings: {P1/P2/P3 findings from code-reviewer agent}
+  - Evidence bundle draft: {per-criterion evidence from requirements review}
+  - File list: {all files changed in this PR}
 ```
 
 **Main thread**: Requirements compliance — map acceptance criteria to implementation.

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -27,6 +27,7 @@ This command operates with these domain skills loaded:
 - `debugging-patterns` — activates on-demand for ALL issues when any verification step fails (not gated on `bug` label)
 - `preflight-checks` — pure bash pre-flight validation (Phase 0)
 - `criterion-verification-map` — per-criterion evidence collection (Phase 2 + Phase 4)
+- `holdout-validation` — cross-reference self-review claims against file state (Phase 4)
 
 ## Phase 0: PRE-FLIGHT
 
@@ -362,7 +363,22 @@ Prove everything works with fix-forward:
    - P2 findings → fix immediately
    - P3 findings → fix if contained (<10 lines, same file), otherwise note for PR body
    - After fixes: re-run quality commands, then targeted re-review on files changed by fixes
-4. **Per-criterion evidence collection** — execute verification tasks created in Phase 2:
+4. **Holdout validation** — invoke `holdout-validation` skill to cross-reference self-review claims against actual file state:
+   ```
+   Skill(holdout-validation):
+     Inputs:
+     - Self-review findings: {P1/P2/P3 findings from step 3}
+     - Evidence bundle draft: {per-criterion evidence collected so far}
+     - File list: {all files modified/created on this branch}
+   ```
+   **Blocking treatment:**
+   - P1/P2 findings from holdout-validation → fix immediately before proceeding (same fix-forward loop as step 3)
+   - After fixes: re-run holdout-validation to confirm the conflict is resolved
+   - P3 findings → note for PR body, do not block
+   - Only proceed to step 5 when holdout-validation returns PASS or P3-only
+
+   The holdout-validation output is passed to the verdict-judge in step 6 as a required input.
+5. **Per-criterion evidence collection** — execute verification tasks created in Phase 2:
    ```
    For each "Verify: ..." task:
      1. TaskUpdate(verifyTaskId, status: "in_progress")
@@ -371,7 +387,7 @@ Prove everything works with fix-forward:
      4. TaskUpdate(verifyTaskId, status: "completed", result: "EVIDENCE_COLLECTED")
    ```
    Assemble evidence bundle (see `criterion-verification-map` skill for format).
-5. **Independent verdict** — if `verdict.enabled` is `true` (default), dispatch Agent(verdict-judge):
+6. **Independent verdict** — if `verdict.enabled` is `true` (default), dispatch Agent(verdict-judge):
    ```
    Agent(verdict-judge):
      "Evaluate whether acceptance criteria are met based on evidence.
@@ -380,9 +396,12 @@ Prove everything works with fix-forward:
       {list of ACs from issue body}
 
       Evidence Bundle:
-      {assembled evidence from step 4}"
+      {assembled evidence from step 5}
+
+      Holdout Validation Output:
+      {findings from step 4 — P1/P2/P3 with file:line citations}"
    ```
-   The verdict-judge receives ONLY the acceptance criteria and evidence bundle.
+   The verdict-judge receives ONLY the acceptance criteria, evidence bundle, and holdout-validation output.
    It does NOT receive: the diff, decision journal, planning rationale, or self-review findings.
 
    **Handle verdicts:**
@@ -397,8 +416,8 @@ Prove everything works with fix-forward:
        > 1. Approve — these criteria are met (I've reviewed the evidence)
        > 2. Reject — fix these criteria before proceeding
      - Based on response: proceed or enter fix loop
-6. **TaskList** — confirm all tasks show status: completed
-7. **Visual verification** — if UI-relevant changes detected (changed .tsx/.jsx/.vue/.html/.css/.scss files OR acceptance criteria mention UI/page/render/display):
+7. **TaskList** — confirm all tasks show status: completed
+8. **Visual verification** — if UI-relevant changes detected (changed .tsx/.jsx/.vue/.html/.css/.scss files OR acceptance criteria mention UI/page/render/display):
    ```
    TaskCreate("Visual verification", "Screenshot-analyze-verify for UI-facing changes")
    TaskCreate("Browser tool discovery", "Detect available browser automation tools")
@@ -411,10 +430,11 @@ Prove everything works with fix-forward:
    - If browser tools not found and `requireVisualVerification: false`: result is "SKIP_WARN"
    - If browser tools not found and `requireVisualVerification: true`: result is "BLOCKED"
    - `TaskList` — confirm all visual verification tasks resolved
-8. **Completion gate**: ALL of:
+9. **Completion gate**: ALL of:
    - All quality checks pass
    - Runtime verification passed (or skipped under one of the three enumerated whitelist categories in the `runtime-verification` skill: `markdown-only`, `config-only`, `dependency-bump-only`)
    - No unresolved P1 findings
+   - Holdout validation: PASS or P3-only (no unresolved P1/P2 conflicts)
    - All tasks completed (including verification tasks)
    - Verdict: all criteria PASS or user-approved (when `verdict.enabled`)
    - Visual verification: no BLOCKED results (see escalation below)
@@ -432,10 +452,11 @@ Prove everything works with fix-forward:
    - Option 1 → `TaskUpdate` visual tasks with result "SKIP_USER_APPROVED"
    - Option 2 → `TaskUpdate` visual tasks with result "MANUAL — user will verify"
    - Option 3 → Provide Playwright MCP installation guidance, then retry browser tool cascade
-9. **Display summary**:
+10. **Display summary**:
    - Tasks completed: N/N
    - Quality checks: pass/fail
    - Self-review findings: P1: X, P2: Y, P3: Z (all P1/P2 fixed via fix-forward)
+   - Holdout validation: PASS / FINDINGS (P1: X, P2: Y, P3: Z — all P1/P2 fixed)
    - Verdict: PASS (N/N criteria) / FAIL / NEEDS-HUMAN-REVIEW / N/A (spec-free task)
    - Runtime verification: pass/fail/skip
    - Visual verification: PASS / FAIL / SKIP / SKIP_WARN / SKIP_USER_APPROVED / MANUAL

--- a/plugins/flow/skills/holdout-validation/SKILL.md
+++ b/plugins/flow/skills/holdout-validation/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: holdout-validation
+description: "Cross-reference agent self-review claims against actual file state using hidden holdout scenarios, producing mapped P1/P2/P3 findings that reference visible acceptance criteria only. Use when verifying implementation completeness after self-review in start (Phase 4 VERIFY), address (convergence check), or review (parallel fan-out). Also use when an agent claims evidence for a criterion but the file state may not support the claim. This skill MUST be consulted because it detects blind spots in self-review that no other skill catches; a conversational answer cannot systematically test holdout scenarios or cross-reference claims against files."
+allowed-tools: Bash, Read, Grep, Glob
+context: fork
+agent: general-purpose
+---
+
+# Holdout Validation
+
+You are an **independent claim verifier** — you cross-reference agent self-review claims against actual file state using hidden holdout scenarios that the executing agent never sees. Your core insight: agents often claim "test added for X" or "error handling covers Y" without the claim being true. You verify the claim against the files.
+
+This skill is adapted from the `ai-first-org-design-kit` holdout-evaluator but simplified to flow's finding vocabulary (P1/P2/P3) and criterion types (behavioral, api, error, data).
+
+## Persona
+
+- **Skeptical.** Claims without file evidence are findings. "I added a test for X" without a test that actually tests X is a P1.
+- **Behavioral.** Evaluate what the files show, not what the agent says it did. Grep the files. Read the test assertions. Check the error handlers.
+- **Secure.** Never reveal holdout scenario names, descriptions, or specifics in mapped output. The executing agent must not learn the test set.
+- **Fair.** Evaluate the work output, not the agent. A genuine effort that exhibits a blind spot still produces a finding — but the feedback should be constructive.
+
+## Inputs
+
+This skill receives three inputs, passed in the prompt by the invoking command:
+
+1. **Self-review findings** — the P1/P2/P3 findings from the code-reviewer agent's self-review, showing what the agent claims about the implementation
+2. **Evidence bundle draft** — the per-criterion evidence collected so far, showing what verification commands produced
+3. **File list** — paths to all files modified or created on the branch
+
+If any input is missing, note it and evaluate what is available. Do not halt — partial evaluation is better than none.
+
+## Process
+
+### Step 1: Load Holdout Scenarios
+
+Determine which criterion types are present in the acceptance criteria and evidence bundle. Load the corresponding scenario files:
+
+- **Behavioral criteria** → read `templates/holdout-scenarios/behavioral.md`
+- **API criteria** → read `templates/holdout-scenarios/api.md`
+- **Error-handling criteria** → read `templates/holdout-scenarios/error.md`
+- **Data criteria** → read `templates/holdout-scenarios/data.md`
+
+Use relative paths from the flow plugin root. If a scenario file is missing for a criterion type, skip that type and note it.
+
+Assign each scenario an ID by document order (scenario-1, scenario-2, etc.) across all loaded files. Use IDs only — never names — in any output.
+
+### Step 2: Parse Self-Review Claims
+
+For each self-review finding and evidence entry:
+
+1. Extract the **claim** — what the agent says about the implementation (e.g., "test added for edge case X", "error handling covers timeout", "validation rejects invalid input")
+2. Extract the **file references** — which files and lines the agent cites as evidence
+3. Classify the claim as **verifiable** (cites specific files/lines/outputs) or **bare assertion** ("I verified X" without supporting detail)
+
+Flag bare assertions immediately — they are findings regardless of holdout scenario results.
+
+### Step 3: Cross-Reference Claims Against Files
+
+For each verifiable claim:
+
+1. **Read the cited file** at the cited location using `Read` or `Grep`
+2. **Check whether the file content supports the claim:**
+   - Claim: "test added for edge case X" → Does a test exist that actually tests edge case X (not just a test that mentions X in its name)?
+   - Claim: "error handling covers timeout" → Does the code actually have timeout handling (not just a comment about it)?
+   - Claim: "validation rejects invalid input" → Does the validation logic actually reject the stated input type?
+3. **Record the result:** CONFIRMED (file supports claim) or CONFLICT (file does not support claim)
+
+### Step 4: Evaluate Holdout Scenarios
+
+For each loaded holdout scenario, evaluate against the file state and self-review claims:
+
+1. **Does the implementation exhibit the failure mode described in this scenario?**
+   - Look for behavioral evidence in the files, not just keywords
+   - Cross-reference against actual test assertions, error handlers, and validation logic
+2. **Does the self-review evidence genuinely address this failure mode?**
+   - Evidence that references specific files and lines with matching content is genuine
+   - Evidence that restates the criterion without adding verifiable detail is not genuine
+3. **Verdict per scenario:** PASS or FAIL
+4. **Criterion mapping** (for each FAIL): which visible acceptance criterion does this map to, described WITHOUT referencing the holdout scenario
+
+### Step 5: Generate Mapped Findings
+
+Convert holdout evaluation results and cross-reference conflicts into flow-standard P1/P2/P3 findings.
+
+**Priority mapping:**
+- **P1 (Critical)** — Self-review claim directly contradicted by file state. Example: agent claims "test covers timeout" but no timeout test exists. Also: holdout scenario detects a failure mode that the self-review completely missed.
+- **P2 (Should fix)** — Holdout scenario detects a weakness the self-review understated. Example: test exists but only covers the happy path, not the edge case claimed. Also: bare assertion without supporting file evidence.
+- **P3 (Note)** — Minor gap between claim and file state that does not affect correctness. Example: test exists and is correct but the cited line number is off.
+
+**Output format (all scenarios PASS):**
+
+```
+Holdout validation: PASS
+No conflicts detected between self-review claims and file state.
+```
+
+**Output format (any findings):**
+
+```
+Holdout validation: FINDINGS
+
+P1:
+- {file:line}: {description of conflict between claim and file state, mapped to visible criterion only}
+
+P2:
+- {file:line}: {description of weakness, mapped to visible criterion only}
+
+P3:
+- {file:line}: {description of minor gap}
+
+Blocking: {Yes — P1/P2 findings must be fixed before proceeding | No — P3 only}
+```
+
+**Security check before outputting:**
+Scan the mapped findings for any holdout scenario names, descriptions, or specifics. If found, rewrite to reference only visible criteria. The findings must pass this test: "Could someone reading these findings determine which specific holdout scenario triggered it?" If yes, generalize further.
+
+When performing this security check, NEVER write out holdout scenario names to demonstrate their absence. Verify using scenario IDs only: "Verified: scenario-1 through scenario-N — no scenario names or descriptions appear in findings."
+
+## Rules
+
+- **NEVER reveal holdout scenario names, descriptions, or specifics** in findings, conversation, or any agent-visible artifact. Scenario IDs only.
+- **Cross-reference claims against files.** The self-review says what the agent claims. The files show what actually exists. Trust the files.
+- **Map findings to visible criteria.** Every holdout finding maps to one or more visible acceptance criteria. The agent should be able to fix the issue using only the visible criteria and your mapped findings.
+- **Use flow finding vocabulary.** P1/P2/P3 with file:line citations. No other priority scheme.
+- **Bare assertions are automatic P2.** "I verified X" without citing what was verified and where is always a finding.
+- **Be specific.** "Test does not cover timeout" is better than "test coverage is weak." Cite the exact file and line where the gap exists.
+
+## Iron Law
+
+**THE HOLDOUT SET MUST REMAIN HIDDEN. If the executing agent can see the test cases, it optimizes for them specifically — defeating the purpose of holdout validation. Every output from this skill must pass the test: "Could the executing agent reconstruct a holdout scenario from this feedback?" If yes, you have leaked. Rewrite.**
+
+| Temptation | Response |
+|------------|----------|
+| "I'll mention the scenario name for clarity" | Never. Use criterion numbers and generic descriptions only. |
+| "I'll list scenario names to prove they're absent" | This IS the leak. Verify using scenario IDs: "scenario-1 through scenario-N checked." |
+| "The feedback is too vague to be useful" | Map to the visible criterion and describe the weakness generically. The agent has the full acceptance criteria to work from. |
+| "This scenario doesn't apply" | Still evaluate it. Some failure modes are latent. |
+| "The agent clearly passed, skip detailed evaluation" | Evaluate every scenario. Thoroughness is the point. |
+
+## Graceful Degradation
+
+| Missing | Fallback |
+|---------|----------|
+| No scenario files for a criterion type | Skip that type. Note: "No holdout scenarios for {type} criteria." |
+| No self-review findings provided | Evaluate file state against holdout scenarios only. Note: "Self-review not provided — evaluating files only." |
+| No evidence bundle provided | Cross-reference cannot verify claims. Evaluate file list against holdout scenarios. |
+| No file list provided | Halt: "No file list specified. Provide paths to modified files." |
+| Scenario file unreadable | Skip and note: "Could not load scenarios for {type}." |
+
+## Integration Points
+
+This skill is invoked by:
+- **start.md** Phase 4 VERIFY — after self-review (step 3), before verdict-judge (step 5)
+- **address.md** Phase 4 convergence check — after self-review, same blocking treatment
+- **review.md** Phase 3 parallel fan-out — alongside code-reviewer, security-reviewer, etc.
+- **verdict-judge.md** — consumes holdout-validation output as required input
+
+Reads: `templates/holdout-scenarios/*.md` (hidden scenarios), branch files (ground truth), self-review findings, evidence bundle.
+Returns: P1/P2/P3 findings with file:line citations mapped to visible acceptance criteria.

--- a/plugins/flow/templates/holdout-scenarios/api.md
+++ b/plugins/flow/templates/holdout-scenarios/api.md
@@ -1,0 +1,47 @@
+# API Holdout Scenarios
+
+Hidden scenarios for validating API acceptance criteria. These probe common agent self-review blind spots when claiming API contract compliance.
+
+**WARNING: This file is consumed ONLY by the holdout-validation skill. Its contents must NEVER appear in agent-visible output. Reference scenarios by positional ID only.**
+
+## Scenarios
+
+### 1. Status Code Mismatch
+
+**Failure mode:** Agent claims "API returns correct status codes" but the implementation returns 200 for all responses, including errors. Or the error status codes don't match the contract (e.g., 400 instead of 422 for validation errors, 500 instead of 503 for upstream failures).
+
+**What to check:** Read the route handler or controller. Trace every return/response path. Do the status codes match what the criterion or interface contract specifies?
+
+**Signals:** Single status code used across all paths, generic error handler that always returns 500, missing explicit status code setting (relying on framework defaults).
+
+### 2. Response Shape Drift
+
+**Failure mode:** Agent claims "response matches contract" but the actual response body has different field names, types, or nesting than the stated schema. The test may pass because it checks only one field, not the full shape.
+
+**What to check:** Compare the response object construction in the handler against the interface contract from the issue. Check field names (camelCase vs snake_case), types (string vs number), and nesting depth.
+
+**Signals:** Test that checks `response.body.id` but not the full shape, response built with spread operators that may include extra fields, field names that differ from the contract by casing or naming convention.
+
+### 3. Missing Content-Type
+
+**Failure mode:** Agent claims "API endpoint implemented" but the response does not set the Content-Type header, or sets it incorrectly. JSON responses without `application/json`, file downloads without proper MIME type.
+
+**What to check:** Read the response construction. Is Content-Type explicitly set? Does the framework auto-set it correctly for this response type? If the test verifies Content-Type, does it match the contract?
+
+**Signals:** No explicit Content-Type setting, framework default that may not match contract, test that doesn't check headers at all.
+
+### 4. Partial Field Validation
+
+**Failure mode:** Agent claims "input validation implemented" but the validation only checks required fields, not field types, ranges, or formats. Or validation covers some fields but not all fields in the contract.
+
+**What to check:** List every field in the input contract. For each, check whether validation exists for: presence, type, range/length, format (email, URL, date). Compare against what the criterion requires.
+
+**Signals:** Validation that only checks `if (!field)` (presence only), missing validation for optional-but-typed fields, no format validation for structured strings (emails, URLs, dates).
+
+### 5. Authentication Bypass
+
+**Failure mode:** Agent claims "endpoint requires authentication" but the middleware/guard is not applied to the route, or the test uses an authenticated client that masks the fact that unauthenticated requests would also succeed.
+
+**What to check:** Read the route registration. Is the auth middleware/guard attached? Read the test — does it include a test case for unauthenticated access that expects 401/403?
+
+**Signals:** Route defined without auth middleware, all test cases use an auth token, no test for missing/invalid token, auth check in handler body instead of middleware (easy to bypass on new routes).

--- a/plugins/flow/templates/holdout-scenarios/behavioral.md
+++ b/plugins/flow/templates/holdout-scenarios/behavioral.md
@@ -1,0 +1,47 @@
+# Behavioral Holdout Scenarios
+
+Hidden scenarios for validating behavioral acceptance criteria. These probe common agent self-review blind spots when claiming behavioral coverage.
+
+**WARNING: This file is consumed ONLY by the holdout-validation skill. Its contents must NEVER appear in agent-visible output. Reference scenarios by positional ID only.**
+
+## Scenarios
+
+### 1. Name-Only Test Coverage
+
+**Failure mode:** Agent claims "test added for behavior X" but the test only asserts the function exists or is callable — it does not verify the stated behavior. The test name mentions X but the assertions check something else entirely.
+
+**What to check:** Read the test file. Do the assertions verify the specific behavioral outcome (return value, state change, side effect) described in the criterion, or do they just verify invocation/existence?
+
+**Signals:** `expect(fn).toBeDefined()`, `assert callable(fn)`, test body that calls the function without checking the result, test name that matches the criterion text but assertions that do not.
+
+### 2. Happy Path Only
+
+**Failure mode:** Agent claims "behavior verified" but the test only covers the success case. The criterion implies edge cases (boundary values, empty inputs, error states) but the test only exercises the normal flow.
+
+**What to check:** Count the test cases for this criterion. Is there only one? Does it use representative inputs or only the simplest possible input? Are boundary conditions tested?
+
+**Signals:** Single test case per criterion, inputs that are obviously "normal" (e.g., `"test"`, `1`, `true`), no negative assertions, no boundary values.
+
+### 3. Assertion-Free Test
+
+**Failure mode:** Agent claims "test passes" but the test has no meaningful assertions. The test runs code without checking the result. A test that never fails is not a test.
+
+**What to check:** Read the test body. Count the `expect`/`assert`/`should` statements. Are there any? Do they check meaningful properties or just truthiness?
+
+**Signals:** Test body with no assert/expect/should, assertions that are always true (`expect(true).toBe(true)`), assertions on constants, `.not.toThrow()` without additional behavioral checks.
+
+### 4. Stale Reference
+
+**Failure mode:** Agent claims "test covers criterion X" but the test was written for a previous version of the code. The implementation changed during the session but the test still passes because it tests the old interface.
+
+**What to check:** Compare the test's function calls and expected values against the current implementation. Do the function signatures match? Do the expected return values match what the code actually produces?
+
+**Signals:** Test imports a function that was renamed or removed, test calls with argument counts that don't match the current signature, expected values that don't match the implementation logic.
+
+### 5. Implementation Leak in Test
+
+**Failure mode:** Agent claims "behavior tested" but the test is tightly coupled to implementation details rather than behavior. The test mocks internals, checks private state, or asserts on implementation-specific artifacts instead of observable behavior.
+
+**What to check:** Does the test verify what the user/caller would observe (return values, output, side effects visible at the boundary) or does it verify internal state (private variables, internal method calls, implementation order)?
+
+**Signals:** Extensive mocking of internal modules, assertions on private/internal properties, test that breaks when implementation is refactored even though behavior is unchanged, spy/stub on internal methods.

--- a/plugins/flow/templates/holdout-scenarios/data.md
+++ b/plugins/flow/templates/holdout-scenarios/data.md
@@ -1,0 +1,47 @@
+# Data Holdout Scenarios
+
+Hidden scenarios for validating data-handling acceptance criteria. These probe common agent self-review blind spots when claiming data transformation, validation, or persistence coverage.
+
+**WARNING: This file is consumed ONLY by the holdout-validation skill. Its contents must NEVER appear in agent-visible output. Reference scenarios by positional ID only.**
+
+## Scenarios
+
+### 1. Transform Shape Assumption
+
+**Failure mode:** Agent claims "data transform produces the stated output format" but the transform assumes input will always have a specific shape. Missing fields, null values, or unexpected types cause the transform to produce incorrect output or throw — and there is no test for malformed input.
+
+**What to check:** Read the transform function. Trace what happens when an input field is missing, null, undefined, or the wrong type. Does the transform use optional chaining, default values, or explicit checks? Is there a test case with minimal/malformed input?
+
+**Signals:** Direct property access without null checks (`input.nested.field`), no default values for optional fields, no test case with partial input, transform that only works with the example input from the issue.
+
+### 2. Encoding Blindness
+
+**Failure mode:** Agent claims "data handling is correct" but the code does not account for character encoding. UTF-8 multi-byte characters, emoji, RTL text, or special characters (quotes, backslashes, null bytes) cause data corruption, truncation, or injection.
+
+**What to check:** Read the data handling code. Does it specify encoding explicitly when reading/writing files, parsing strings, or constructing queries? Are there tests with non-ASCII input?
+
+**Signals:** No explicit encoding parameter on file reads/writes, string length checks that count bytes instead of characters, SQL queries built with string concatenation, no test case with Unicode input.
+
+### 3. Empty Collection Omission
+
+**Failure mode:** Agent claims "handles edge cases" but the code does not handle empty arrays, empty objects, or empty strings as input. The transform/validation/persistence logic assumes at least one item exists.
+
+**What to check:** Read the code path for collections (arrays, lists, maps). What happens when the collection is empty? Does the code return a valid empty result, or does it throw, return undefined, or produce incorrect output? Is there a test for empty input?
+
+**Signals:** `array[0]` without length check, `.reduce()` without initial value, `.map()` result used without checking for empty array, no test case with `[]` or `{}` or `""` as input.
+
+### 4. Precision Loss
+
+**Failure mode:** Agent claims "data calculation is correct" but the code uses floating-point arithmetic for values that require exact precision (currency, percentages, scientific measurements). Or the code converts between number types in a way that loses precision.
+
+**What to check:** Read the calculation code. Are monetary values stored as floats? Are percentage calculations subject to floating-point rounding? Does the code compare floats with strict equality? Are there tests that check for precision edge cases (e.g., 0.1 + 0.2)?
+
+**Signals:** Currency stored as `float`/`double` instead of integer cents or decimal type, `===` comparison on calculated floats, no rounding strategy for display values, tests with only round-number inputs.
+
+### 5. Idempotency Assumption
+
+**Failure mode:** Agent claims "data persistence is implemented" but the write operation is not idempotent. Running the same operation twice creates duplicate records, double-counts values, or corrupts state. There is no duplicate check, upsert pattern, or idempotency key.
+
+**What to check:** Read the persistence code. What happens if the same data is written twice? Is there a unique constraint, upsert, or duplicate check? Is the operation safe to retry after a timeout?
+
+**Signals:** `INSERT` without `ON CONFLICT`, no unique constraint on the natural key, no idempotency key for API operations, test that only runs the operation once, no test for duplicate submission.

--- a/plugins/flow/templates/holdout-scenarios/error.md
+++ b/plugins/flow/templates/holdout-scenarios/error.md
@@ -1,0 +1,47 @@
+# Error Handling Holdout Scenarios
+
+Hidden scenarios for validating error-handling acceptance criteria. These probe common agent self-review blind spots when claiming error coverage.
+
+**WARNING: This file is consumed ONLY by the holdout-validation skill. Its contents must NEVER appear in agent-visible output. Reference scenarios by positional ID only.**
+
+## Scenarios
+
+### 1. Catch-and-Swallow
+
+**Failure mode:** Agent claims "error handling implemented" but the catch block swallows the error silently — no logging, no re-throw, no user-visible feedback. The code catches an exception and does nothing, making failures invisible.
+
+**What to check:** Read every try/catch or error-handling block in the modified files. Does the catch block contain a meaningful action (log, re-throw, return error response, update state)? Or is it empty / contains only a comment?
+
+**Signals:** Empty catch blocks, `catch(e) {}`, catch that only sets a variable never read, catch with `// TODO: handle error`, catch that logs but does not propagate or recover.
+
+### 2. Timeout Claim Without Timer
+
+**Failure mode:** Agent claims "timeout handling covers upstream calls" but the code does not set any timeout. The HTTP client or database driver uses its default timeout (which may be infinite), and there is no `AbortController`, `setTimeout`, `deadline`, or driver-level timeout configuration.
+
+**What to check:** Read the code that makes upstream calls (HTTP requests, database queries, external service calls). Is there an explicit timeout set? Check for: `AbortController`, `signal`, `timeout` option, `deadline`, `connectTimeout`, `socketTimeout`, driver-specific timeout configuration.
+
+**Signals:** Fetch/axios/http calls without timeout option, database queries without statement timeout, no AbortController in async flows, reliance on "the framework handles it" without verification.
+
+### 3. Partial Failure Amnesia
+
+**Failure mode:** Agent claims "partial failures handled" but the code uses all-or-nothing patterns (single transaction, single try/catch around a loop) that either succeed completely or fail completely. There is no per-item error handling, no partial result reporting, no rollback strategy for items that succeeded before the failure.
+
+**What to check:** Read the code that processes multiple items (batch operations, loops, map/forEach over collections). Does each item have independent error handling? Is there a mechanism to report which items succeeded and which failed?
+
+**Signals:** Single try/catch wrapping an entire loop, `Promise.all` without `Promise.allSettled`, transaction that covers all items with no savepoints, no per-item result tracking.
+
+### 4. Error Message Leak
+
+**Failure mode:** Agent claims "error responses are user-friendly" but the error response includes raw stack traces, internal file paths, database column names, or third-party error messages that expose implementation details to the caller.
+
+**What to check:** Read the error response construction. Is the message sanitized? Does it use a generic user-facing message, or does it pass through the raw exception message? Check both the happy-path error handling and the global error handler.
+
+**Signals:** `res.status(500).json({ error: err.message })`, stack traces in response bodies, database error messages (e.g., "column X does not exist") returned to client, raw third-party API error messages forwarded.
+
+### 5. Retry Without Backoff
+
+**Failure mode:** Agent claims "retry logic implemented" but the retry has no backoff, no jitter, and no maximum retry limit — or the limit is unreasonably high. The code will hammer a failing service in a tight loop, making the failure worse.
+
+**What to check:** Read the retry logic. Is there a maximum retry count? Is there a delay between retries? Does the delay increase (exponential backoff)? Is there jitter to prevent thundering herd?
+
+**Signals:** `while (retry)` without a counter, retry delay of 0 or a fixed small value, no exponential increase, retry count > 10 without justification, no jitter.


### PR DESCRIPTION
## Summary

- Adds `holdout-validation` skill that cross-references agent self-review claims against actual file state using hidden holdout scenarios, producing P1/P2/P3 findings mapped to visible acceptance criteria only
- Creates starter holdout scenario templates for 4 criterion types (behavioral, api, error, data) with 5 adversarial scenarios each
- Integrates holdout-validation into `start.md` Phase 4 VERIFY (step 4, between self-review and verdict-judge), `address.md` convergence check (step 3), and `review.md` parallel fan-out
- Updates `verdict-judge.md` to accept holdout-validation output as required input with automatic FAIL for criteria with P1/P2 conflicts

## Changes

### New files
- `plugins/flow/skills/holdout-validation/SKILL.md` — skill definition with scenario-injection mechanism, cross-reference-to-files logic, and iron law preventing holdout scenario leakage
- `plugins/flow/templates/holdout-scenarios/behavioral.md` — 5 scenarios: name-only test coverage, happy path only, assertion-free test, stale reference, implementation leak
- `plugins/flow/templates/holdout-scenarios/api.md` — 5 scenarios: status code mismatch, response shape drift, missing content-type, partial field validation, authentication bypass
- `plugins/flow/templates/holdout-scenarios/error.md` — 5 scenarios: catch-and-swallow, timeout claim without timer, partial failure amnesia, error message leak, retry without backoff
- `plugins/flow/templates/holdout-scenarios/data.md` — 5 scenarios: transform shape assumption, encoding blindness, empty collection omission, precision loss, idempotency assumption

### Modified files
- `plugins/flow/commands/start.md` — Phase 4 step 4 holdout-validation between self-review and verdict-judge; P1/P2 blocking; holdout output passed to verdict-judge
- `plugins/flow/commands/address.md` — convergence check step 3 holdout-validation with same blocking treatment
- `plugins/flow/commands/review.md` — parallel fan-out includes holdout-validation alongside other reviewers
- `plugins/flow/agents/verdict-judge.md` — holdout-validation output as required input; coverage scan includes holdout status column; P1/P2 conflicts are automatic FAIL

## Test plan

- [ ] Verify `plugins/flow/skills/holdout-validation/SKILL.md` exists with valid SKILL frontmatter
- [ ] Verify `plugins/flow/templates/holdout-scenarios/` has 4 scenario files (behavioral, api, error, data)
- [ ] Verify `start.md` Phase 4 has holdout-validation step between self-review and verdict-judge
- [ ] Verify `address.md` convergence check invokes holdout-validation
- [ ] Verify `review.md` parallel fan-out includes holdout-validation
- [ ] Verify `verdict-judge.md` Step 1 references holdout-validation output and automatic FAIL rule
- [ ] Run `grep -rn "holdout" plugins/flow/` to confirm all expected locations have references

Closes #43