### PR TITLE
docs: add flow plugin team workshop materials

### DIFF
--- a/docs/flow-team-session/CHEATSHEET.md
+++ b/docs/flow-team-session/CHEATSHEET.md
@@ -63,7 +63,7 @@ Promote tiers (autonomous → journal → confirm). Never demote.
 ```
 PreToolUse  Bash    block-force-push   block-destructive   block-secrets
 PostToolUse Edit    log-file-changes
-PostToolUse Bash    log-commits        (idempotent since v2.0.1)
+PostToolUse Bash    log-commits        (idempotent — skips lines already auto-logged)
 TaskCompleted       verify-task-completion
 TeammateIdle        nudge-idle-teammate           (experimental)
 SessionEnd          session-end-learn             (experimental)
@@ -86,6 +86,8 @@ trace       Stranger   journal
 ```
 
 **Iron law**: NO SKIPPING PHASES. (`autonomous-workflow/SKILL.md` line 13)
+
+**Fix-forward** (REVIEW layer): the agent fixes P1/P2 findings inline during self-review rather than reporting them as work-for-the-reviewer. Bounded by `fixForwardMaxIterations` to prevent loops.
 
 ---
 
@@ -139,11 +141,11 @@ plugins/flow/settings.json     ←  plugin defaults
 .claude/settings.flow.local.json ← project local (gitignored)
 ```
 
-Strict defaults you might want to flip:
-- `testing.tddMode` (`enforce` → `suggest` if not yet ready)
-- `verdict.requireAllPass` (`true` → `false` if rolling out gradually)
+Strict defaults and why they're strict:
+- `testing.tddMode = enforce` — RED-GREEN-REFACTOR is observed before a task can complete (catches test-first violations at write-time). Flip to `suggest` if your team prefers test-after.
+- `verdict.requireAllPass = true` — every AC must PASS or the verdict is FAIL. Flip to `false` if rolling out gradually and willing to accept soft passes on `NEEDS-HUMAN-REVIEW`.
 
-To opt out fully: see `plugins/flow/README.md` lines 41–54.
+Opt-out template: `plugins/flow/README.md` lines 41–54.
 
 ---
 
@@ -155,6 +157,6 @@ To opt out fully: see `plugins/flow/README.md` lines 41–54.
 | Verdict FAIL feels wrong | Check evidence-bundle completeness subsections |
 | Hooks not firing | `~/.claude/logs/` |
 | Force push blocked | Use `--force-with-lease` (allowed + journaled) |
-| Auto-log loop | Confirm `plugin.json` shows `2.0.1` |
+| Auto-log loop | Restore `<!-- auto-log: ... -->` markers; `claude plugins update flow` |
 
 When in doubt: `/flow:status` first.

--- a/docs/flow-team-session/CHEATSHEET.md
+++ b/docs/flow-team-session/CHEATSHEET.md
@@ -11,7 +11,7 @@ One page. Pin to the wall. Detail in `HANDBOOK.md`.
 | `/flow:start <issue>` | Begin work — preflight, EXPLORE, PLAN with verification commands, branch + tasks |
 | `/flow:commit` | Atomic conventional commits with change classification |
 | `/flow:pr` | Push, parallel agent review, PR with comprehension report |
-| `/flow:review <pr>` | 5-facet review (or adversarial team if `agentTeams: true`) |
+| `/flow:review <pr>` | 6-facet parallel review (or adversarial team if `agentTeams: true`) |
 | `/flow:address <pr>` | Categorize comments, surgical fixes, re-request review |
 
 ## Tier 3 — always confirms

--- a/docs/flow-team-session/CHEATSHEET.md
+++ b/docs/flow-team-session/CHEATSHEET.md
@@ -1,0 +1,160 @@
+# Flow Cheatsheet
+
+One page. Pin to the wall. Detail in `HANDBOOK.md`.
+
+---
+
+## Daily five
+
+| Command | Use it for |
+|---------|-----------|
+| `/flow:start <issue>` | Begin work — preflight, EXPLORE, PLAN with verification commands, branch + tasks |
+| `/flow:commit` | Atomic conventional commits with change classification |
+| `/flow:pr` | Push, parallel agent review, PR with comprehension report |
+| `/flow:review <pr>` | 5-facet review (or adversarial team if `agentTeams: true`) |
+| `/flow:address <pr>` | Categorize comments, surgical fixes, re-request review |
+
+## Tier 3 — always confirms
+
+| Command | Notes |
+|---------|-------|
+| `/flow:merge <pr>` | Prerequisite check + AskUserQuestion. Hooks block force-push regardless. |
+| `/flow:release <type>` | Changelog from merged PRs + AskUserQuestion. |
+
+## Read-only / learning
+
+| Command | When |
+|---------|------|
+| `/flow:status` | Anywhere, anytime — view assigned issues, open PRs, journal health |
+| `/flow:explain` | "Why did we decide X?" — loads journal + diff |
+| `/flow:learn` | Quarterly — turn journal patterns into skill proposals |
+
+## Shape work first
+
+| Command | Before… |
+|---------|---------|
+| `/flow:issue` | …filing an issue (AC drafting + Spec Validation Gate) |
+| `/flow:brainstorm` | …choosing an approach |
+| `/flow:debug` | …chasing a bug you can't reproduce |
+| `/flow:design` | …a feature where architecture matters |
+
+## Bootstrap
+
+| Command | When |
+|---------|------|
+| `/flow:setup` | Once per repo |
+| `/flow:resolve` | Merge conflicts |
+| `/flow:flow` | Universal dispatcher (`/flow <verb> <target>`) |
+
+---
+
+## Three-tier safety
+
+| Tier | Examples | Behavior |
+|------|----------|----------|
+| **1 — Autonomous** | edits, commits, branches, tests, agent dispatch | Execute without asking |
+| **2 — Journal** | push, PR create, issue assign/create, PR comment | Execute + log to `.decisions/` |
+| **3 — Confirm** | merge, release, force-push, force branch-delete | Always ask. Non-negotiable. |
+
+Promote tiers (autonomous → journal → confirm). Never demote.
+
+## Hook layer (8 wired scripts)
+
+```
+PreToolUse  Bash    block-force-push   block-destructive   block-secrets
+PostToolUse Edit    log-file-changes
+PostToolUse Bash    log-commits        (idempotent since v2.0.1)
+TaskCompleted       verify-task-completion
+TeammateIdle        nudge-idle-teammate           (experimental)
+SessionEnd          session-end-learn             (experimental)
+```
+
+`gate-merge` / `gate-release` are NOT hook scripts — confirmation is in the command files via `AskUserQuestion`.
+
+---
+
+## EPCV — the loop
+
+```
+EXPLORE  →  PLAN  →  CODE  →  VERIFY
+context     tasks +    Per-Task    a. STATIC    (lint+test+typecheck+LSP)
+parallel    verif      Gate +      b. RUNTIME   (build, run, smoke test)
+reads       cmd per    TDD +       c. REVIEW    (self-review, fix-forward)
++LSP        AC +       commits +   d. VERDICT   (verdict-judge — independent)
+trace       Stranger   journal
+            Test
+```
+
+**Iron law**: NO SKIPPING PHASES. (`autonomous-workflow/SKILL.md` line 13)
+
+---
+
+## Verdict-judge — what it sees vs not
+
+| Sees | Does NOT see |
+|------|--------------|
+| Acceptance criteria | The diff |
+| Evidence bundle | Decision journal |
+| Holdout-validation output | Planning notes / approach rationale |
+| | Self-review findings |
+| | Memory from prior sessions |
+
+If the evidence doesn't prove the AC → FAIL. Even if the code is "obviously correct."
+
+## Per-criterion evidence — required subsections
+
+Every AC's evidence MUST include:
+1. **What was NOT tested** (never blank — write "none" if truly nothing)
+2. **Known limitations of this evidence**
+3. **Negative/adversarial cases covered**
+
+Missing any → criterion FAILs automatically.
+
+---
+
+## Six-field escalation
+
+Used for any human decision. Never "what should I do?"
+
+`Situation / What I tried / Options (label one Recommended) / My recommendation / Time sensitivity / Risk if wrong`
+
+## P1 / P2 / P3
+
+| Priority | Meaning | Action |
+|----------|---------|--------|
+| **P1** | Must fix — blocks merge, security, data loss, broken | Fix before proceeding |
+| **P2** | Should fix — logic bug, edge case, test gap | Fix in this PR |
+| **P3** | Consider — style, optimization, future improvement | Fix in-PR or six-field escalate |
+
+P3 is **not** a free pass.
+
+---
+
+## Settings cascade (lowest → highest priority)
+
+```
+plugins/flow/settings.json     ←  plugin defaults
+~/.claude/settings.flow.json   ←  user global
+.claude/settings.flow.json     ←  project shared (committed)
+.claude/settings.flow.local.json ← project local (gitignored)
+```
+
+Strict defaults you might want to flip:
+- `testing.tddMode` (`enforce` → `suggest` if not yet ready)
+- `verdict.requireAllPass` (`true` → `false` if rolling out gradually)
+
+To opt out fully: see `plugins/flow/README.md` lines 41–54.
+
+---
+
+## When something breaks
+
+| Symptom | First place |
+|---------|------------|
+| Plan blocked | `.decisions/issue-N.md` — search "Stranger Test" |
+| Verdict FAIL feels wrong | Check evidence-bundle completeness subsections |
+| Hooks not firing | `~/.claude/logs/` |
+| Force push blocked | Use `--force-with-lease` (allowed + journaled) |
+| Auto-log loop | Confirm `plugin.json` shows `2.0.1` |
+
+When in doubt: `/flow:status` first.

--- a/docs/flow-team-session/CONVENTIONS-DECIDED.md
+++ b/docs/flow-team-session/CONVENTIONS-DECIDED.md
@@ -1,0 +1,69 @@
+# Conventions Decided
+
+**Status**: TEMPLATE — fill in during the session, then commit.
+
+**Session date**: ____
+**Facilitator**: ____
+**Attendees** (engineering / PM / design): ____
+
+This is the source of truth for the team's flow plugin overrides. Settings decisions land in `.claude/settings.flow.json` (committed). Policy decisions stay here — the plugin doesn't enforce them, humans do.
+
+---
+
+## Settings decisions
+
+| # | Setting | Value | Notes |
+|---|---------|-------|-------|
+| 1 | `testing.tddMode` | _____ | |
+| 2 | `verdict.requireAllPass` | _____ | |
+| 3 | `agentTeams` | _____ | |
+| 4 | `conventions.branchPatterns` | _____ | |
+| 5 | `conventions.commitTypes` | _____ | |
+| 6 | `journal.sensitivityDefault` | _____ | |
+| 7 | `tiers` | _____ | |
+| 8 | `specFirst.allowSpecFreeLabels` | _____ | |
+
+If any value differs from `plugins/flow/settings.json` defaults, file a follow-up PR adding the override to `.claude/settings.flow.json` (committed) within one week.
+
+---
+
+## Policy decisions
+
+### 9. Reviewer routing
+
+**Approach**: ____
+
+**Owner**: ____
+
+**Examples / clarifications**:
+
+- ____
+
+### 10. Learning-loop cadence
+
+**Owner of `/flow:learn` runs**: ____
+
+**Cadence**: ____ (e.g. monthly, post-project-ship, after every 10 issues)
+
+**Proposal triage**: who reviews `~/.claude/flow-proposals/` and decides what gets promoted to `plugins/flow/skills/learned/`? ____
+
+### 11. P3 disagreement (if surfaced)
+
+**Approach**: ____
+
+---
+
+## Revisit dates
+
+| Decision | Revisit by | Trigger |
+|----------|-----------|---------|
+| ____ | ____ | ____ |
+
+---
+
+## Sign-off
+
+By committing this file, attendees confirm: these are the conventions our team will follow until the next revisit date. Disagreements get filed as issues, not silently ignored.
+
+**Committed by**: ____
+**Date**: ____

--- a/docs/flow-team-session/CONVENTIONS-WORKSHEET.md
+++ b/docs/flow-team-session/CONVENTIONS-WORKSHEET.md
@@ -1,0 +1,42 @@
+# Conventions Worksheet (live during session)
+
+Project this on screen during section 6. **Don't advance past a row until it has an answer** — even if the answer is "default, revisit in 30 days."
+
+After the session, copy decisions into `CONVENTIONS-DECIDED.md` and open a follow-up PR for `.claude/settings.flow.json` if any non-default values were chosen.
+
+Defaults are pulled from `plugins/flow/settings.json`.
+
+---
+
+| # | Decision | Default | Options | Lands in | Decision |
+|---|----------|---------|---------|----------|----------|
+| 1 | TDD mode | `enforce` | `enforce` / `suggest` | `settings.flow.json` → `testing.tddMode` | ☐ default ☐ change to: ____ |
+| 2 | Verdict requires all pass | `true` | `true` / `false` | `settings.flow.json` → `verdict.requireAllPass` | ☐ default ☐ change to: ____ |
+| 3 | Agent teams (adversarial review) | `false` | `false` / `true` (+ env `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`) | `settings.flow.json` → `agentTeams` | ☐ default ☐ change to: ____ |
+| 4 | Branch naming patterns | `feature/issue-{N}-{desc}`, `fix/issue-{N}-{desc}`, `docs/issue-{N}-{desc}` | keep / adjust prefixes / add categories | `settings.flow.json` → `conventions.branchPatterns` | ☐ default ☐ change to: ____ |
+| 5 | Commit type vocabulary | 12 types: `feat, fix, docs, style, refactor, test, chore, perf, ci, build, revert, improve` | keep / drop unused / add | `settings.flow.json` → `conventions.commitTypes` | ☐ default ☐ change to: ____ |
+| 6 | Journal sensitivity default | `public` | `public` / `internal` | `settings.flow.json` → `journal.sensitivityDefault` | ☐ default ☐ change to: ____ |
+| 7 | Tier overrides | push=journal, prCreate=journal, issueAssign=journal, issueCreate=journal, merge=confirm, release=confirm | keep / promote any to `confirm` (cannot demote) | `settings.flow.json` → `tiers` | ☐ default ☐ change to: ____ |
+| 8 | Spec-free label list | `["documentation", "chore"]` | keep / add labels / remove | `settings.flow.json` → `specFirst.allowSpecFreeLabels` | ☐ default ☐ change to: ____ |
+| 9 | Reviewer routing (policy) | n/a | round-robin / by area / by author preference / least-recently-reviewed | `CONVENTIONS-DECIDED.md` (policy) | choice: ____ |
+| 10 | Learning-loop cadence (policy) | n/a | owner of `/flow:learn` + cadence + proposal triage | `CONVENTIONS-DECIDED.md` (policy) | owner: ____ cadence: ____ |
+
+---
+
+## Implicit 11th decision (surface if energy allows)
+
+How do we handle disagreement on a P3?
+
+**Recommended answer**: anyone can rewrite a P3 as a six-field escalation in the PR; reviewer accepts/rejects.
+
+☐ adopt recommendation ☐ alternative: ____
+
+---
+
+## Forcing function
+
+The facilitator does not advance to the next decision until the current row has a checkbox marked.
+
+90 seconds per row. Section 6 is 15 minutes — that's 90 seconds × 10 rows = 15 min, exactly. No buffer. Section 6 is a vote, not a debate.
+
+If a decision genuinely needs more discussion: pick the default, mark "revisit in 30 days," move on. Don't burn the whole session on one row.

--- a/docs/flow-team-session/HANDBOOK.md
+++ b/docs/flow-team-session/HANDBOOK.md
@@ -234,7 +234,7 @@ The verdict-judge is structurally different: it's the only agent whose value dep
 
 22 named skills + a `learned/` directory (promotion area for proposals from `/flow:learn`). Source: `plugins/flow/skills/*/SKILL.md`.
 
-### Foundation (always loaded, ≤100 lines each)
+### Foundation (always loaded; smaller and stable)
 
 | Skill | What it enforces |
 |-------|------------------|
@@ -384,7 +384,7 @@ The full schema is in `plugins/flow/schema.json`. Defaults are in `plugins/flow/
 
 ## 12. Migrating from gh-workflow
 
-The `gh-workflow` plugin (v1.7.0) is the predecessor. Comparison from `plugins/flow/README.md` lines 222–230:
+The `gh-workflow` plugin (v1.7.0) is the predecessor. Comparison from `plugins/flow/README.md` lines 223–230:
 
 | Aspect | gh-workflow | flow |
 |--------|------------|------|
@@ -400,7 +400,7 @@ The `gh-workflow` plugin (v1.7.0) is the predecessor. Comparison from `plugins/f
 1. The two plugins coexist at the marketplace level. `/flow:setup` warns if both are installed.
 2. Commit-message vocabulary, branch patterns, and reviewer routing carry over — those are decisions, not implementations.
 3. `/gh-start` ↔ `/flow:start`, `/gh-commit` ↔ `/flow:commit`, `/gh-pr` ↔ `/flow:pr`, etc. The verbs are the same; the autonomy is different.
-4. If you preferred gh-workflow's interactive style, set `tddMode: suggest`, `verdict.requireAllPass: false`, and promote more tiers to `confirm`. Strict defaults can be opted out of (`README.md` lines 41–54).
+4. If you preferred gh-workflow's interactive style, set `tddMode: suggest`, `verdict.requireAllPass: false`, and promote more tiers to `confirm`. Strict defaults can be opted out of (`README.md` lines 40–56).
 
 ---
 

--- a/docs/flow-team-session/HANDBOOK.md
+++ b/docs/flow-team-session/HANDBOOK.md
@@ -1,0 +1,439 @@
+# Flow Plugin Handbook
+
+Long-form reference for the team. The slide deck (`slides.md`) is the room-facing view; this handbook is what you read when something doesn't make sense afterwards.
+
+**Plugin version**: 2.0.1 (`plugins/flow/.claude-plugin/plugin.json`)
+**Source of truth**: `plugins/flow/` in this repo. When this handbook and the source disagree, the source wins — file an issue.
+
+## Table of contents
+
+1. The 6 Excellence Principles
+2. The two skeletons — three-tier safety + Explore-Plan-Code-Verify
+3. Vocabulary — skills vs agents vs commands
+4. Commands (17) — what each does
+5. Agents (8) — what each is for
+6. Skills (22 + `learned/`) — knowledge units
+7. Hooks — what's actually wired
+8. Decision journal — the audit trail
+9. Holdout validation and the verdict-judge
+10. Configuration cascade
+11. Failure modes and where to look
+12. Migrating from gh-workflow
+
+---
+
+## 1. The 6 Excellence Principles
+
+Flow v2.0 enforces six principles. They are the answer to "why does this plugin block me?". Source: `plugins/flow/README.md` lines 5–66.
+
+### 1. Stranger Test
+
+Every plan must be executable by someone with zero prior context. If an instruction requires unstated assumptions or "you know what I mean" reasoning, it fails the Stranger Test and the PLAN phase blocks until rewritten.
+
+**Failure mode it prevents**: implementer joins the PR mid-cycle, can't tell what "fix the auth thing" means, makes the wrong fix.
+
+### 2. Spec-as-Eval-Suite
+
+Acceptance criteria are not documentation — they are the eval suite. Each criterion must have a concrete, automated verification command defined **before the PLAN phase begins**. Vague criteria like "works correctly" are rejected by the Spec Validation Gate.
+
+**Failure mode it prevents**: tests pass, criteria are never actually verified, the PR ships and breaks production.
+
+> **Iron Law** (`plugins/flow/skills/criterion-verification-map/SKILL.md` line 15):
+> "EVERY ACCEPTANCE CRITERION IS AN EVAL SOURCE. At plan time, each criterion must produce a runnable verification command. No criterion is deferred to verify time with 'we'll figure out how to test this later.' No criterion passes by assumption. No criterion is 'too obvious to verify.'"
+
+### 3. Proactive Autonomy
+
+Agents resolve ambiguity themselves first. When escalation is unavoidable, it follows a structured **six-field format**. Anti-patterns like "what should I do?" are blocked.
+
+The six fields (`autonomous-workflow/SKILL.md` lines 162–173):
+
+| Field | Purpose |
+|-------|---------|
+| **Situation** | What happened — the specific state or finding that requires a decision |
+| **What I tried** | What you attempted before escalating — research, alternatives considered, commands run |
+| **Options** | 2-3 concrete paths forward, each with trade-offs. Label one "(Recommended)" |
+| **My recommendation** | Which option you recommend and why — never leave this blank |
+| **Time sensitivity** | Is this blocking? Urgent? Safe to defer? |
+| **Risk if wrong** | What happens if the chosen option turns out to be the wrong call, and who is affected |
+
+**Failure mode it prevents**: agent dumps an open-ended question into a PM's inbox at 11pm on a Friday with no recommendation.
+
+### 4. Quality > Speed
+
+TDD mode defaults to `enforce`. The verdict judge requires all acceptance criteria to pass. P3 findings are no longer deferrable.
+
+| Setting | Old Default | New Default |
+|---------|-------------|-------------|
+| `testing.tddMode` | `"suggest"` | `"enforce"` |
+| `verdict.requireAllPass` | `false` | `true` |
+
+(`plugins/flow/README.md` lines 35–39)
+
+**Failure mode it prevents**: "tests pass" treated as proof of correctness when only the happy path was tested.
+
+### 5. No Lazy Verification
+
+Evidence bundles must include three completeness subsections per criterion (`criterion-verification-map/SKILL.md` lines 89–106):
+
+- **What was NOT tested** — explicit list of related behaviors not covered
+- **Known limitations of this evidence** — how the evidence could be misleading even though it looks positive
+- **Negative/adversarial cases covered** — specific failure modes the system rejects
+
+The verdict-judge treats any criterion missing these subsections as having incomplete evidence and FAILs it.
+
+**Failure mode it prevents**: "test added" claim that turns out to be testing a stub, not the real behavior.
+
+### 6. No Incomplete Shipments
+
+Pre-existing findings in touched files keep their natural priority (no longer capped at P3). The finding-ledger merge gate blocks merges when `FLOW_RESOLUTION_CYCLE` markers contain unresolved or escalated items. **"DEFERRED" markers have been renamed to "ESCALATED"** to signal that deferral is not an option (`plugins/flow/CHANGELOG.md` v2.0.0).
+
+**Failure mode it prevents**: P3 backlog that grows forever and nothing ever gets fixed.
+
+---
+
+## 2. The two skeletons
+
+Two structures hold the plugin together. Learn these and the rest follows.
+
+### 2a. Three-tier safety
+
+Source: `plugins/flow/references/three-tier-safety.md`.
+
+| Tier | What | Behavior | Examples |
+|------|------|----------|----------|
+| **1 — Autonomous** | Local, reversible | Execute without asking | File edits, commits, branch creation, staging, running tests, agent dispatch |
+| **2 — Journal** | Team-visible, recoverable | Execute and log to decision journal | Push, PR creation, issue assignment, issue creation, PR comment |
+| **3 — Confirm** | Hard to reverse, high-impact | Always require human confirmation | PR merge, release creation, force push, branch force-deletion |
+
+**Promotion rule**: actions can be promoted (autonomous → journal → confirm) but never demoted. Safety is never accidentally reduced.
+
+**Hook enforcement at the Bash layer**:
+
+| Hook | Action | Behavior |
+|------|--------|----------|
+| `block-force-push.sh` | `git push --force` | Exit 2 (block) |
+| `block-destructive.sh` | `rm -rf`, `git reset --hard` | Exit 2 (block) |
+| `block-secrets.sh` | Inline credentials | Exit 2 (block) |
+
+**Important**: merge and release confirmation is handled at the **command level** via AskUserQuestion (see `/flow:merge` and `/flow:release`), not by a `gate-merge` or `gate-release` hook script (`three-tier-safety.md` line 80). The README mentions those names — they are not wired. The eight wired hook scripts are listed in §7.
+
+### 2b. Explore-Plan-Code-Verify (EPCV)
+
+Source: `plugins/flow/skills/autonomous-workflow/SKILL.md`.
+
+> **Iron Law** (line 13): "NO SKIPPING PHASES. Explore before Plan, Plan before Code, Code before Verify. Every phase produces an artifact."
+
+| Phase | What | Output |
+|-------|------|--------|
+| **EXPLORE** | Gather context. Parallel reads, agent dispatch, capability discovery, LSP tracing. | Context inventory |
+| **PLAN** | Decompose work. TaskCreate per deliverable. Verification command attached to each criterion. Stranger Test gate. | Task list with criteria |
+| **CODE** | Execute tasks. TaskUpdate(in_progress) → implement → commit → TaskUpdate(completed) only after Per-Task Verification Gate. | Working code, journal entries |
+| **VERIFY** | Four mandatory layers (below). | Evidence bundle, verdict |
+
+**The four VERIFY layers** (`autonomous-workflow/SKILL.md` lines 24–28):
+
+| Layer | What | Tool |
+|-------|------|------|
+| **a. Static** | Lint, test, typecheck in parallel + LSP diagnostics if available | `Skill(test-runner)` agent + LSP |
+| **b. Runtime** | Build the project, start it, verify at runtime. Debug-fix-retest loop bounded by `closedLoop.maxDebugIterations`. | `runtime-verification` skill |
+| **c. Review** | Self-review with **fix-forward** — fix P1/P2 findings immediately, don't just report them | `code-review-methodology` skill |
+| **d. Verdict** | Independent judgment. Acceptance criteria + evidence bundle → verdict-judge agent → PASS/FAIL/NEEDS-HUMAN-REVIEW. Judge has no access to diff or journal. | `verdict-judge` agent |
+
+**Per-Task Verification Gate** (`autonomous-workflow/SKILL.md` lines 44–59): a task may NOT be marked completed until ALL of: tests pass, verification evidence captured, no out-of-context files, TDD cycle observed when `tddMode: enforce`. This is the primary quality enforcement point — VERIFY is independent confirmation, not first-pass verification.
+
+---
+
+## 3. Vocabulary — skills vs agents vs commands
+
+If you only remember three definitions, remember these.
+
+| Concept | What it is | Plural noun for | Example |
+|---------|-----------|-----------------|---------|
+| **Command** | An entry point — a `/flow:*` invocation that drives a workflow phase | "things you type" | `/flow:start 42` |
+| **Agent** | A subagent dispatched by a command, with its own context and a narrow tool budget | "specialists you hire" | `verdict-judge` |
+| **Skill** | A reusable knowledge unit loaded into the active context, applied autonomously | "playbooks Claude reads" | `criterion-verification-map` |
+
+The same knowledge lives in different containers depending on how it's reused:
+
+- A **command** runs once per workflow step and re-reads itself each session.
+- An **agent** runs in a forked context with isolated tools — useful for independent judgment (verdict-judge sees no diff) or parallel review.
+- A **skill** is invoked from anywhere — commands, other skills, agents — and contributes its iron laws + protocols to whatever workflow needs them.
+
+A skill becoming popular enough across commands → it's the right shape. A command duplicating logic from another command → that logic should be a skill.
+
+---
+
+## 4. Commands (17)
+
+Daily five (you'll use these every day):
+
+| Command | Purpose |
+|---------|---------|
+| `/flow:start <issue>` | Assign issue, create branch, decompose tasks, implement |
+| `/flow:commit` | Classify changes, flag anomalies, create atomic commits |
+| `/flow:pr` | Full review pipeline + PR creation |
+| `/flow:review <pr>` | Multi-faceted code review (single or team) |
+| `/flow:address <pr>` | Systematic feedback resolution |
+
+Tier 3 (confirmation required):
+
+| Command | Purpose |
+|---------|---------|
+| `/flow:merge <pr>` | Merge with prerequisite verification — never autonomous |
+| `/flow:release <type>` | Changelog + semantic version release — never autonomous |
+
+Supporting three (read-only or learning):
+
+| Command | Purpose |
+|---------|---------|
+| `/flow:status` | Read-only workflow overview |
+| `/flow:explain` | Interactive Q&A about decisions on the current branch/issue |
+| `/flow:learn` | Analyze the decision journal for patterns; generate skill proposals |
+
+Entry-point variants (shape work before implementation):
+
+| Command | Purpose |
+|---------|---------|
+| `/flow:issue [topic]` | Create well-crafted GitHub issues with duplicate detection and verifiable acceptance criteria |
+| `/flow:brainstorm [topic]` | Explore approaches, generate options, analyze trade-offs |
+| `/flow:debug [error]` | Structured debugging with root cause analysis |
+| `/flow:design [feature]` | Architecture discussion and design validation |
+
+Rare / bootstrap:
+
+| Command | Purpose |
+|---------|---------|
+| `/flow:setup` | Initialize flow for a repository — detect tech stack, generate settings, configure LSP |
+| `/flow:resolve` | Resolve merge conflicts on a branch or PR |
+| `/flow:flow` | Universal dispatcher — `/flow <verb> <target>` |
+
+**Command-level tier-3 prompts**: `/flow:merge` and `/flow:release` invoke `AskUserQuestion` for confirmation. There is no `gate-merge` or `gate-release` hook — the structural gate is in the command file itself plus the Bash hooks for the underlying dangerous operations.
+
+---
+
+## 5. Agents (8)
+
+Each agent is a forked context with its own tool budget. Source: `plugins/flow/agents/*.md`.
+
+| Agent | What it does |
+|-------|-------------|
+| **implementation-planner** | Parse acceptance criteria, decompose into tasks with dependencies, identify parallel work |
+| **test-runner** | Discover and run lint/test/typecheck commands, return structured pass/fail |
+| **code-reviewer** | Quality + correctness review, P1/P2/P3 findings with file:line citations |
+| **convention-checker** | Git convention validation — commit messages, branch naming, PR format |
+| **security-reviewer** | OWASP-style review — secrets, auth/authz, input validation, dependency vulnerabilities |
+| **error-handler-inspector** | Unhandled errors, missing edge cases, silent failures, exception gaps |
+| **integration-verifier** | End-to-end functionality — dev server startup, smoke tests, AC validation at runtime |
+| **verdict-judge** | Independent acceptance-criteria evaluation. **Receives only ACs + evidence bundle + holdout output. No diff, no journal, no rationale.** |
+
+The verdict-judge is structurally different: it's the only agent whose value depends on what it does NOT see. See §9.
+
+---
+
+## 6. Skills (22 + `learned/`)
+
+22 named skills + a `learned/` directory (promotion area for proposals from `/flow:learn`). Source: `plugins/flow/skills/*/SKILL.md`.
+
+### Foundation (always loaded, ≤100 lines each)
+
+| Skill | What it enforces |
+|-------|------------------|
+| **evidence-based-development** | "Evidence before claims, always." File:line citations required. ASSERTION/EVIDENCE/VERIFIED pattern. P1/P2/P3 priority system. |
+| **autonomous-workflow** | EPCV iron law, three-tier classification, six-field escalation template, per-task verification gate. |
+| **code-quality-principles** | Boy Scout Rule, secret-free commits, anti-pattern detection, prohibition of mocks/stubs/TODOs in production code. |
+
+### Domain (contextually invoked, max 3 concurrent)
+
+| Skill | When it activates |
+|-------|------------------|
+| **issue-crafting** | Creating GitHub issues — solution-agnostic requirements, duplicate detection, verifiable AC |
+| **branch-and-task-management** | Starting work — branch naming, issue context loading, AC decomposition |
+| **change-classification** | Preparing commits — in-context vs out-of-context vs uncertain, first-touch flagging |
+| **convention-enforcement** | Commits/PRs — detect project rules from CLAUDE.md and settings, validate compliance |
+| **capability-discovery** | Start of any workflow — detect agents, quality commands, tech stack, LSP availability |
+| **code-review-methodology** | Code review — 2-stage review (spec compliance, then quality), P1/P2/P3 synthesis, deduplication by file:line |
+| **criterion-verification-map** | Plan time — classify each AC, produce verification command + evidence shape + does-NOT-promise. Verify time — assemble evidence bundle |
+| **pr-lifecycle** | Creating PRs — pre-flight, body generation, reviewer suggestion, comprehension narrative |
+| **preflight-checks** | Pure-bash validation — clean git, gh auth, issue exists, remote reachable. No LLM calls |
+| **feedback-resolution** | Addressing review comments — categorize, surgical fixes, ambiguity handling, re-review request |
+| **holdout-validation** | Cross-reference self-review claims against actual file state using hidden scenarios |
+| **merge-and-release** | Tier 3 operations — prerequisite verification, semantic versioning, changelog generation |
+| **merge-conflict-resolution** | Resolving conflicts — detection, classification, per-file strategy, post-resolution verification |
+| **runtime-verification** | After static checks — dev server startup, API smoke tests, E2E, browser checks, LSP diagnostics |
+| **team-coordination** | Adversarial review (when `agentTeams: true`) — independent analysis before shared conclusions |
+| **architecture-patterns** | System design — design-from-functionality, coupling analysis, C4 thinking |
+| **brainstorming** | Approach exploration — option generation, trade-off analysis, collaborative selection |
+| **debugging-patterns** | Any verification failure — structured log analysis, hypothesis testing, fix validation. Activates on test/build/server failures, not just `bug` label |
+| **tdd-patterns** | Implementation — Red-Green-Refactor cycle, test quality, runner discipline. Enforced when `tddMode: enforce` |
+| **`learned/`** | Promotion area for `/flow:learn` proposals. Empty until a human reviews and promotes. |
+
+---
+
+## 7. Hooks — what's actually wired
+
+Source of truth: `plugins/flow/hooks/hooks.json`.
+
+| Trigger | Matcher | Script | What it does |
+|---------|---------|--------|--------------|
+| PreToolUse | Bash | `block-force-push.sh` | Exit 2 on `git push --force` (`--force-with-lease` allowed, journaled) |
+| PreToolUse | Bash | `block-destructive.sh` | Exit 2 on `rm -rf`, `git reset --hard`, etc. |
+| PreToolUse | Bash | `block-secrets.sh` | Exit 2 on inline credentials |
+| PostToolUse | Edit\|Write | `log-file-changes.sh` | Append `<!-- auto-log: ... -->` entry to journal |
+| PostToolUse | Bash | `log-commits.sh` | Append commit auto-log entry. Idempotency guards added in v2.0.1 (`CHANGELOG.md`) prevent the auto-log infinite loop |
+| TaskCompleted | (any) | `verify-task-completion.sh` | Per-Task Verification Gate enforcement |
+| TeammateIdle | (any) | `nudge-idle-teammate.sh` | Experimental — used with agent teams |
+| SessionEnd | (any) | `session-end-learn.sh` | Experimental — feeds the learning loop |
+
+That's eight scripts. The README mentions `gate-merge` and `gate-release` — those are not wired and don't exist as scripts. Merge/release confirmation is in the **command** files via AskUserQuestion.
+
+---
+
+## 8. Decision journal — the audit trail
+
+Source: `plugins/flow/references/decision-journal-schema.md`.
+
+**Default location**: `.decisions/` (configurable via `journal.dir`).
+
+**Two entry kinds**:
+
+1. **Auto-log entries** (HTML comments, written by hooks):
+   ```
+   <!-- auto-log: 2026-05-05 14:32 Edit /path/to/file -->
+   <!-- auto-log: 2026-05-05 14:35 commit "feat: add --json flag to sync" -->
+   ```
+2. **Structured entries** (Markdown, written by skills):
+   ```markdown
+   ### [Implementation] Title
+
+   **Timestamp**: 2026-05-05 14:40
+   **Sensitivity**: public
+
+   **Decision**: What was decided.
+   **Reasoning**: Why this approach.
+   **Alternatives considered**: …
+   **Evidence**: links/output/files.
+   ```
+
+**Sensitivity**: `public` (default) goes into PR bodies; `internal` is redacted.
+
+**Categories**: `Architecture`, `Implementation`, `Convention`, `Quality`, `Risk`.
+
+The journal is the input to `/flow:learn` and to `/flow:explain`. If the journal disappears, those features lose their substrate.
+
+---
+
+## 9. Holdout validation and the verdict-judge
+
+The two independence mechanisms.
+
+### Holdout validation
+
+The `holdout-validation` skill maintains hidden scenarios that the executing agent never sees. After self-review, it cross-references the agent's claims against actual file state. "I added a test for X" without a test that actually tests X is a P1.
+
+### Verdict-judge
+
+The verdict-judge agent receives **only**:
+
+1. Acceptance criteria (from the issue).
+2. Evidence bundle (verification commands + outputs + completeness subsections).
+3. Holdout-validation output.
+
+It does NOT see:
+
+- The diff (no code changes)
+- The decision journal (no rationale)
+- Planning notes (no approach choices)
+- Self-review findings from the code-writing agent
+- Project memory from previous sessions
+
+(Source: `plugins/flow/agents/verdict-judge.md`.)
+
+This separation is the answer to "but how does the agent know if it's right?" — by deliberately limiting what the judge sees, FAIL/PASS becomes a function of evidence alone, not of self-told stories. If the evidence doesn't prove the criterion, FAIL — even if the code is "obviously correct."
+
+**Step 1 (mandatory)**: missing-criterion scan. Before evaluating any criterion on its merits, the judge checks every AC has evidence. A bundle with three of four ACs covered fails fast — you can't pass on partial coverage.
+
+---
+
+## 10. Configuration cascade
+
+Settings cascade in priority order (later overrides earlier):
+
+1. `plugins/flow/settings.json` — plugin defaults
+2. `~/.claude/settings.flow.json` — user global
+3. `.claude/settings.flow.json` — project shared (committed)
+4. `.claude/settings.flow.local.json` — project local (gitignored)
+
+The full schema is in `plugins/flow/schema.json`. Defaults are in `plugins/flow/settings.json`. The 10 conventions decided in the workshop land here — see `CONVENTIONS-WORKSHEET.md` for the mapping.
+
+---
+
+## 11. Failure modes and where to look
+
+| Symptom | Look here |
+|---------|-----------|
+| "Why did the plan get blocked?" | `.decisions/issue-N.md` for the most recent entry. Search for "Stranger Test" or "Spec Validation Gate." |
+| "The verdict is FAIL but the code works" | `criterion-verification-map/SKILL.md` — check completeness subsections in the evidence bundle. Missing one = automatic FAIL. |
+| "Hooks aren't firing" | `plugins/flow/hooks/hooks.json` — confirm matcher and trigger. Check `~/.claude/logs/` for hook stderr. |
+| "Auto-log is duplicating commits" | Was supposed to be fixed in v2.0.1. Confirm `plugin.json` shows `"version": "2.0.1"`. If you see it on 2.0.0 or earlier, upgrade. |
+| "/flow:learn isn't proposing skills" | `~/.claude/flow-proposals/` for proposals; ensure `learning.enabled: true` and `journal.dir` is populated. |
+| "Agent teams not spawning" | Both `agentTeams: true` AND `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` env var must be set. |
+| "Tier 3 prompt isn't appearing" | Check `tiers.merge` and `tiers.release` in your settings cascade. Promoted to `confirm` is the default. |
+| "Force push got blocked but I needed it" | Use `--force-with-lease` instead — explicitly allowed and journaled (`three-tier-safety.md` line 41). |
+
+---
+
+## 12. Migrating from gh-workflow
+
+The `gh-workflow` plugin (v1.7.0) is the predecessor. Comparison from `plugins/flow/README.md` lines 222–230:
+
+| Aspect | gh-workflow | flow |
+|--------|------------|------|
+| Paradigm | Command-driven | Skill-driven |
+| Interaction | ~40 decision points | Autonomous with journal |
+| Learning | None across sessions | Decision journal + skill proposals |
+| Review | Sequential agents | Parallel + adversarial (team option) |
+| Safety | Interactive gates | Hook-enforced tiers |
+| Knowledge | Locked in commands | Composable, reusable skills |
+
+**Practical migration**:
+
+1. The two plugins coexist at the marketplace level. `/flow:setup` warns if both are installed.
+2. Commit-message vocabulary, branch patterns, and reviewer routing carry over — those are decisions, not implementations.
+3. `/gh-start` ↔ `/flow:start`, `/gh-commit` ↔ `/flow:commit`, `/gh-pr` ↔ `/flow:pr`, etc. The verbs are the same; the autonomy is different.
+4. If you preferred gh-workflow's interactive style, set `tddMode: suggest`, `verdict.requireAllPass: false`, and promote more tiers to `confirm`. Strict defaults can be opted out of (`README.md` lines 41–54).
+
+---
+
+## Appendix — file paths quick reference
+
+```
+plugins/flow/
+├── README.md                                   ← Excellence Principles + skill tree
+├── CHANGELOG.md                                ← v2.0 breaking changes, v2.0.1 fix
+├── settings.json                               ← all defaults
+├── schema.json                                 ← full config schema
+├── .claude-plugin/plugin.json                  ← version
+├── agents/{8}.md                               ← one file per agent
+├── commands/{17}.md                            ← one file per command
+├── skills/{22}/SKILL.md + learned/             ← knowledge units
+├── references/
+│   ├── three-tier-safety.md
+│   ├── decision-journal-schema.md
+│   ├── classification-signals.md
+│   ├── code-review-checklist.md
+│   ├── gate-configuration.md
+│   ├── skill-manifests.md
+│   └── test-review-checklist.md
+├── templates/
+│   ├── issue-body.md
+│   ├── pr-body.md
+│   ├── self-review-comment.md
+│   ├── review-comment.md
+│   ├── resolution-comment.md
+│   ├── skill-proposal.md
+│   ├── CLAUDE-flow.md
+│   └── holdout-scenarios/
+└── hooks/
+    ├── hooks.json
+    └── scripts/{8}.sh
+```

--- a/docs/flow-team-session/HANDBOOK.md
+++ b/docs/flow-team-session/HANDBOOK.md
@@ -17,7 +17,9 @@ Long-form reference for the team. The slide deck (`slides.md`) is the room-facin
 9. Holdout validation and the verdict-judge
 10. Configuration cascade
 11. Failure modes and where to look
-12. Migrating from gh-workflow
+
+Appendix A — Coming from `gh-workflow`?
+Appendix B — File paths quick reference
 
 ---
 
@@ -129,6 +131,13 @@ Source: `plugins/flow/skills/autonomous-workflow/SKILL.md`.
 | **CODE** | Execute tasks. TaskUpdate(in_progress) → implement → commit → TaskUpdate(completed) only after Per-Task Verification Gate. | Working code, journal entries |
 | **VERIFY** | Four mandatory layers (below). | Evidence bundle, verdict |
 
+**What each phase leaves behind** (concrete artifacts a reader can open):
+
+- **EXPLORE → Artifact**: a populated `.decisions/issue-N.md` with a `## Specification` heading (non-goals, failure modes, interface contracts) and the Spec Validation Gate result mapping each AC to its runnable verification command. Source: `commands/start.md` lines 122–126, 229.
+- **PLAN → Artifact**: an atomic TaskList where each task bundles implementation + test + verification command + expected evidence shape; a feature branch off the default branch; the Stranger Test result recorded in the journal under `## Stranger Test` as PASS or BLOCK. Source: `commands/start.md` lines 232–269; `criterion-verification-map/SKILL.md` lines 43–55.
+- **CODE → Artifact**: per-task commits, each containing implementation + test + the verification evidence captured at task-completion time (not deferred); `<!-- auto-log: ... -->` entries in the journal for every Edit/Write and commit; the Per-Task Verification Gate satisfied for each task. Source: `autonomous-workflow/SKILL.md` lines 23, 44–59.
+- **VERIFY → Artifact**: an evidence bundle (one block per AC with `Does NOT promise` + the three completeness subsections), the holdout-validation output, and the verdict-judge agent's PASS/FAIL/NEEDS-HUMAN-REVIEW per criterion — fed only the evidence bundle + ACs + holdout output. Source: `criterion-verification-map/SKILL.md` lines 68–106, 137–139; `autonomous-workflow/SKILL.md` lines 24–28.
+
 **The four VERIFY layers** (`autonomous-workflow/SKILL.md` lines 24–28):
 
 | Layer | What | Tool |
@@ -225,15 +234,18 @@ Rare / bootstrap:
 
 Three commands dispatch a parallel review fan-out. Knowing which agents run where is useful when reading PR-body findings tables and re-review comments.
 
-A note on counting: `code-review-methodology` describes a **5-facet methodology** (quality, security, conventions, tests, requirements) — that's the conceptual review frame. The **fan-out below dispatches more than five agents in parallel** because `holdout-validation` runs alongside the five methodology facets to cross-reference self-review claims against file state. So "5-facet methodology" and "6-agent parallel dispatch" are both correct — they describe different things.
+`/flow:pr` Phase 3 dispatches six review facets in parallel: `code-reviewer`, `convention-checker`, `test-runner`, `security-reviewer`, `error-handler-inspector`, and `holdout-validation`. The same six run in `/flow:review` Path B; `/flow:address` Phase 4 drops `security-reviewer` (re-review of fix commits doesn't re-test architectural threat surface), leaving five.
 
-| Command / Phase | Agents dispatched in parallel | Notes |
-|-----------------|-------------------------------|-------|
-| `/flow:pr` Phase 3 | `code-reviewer`, `convention-checker`, `test-runner`, `security-reviewer`, `error-handler-inspector`, `holdout-validation` | Six facets in one shot before PR creation. `integration-verifier` follows in Phase 4 (post-parallel). |
-| `/flow:review` Path B | `code-reviewer`, `convention-checker`, `test-runner`, `security-reviewer`, `error-handler-inspector`, `holdout-validation` | Same six facets as `/flow:pr`. Spawned during multi-faceted review on an existing PR. |
-| `/flow:address` Phase 4 | `code-reviewer`, `convention-checker`, `test-runner`, `error-handler-inspector`, `holdout-validation` | Five facets — security re-review is not re-run on an address pass; the original `/flow:pr` covered it and the diff is narrow. |
+| Facet | One-line purpose |
+|-------|------------------|
+| `code-reviewer` | Quality + correctness review, P1/P2/P3 with file:line citations |
+| `convention-checker` | Git convention compliance — commit messages, branch naming, PR shape |
+| `test-runner` | Lint, test, typecheck — structured pass/fail report |
+| `security-reviewer` | OWASP-style review — secrets, auth/authz, input validation, dep vulns. Not re-run by `/flow:address` |
+| `error-handler-inspector` | Unhandled errors, missing edge cases, silent failures |
+| `holdout-validation` | Cross-reference self-review claims against actual file state via hidden scenarios |
 
-The fan-out runs all agents in a single dispatch — they do not see each other's findings, which keeps each agent's signal independent. The command consolidates afterwards, deduplicating findings by `file:line`.
+The fan-out runs all agents in a single dispatch — they do not see each other's findings, which keeps each agent's signal independent. The command consolidates afterwards, deduplicating findings by `file:line`. (The `code-review-methodology` skill describes a separate 5-pillar review frame in source — the workshop count above is the dispatch-side count, since that's what runs.)
 
 ---
 
@@ -408,29 +420,25 @@ The full schema is in `plugins/flow/schema.json`. Defaults are in `plugins/flow/
 
 ---
 
-## 12. Migrating from gh-workflow
+## Appendix A — Coming from `gh-workflow`?
 
-The `gh-workflow` plugin coexists in the marketplace. Comparison from `plugins/flow/README.md` lines 246–255:
+If you've used the `gh-workflow` plugin, the verbs carry over; the autonomy doesn't. The two plugins coexist at the marketplace level — `/flow:setup` warns when both are installed.
 
-| Aspect | gh-workflow | flow |
-|--------|------------|------|
-| Paradigm | Command-driven | Skill-driven |
-| Interaction | ~40 decision points | Autonomous with journal |
-| Learning | None across sessions | Decision journal + skill proposals |
-| Review | Sequential agents | Parallel + adversarial (team option) |
-| Safety | Interactive gates | Hook-enforced tiers |
-| Knowledge | Locked in commands | Composable, reusable skills |
+| gh-workflow | flow equivalent | What's different |
+|-------------|-----------------|------------------|
+| `/gh-start` | `/flow:start` | Adds Phase 0 preflight + Spec Validation Gate |
+| `/gh-commit` | `/flow:commit` | Same vocabulary; classification + journal auto-log |
+| `/gh-pr` | `/flow:pr` | 6-facet parallel agent review before PR creation |
+| `/gh-review` | `/flow:review` | Adversarial team option (`agentTeams: true`) |
+| `/gh-address` | `/flow:address` | 5-facet re-review + `FLOW_RESOLUTION_CYCLE` ledger |
+| `/gh-merge` | `/flow:merge` | Both Tier 3; flow's prereq check is structural |
+| `/gh-release` | `/flow:release` | Both Tier 3; flow generates changelog from merged PRs |
 
-**Practical migration**:
-
-1. The two plugins coexist at the marketplace level. `/flow:setup` warns if both are installed.
-2. Commit-message vocabulary, branch patterns, and reviewer routing carry over — those are decisions, not implementations.
-3. `/gh-start` ↔ `/flow:start`, `/gh-commit` ↔ `/flow:commit`, `/gh-pr` ↔ `/flow:pr`, etc. The verbs are the same; the autonomy is different.
-4. If your team prefers a more interactive style, set `tddMode: suggest`, `verdict.requireAllPass: false`, and promote more tiers to `confirm`. Strict defaults are opt-out (`plugins/flow/README.md` lines 40–56).
+Migration is a config decision, not a code change: commit-message vocabulary, branch patterns, and reviewer routing carry over. If your team prefers a more interactive style, set `tddMode: suggest`, `verdict.requireAllPass: false`, and promote more tiers to `confirm` — strict defaults are opt-out (`plugins/flow/README.md` lines 40–56). See also: `plugins/flow/references/comparison-with-gh-workflow.md`.
 
 ---
 
-## Appendix — file paths quick reference
+## Appendix B — file paths quick reference
 
 ```
 plugins/flow/

--- a/docs/flow-team-session/HANDBOOK.md
+++ b/docs/flow-team-session/HANDBOOK.md
@@ -2,7 +2,6 @@
 
 Long-form reference for the team. The slide deck (`slides.md`) is the room-facing view; this handbook is what you read when something doesn't make sense afterwards.
 
-**Plugin version**: 2.0.1 (`plugins/flow/.claude-plugin/plugin.json`)
 **Source of truth**: `plugins/flow/` in this repo. When this handbook and the source disagree, the source wins — file an issue.
 
 ## Table of contents
@@ -24,7 +23,7 @@ Long-form reference for the team. The slide deck (`slides.md`) is the room-facin
 
 ## 1. The 6 Excellence Principles
 
-Flow v2.0 enforces six principles. They are the answer to "why does this plugin block me?". Source: `plugins/flow/README.md` lines 5–66.
+Flow enforces six principles. They are the answer to "why does this plugin block me?". Source: `plugins/flow/README.md` lines 5–66.
 
 ### 1. Stranger Test
 
@@ -60,14 +59,14 @@ The six fields (`autonomous-workflow/SKILL.md` lines 162–173):
 
 ### 4. Quality > Speed
 
-TDD mode defaults to `enforce`. The verdict judge requires all acceptance criteria to pass. P3 findings are no longer deferrable.
+TDD mode defaults to `enforce`. The verdict judge requires all acceptance criteria to pass. P3 findings are fix-or-escalate.
 
-| Setting | Old Default | New Default |
-|---------|-------------|-------------|
-| `testing.tddMode` | `"suggest"` | `"enforce"` |
-| `verdict.requireAllPass` | `false` | `true` |
+| Setting | Default | Why |
+|---------|---------|-----|
+| `testing.tddMode` | `"enforce"` | Catching test-first violations at write-time is cheaper than catching them at review-time. The Per-Task Verification Gate observes RED-GREEN-REFACTOR before letting a task complete. Teams that prefer test-after can flip to `"suggest"` (decision 1 in the conventions worksheet) and document the rationale. |
+| `verdict.requireAllPass` | `true` | The verdict judge must return PASS for every acceptance criterion or the verdict is FAIL. Partial coverage is a FAIL, not "mostly done." Teams that allow a soft pass on `NEEDS-HUMAN-REVIEW` can set this to `false` and accept the trade-off. |
 
-(`plugins/flow/README.md` lines 35–39)
+(`plugins/flow/settings.json`)
 
 **Failure mode it prevents**: "tests pass" treated as proof of correctness when only the happy path was tested.
 
@@ -85,7 +84,7 @@ The verdict-judge treats any criterion missing these subsections as having incom
 
 ### 6. No Incomplete Shipments
 
-Pre-existing findings in touched files keep their natural priority (no longer capped at P3). The finding-ledger merge gate blocks merges when `FLOW_RESOLUTION_CYCLE` markers contain unresolved or escalated items. **"DEFERRED" markers have been renamed to "ESCALATED"** to signal that deferral is not an option (`plugins/flow/CHANGELOG.md` v2.0.0).
+Pre-existing findings in touched files keep their natural priority — they are not capped at P3 just because they were already there when you opened the file. The finding-ledger merge gate blocks merges when `FLOW_RESOLUTION_CYCLE` markers contain unresolved or escalated items. The lifecycle uses **ESCALATED** as its terminal state for any finding the engineer chooses not to fix in-PR — and ESCALATED is auditable (six-field structure required, reviewer must accept). The vocabulary is the policy: there is no silent deferral.
 
 **Failure mode it prevents**: P3 backlog that grows forever and nothing ever gets fixed.
 
@@ -149,15 +148,28 @@ If you only remember three definitions, remember these.
 
 | Concept | What it is | Plural noun for | Example |
 |---------|-----------|-----------------|---------|
-| **Command** | An entry point — a `/flow:*` invocation that drives a workflow phase | "things you type" | `/flow:start 42` |
+| **Command** | An entry point — a `/flow:*` invocation that drives a workflow phase. Carries the executable bash. | "things you type" | `/flow:start 42` |
 | **Agent** | A subagent dispatched by a command, with its own context and a narrow tool budget | "specialists you hire" | `verdict-judge` |
-| **Skill** | A reusable knowledge unit loaded into the active context, applied autonomously | "playbooks Claude reads" | `criterion-verification-map` |
+| **Skill** | A reference document — policy, philosophy, rationale — loaded into the active context | "reference docs Claude reads" | `criterion-verification-map` |
 
 The same knowledge lives in different containers depending on how it's reused:
 
-- A **command** runs once per workflow step and re-reads itself each session.
+- A **command** runs once per workflow step and re-reads itself each session. It owns the bash blocks and the phase ordering.
 - An **agent** runs in a forked context with isolated tools — useful for independent judgment (verdict-judge sees no diff) or parallel review.
 - A **skill** is invoked from anywhere — commands, other skills, agents — and contributes its iron laws + protocols to whatever workflow needs them.
+
+**Why skills carry no executable bash**: skills are policy and rationale that compounds across sessions. Bash that runs at workflow time belongs in commands, where it can be audited and version-controlled per phase. Splitting the responsibility this way means a skill can be re-read by a new command without forking logic, and a command can change its bash without rewriting team knowledge.
+
+### Required Skills vs `Skill()` invocation
+
+Commands declare skill dependencies in two complementary ways (`plugins/flow/README.md` lines 142–156):
+
+- **`## Required Skills`** (declarative) — skills that inform the WHOLE command. Loaded as ambient context at the start, applied throughout. Example: `code-review-methodology` for `/flow:review`.
+- **`Skill(X)`** (imperative) — explicit forks at specific phase boundaries where the command hands off to a skill for a discrete sub-task. Example: `Skill(capability-discovery)` invoked once during EXPLORE.
+
+Two rules govern usage. First: every command either has a `## Required Skills` section, or an explicit `_None — {reason}_` marker so absence is intentional. Second: every `Skill(X)` invocation in a command body must also appear in that command's `## Required Skills` list. The Required Skills list is the canonical dependency manifest; invocations are phase-specific calls.
+
+Why both: a skill listed as Required is loaded as ambient context; an explicit `Skill()` call is useful when a phase needs the skill's full protocol re-anchored at a specific point. Read-only / dispatcher commands (`status`, `learn`, `explain`, `flow`) typically use the `_None_` marker.
 
 A skill becoming popular enough across commands → it's the right shape. A command duplicating logic from another command → that logic should be a skill.
 
@@ -208,6 +220,20 @@ Rare / bootstrap:
 | `/flow:flow` | Universal dispatcher — `/flow <verb> <target>` |
 
 **Command-level tier-3 prompts**: `/flow:merge` and `/flow:release` invoke `AskUserQuestion` for confirmation. There is no `gate-merge` or `gate-release` hook — the structural gate is in the command file itself plus the Bash hooks for the underlying dangerous operations.
+
+### Parallel agent fan-out — which command, which agents
+
+Three commands dispatch a parallel review fan-out. Knowing which agents run where is useful when reading PR-body findings tables and re-review comments.
+
+A note on counting: `code-review-methodology` describes a **5-facet methodology** (quality, security, conventions, tests, requirements) — that's the conceptual review frame. The **fan-out below dispatches more than five agents in parallel** because `holdout-validation` runs alongside the five methodology facets to cross-reference self-review claims against file state. So "5-facet methodology" and "6-agent parallel dispatch" are both correct — they describe different things.
+
+| Command / Phase | Agents dispatched in parallel | Notes |
+|-----------------|-------------------------------|-------|
+| `/flow:pr` Phase 3 | `code-reviewer`, `convention-checker`, `test-runner`, `security-reviewer`, `error-handler-inspector`, `holdout-validation` | Six facets in one shot before PR creation. `integration-verifier` follows in Phase 4 (post-parallel). |
+| `/flow:review` Path B | `code-reviewer`, `convention-checker`, `test-runner`, `security-reviewer`, `error-handler-inspector`, `holdout-validation` | Same six facets as `/flow:pr`. Spawned during multi-faceted review on an existing PR. |
+| `/flow:address` Phase 4 | `code-reviewer`, `convention-checker`, `test-runner`, `error-handler-inspector`, `holdout-validation` | Five facets — security re-review is not re-run on an address pass; the original `/flow:pr` covered it and the diff is narrow. |
+
+The fan-out runs all agents in a single dispatch — they do not see each other's findings, which keeps each agent's signal independent. The command consolidates afterwards, deduplicating findings by `file:line`.
 
 ---
 
@@ -279,7 +305,7 @@ Source of truth: `plugins/flow/hooks/hooks.json`.
 | PreToolUse | Bash | `block-destructive.sh` | Exit 2 on `rm -rf`, `git reset --hard`, etc. |
 | PreToolUse | Bash | `block-secrets.sh` | Exit 2 on inline credentials |
 | PostToolUse | Edit\|Write | `log-file-changes.sh` | Append `<!-- auto-log: ... -->` entry to journal |
-| PostToolUse | Bash | `log-commits.sh` | Append commit auto-log entry. Idempotency guards added in v2.0.1 (`CHANGELOG.md`) prevent the auto-log infinite loop |
+| PostToolUse | Bash | `log-commits.sh` | Append commit auto-log entry. The script is idempotent — it skips lines already carrying the `auto-log` marker, so a journal commit cannot trigger another append. |
 | TaskCompleted | (any) | `verify-task-completion.sh` | Per-Task Verification Gate enforcement |
 | TeammateIdle | (any) | `nudge-idle-teammate.sh` | Experimental — used with agent teams |
 | SessionEnd | (any) | `session-end-learn.sh` | Experimental — feeds the learning loop |
@@ -374,7 +400,7 @@ The full schema is in `plugins/flow/schema.json`. Defaults are in `plugins/flow/
 | "Why did the plan get blocked?" | `.decisions/issue-N.md` for the most recent entry. Search for "Stranger Test" or "Spec Validation Gate." |
 | "The verdict is FAIL but the code works" | `criterion-verification-map/SKILL.md` — check completeness subsections in the evidence bundle. Missing one = automatic FAIL. |
 | "Hooks aren't firing" | `plugins/flow/hooks/hooks.json` — confirm matcher and trigger. Check `~/.claude/logs/` for hook stderr. |
-| "Auto-log is duplicating commits" | Was supposed to be fixed in v2.0.1. Confirm `plugin.json` shows `"version": "2.0.1"`. If you see it on 2.0.0 or earlier, upgrade. |
+| "Auto-log is duplicating commits" | The script is idempotent only when the marker is intact. If the journal file's `<!-- auto-log: ... -->` lines were edited out, append loops can resurface — restore the markers or run `claude plugins update flow` to refresh the script. |
 | "/flow:learn isn't proposing skills" | `~/.claude/flow-proposals/` for proposals; ensure `learning.enabled: true` and `journal.dir` is populated. |
 | "Agent teams not spawning" | Both `agentTeams: true` AND `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` env var must be set. |
 | "Tier 3 prompt isn't appearing" | Check `tiers.merge` and `tiers.release` in your settings cascade. Promoted to `confirm` is the default. |
@@ -384,7 +410,7 @@ The full schema is in `plugins/flow/schema.json`. Defaults are in `plugins/flow/
 
 ## 12. Migrating from gh-workflow
 
-The `gh-workflow` plugin (v1.7.0) is the predecessor. Comparison from `plugins/flow/README.md` lines 223–230:
+The `gh-workflow` plugin coexists in the marketplace. Comparison from `plugins/flow/README.md` lines 246–255:
 
 | Aspect | gh-workflow | flow |
 |--------|------------|------|
@@ -400,7 +426,7 @@ The `gh-workflow` plugin (v1.7.0) is the predecessor. Comparison from `plugins/f
 1. The two plugins coexist at the marketplace level. `/flow:setup` warns if both are installed.
 2. Commit-message vocabulary, branch patterns, and reviewer routing carry over — those are decisions, not implementations.
 3. `/gh-start` ↔ `/flow:start`, `/gh-commit` ↔ `/flow:commit`, `/gh-pr` ↔ `/flow:pr`, etc. The verbs are the same; the autonomy is different.
-4. If you preferred gh-workflow's interactive style, set `tddMode: suggest`, `verdict.requireAllPass: false`, and promote more tiers to `confirm`. Strict defaults can be opted out of (`README.md` lines 40–56).
+4. If your team prefers a more interactive style, set `tddMode: suggest`, `verdict.requireAllPass: false`, and promote more tiers to `confirm`. Strict defaults are opt-out (`plugins/flow/README.md` lines 40–56).
 
 ---
 
@@ -409,7 +435,7 @@ The `gh-workflow` plugin (v1.7.0) is the predecessor. Comparison from `plugins/f
 ```
 plugins/flow/
 ├── README.md                                   ← Excellence Principles + skill tree
-├── CHANGELOG.md                                ← v2.0 breaking changes, v2.0.1 fix
+├── CHANGELOG.md                                ← release history (versioning reference)
 ├── settings.json                               ← all defaults
 ├── schema.json                                 ← full config schema
 ├── .claude-plugin/plugin.json                  ← version

--- a/docs/flow-team-session/HANDBOOK.md
+++ b/docs/flow-team-session/HANDBOOK.md
@@ -115,7 +115,7 @@ Source: `plugins/flow/references/three-tier-safety.md`.
 | `block-destructive.sh` | `rm -rf`, `git reset --hard` | Exit 2 (block) |
 | `block-secrets.sh` | Inline credentials | Exit 2 (block) |
 
-**Important**: merge and release confirmation is handled at the **command level** via AskUserQuestion (see `/flow:merge` and `/flow:release`), not by a `gate-merge` or `gate-release` hook script (`three-tier-safety.md` line 80). The README mentions those names — they are not wired. The eight wired hook scripts are listed in §7.
+**Important**: merge and release confirmation is handled at the **command level** via AskUserQuestion (see `/flow:merge` and `/flow:release`), not by a `gate-merge` or `gate-release` hook script (`three-tier-safety.md` line 80). The eight wired hook scripts are listed in §7.
 
 ### 2b. Explore-Plan-Code-Verify (EPCV)
 
@@ -284,7 +284,7 @@ Source of truth: `plugins/flow/hooks/hooks.json`.
 | TeammateIdle | (any) | `nudge-idle-teammate.sh` | Experimental — used with agent teams |
 | SessionEnd | (any) | `session-end-learn.sh` | Experimental — feeds the learning loop |
 
-That's eight scripts. The README mentions `gate-merge` and `gate-release` — those are not wired and don't exist as scripts. Merge/release confirmation is in the **command** files via AskUserQuestion.
+That's eight scripts — matching `plugins/flow/README.md` lines 133–139. There is no `gate-merge` or `gate-release` hook script; merge/release confirmation is in the **command** files via AskUserQuestion.
 
 ---
 

--- a/docs/flow-team-session/README.md
+++ b/docs/flow-team-session/README.md
@@ -1,6 +1,6 @@
 # Flow Plugin Team Workshop — docs
 
-A 90-minute mixed-audience (engineering + PM/design) workshop for the `/flow` plugin v2.0.1. Mental model + lifecycle walkthrough + 10 conventions decided live.
+A 90-minute mixed-audience (engineering + PM/design) workshop for the `/flow` plugin. Mental model + lifecycle walkthrough + 10 conventions decided live.
 
 ## What's in here
 

--- a/docs/flow-team-session/README.md
+++ b/docs/flow-team-session/README.md
@@ -1,0 +1,59 @@
+# Flow Plugin Team Workshop — docs
+
+A 90-minute mixed-audience (engineering + PM/design) workshop for the `/flow` plugin v2.0.1. Mental model + lifecycle walkthrough + 10 conventions decided live.
+
+## What's in here
+
+| File | Purpose | When to use |
+|------|---------|-------------|
+| `slides.md` | Marp source for the deck (~63 slides) | Project this during the session. Render with `npx -y @marp-team/marp-cli --pdf slides.md`. |
+| `HANDBOOK.md` | Long-form reference (~15 pages) | Read after the session. Bookmark for later. |
+| `CHEATSHEET.md` | One-page printable, two-column | Pin to the wall. Reach for it daily. |
+| `walkthrough-script.md` | Pre-recording shotlist + live-narration timing + dry-run checklist | Producing the recording. Re-recording it later. |
+| `CONVENTIONS-WORKSHEET.md` | 10-row fillable template | Project on screen during section 6. Don't advance until each row has an answer. |
+| `CONVENTIONS-DECIDED.md` | Empty template for the post-session artifact | Fill in during the session. Commit. Open follow-up PR for `.claude/settings.flow.json`. |
+| `faq-and-glossary.md` | Anticipated questions + term lookup | When someone asks "what's ESCALATED again?" |
+| `README.md` | This index | First-time onboarding. |
+
+## How to run the session
+
+1. **Two weeks before**: skim `walkthrough-script.md`. Pre-record using a synthetic `sync-cli` repo (the script tells you exactly what to capture). Confirm composite ≤ 20 minutes.
+2. **One week before**: dress-rehearse the deck against a 1-person audience matching the target profile. Time each segment. Adjust if any segment is >20% over budget.
+3. **Day of, 30 min before**: run the pre-recording checklist in `walkthrough-script.md`. Confirm `/flow:setup` and `/flow:status` work cold from a clean machine.
+4. **Day of, 5 min before**: project `CONVENTIONS-WORKSHEET.md`. The forcing function is that the team can see the open rows.
+5. **Session**: follow `slides.md` agenda. 90 minutes. Hard buffer in segments 5 and 6.
+6. **Right after**: copy the marked rows from `CONVENTIONS-WORKSHEET.md` into `CONVENTIONS-DECIDED.md`. Commit. If non-default settings were chosen, open a follow-up PR adding overrides to `.claude/settings.flow.json`.
+
+## Why a workshop instead of a doc?
+
+The mental model — particularly the verdict-judge's information isolation — needs to be **shown**. The recording solves the "demos break in front of audiences" problem; live narration lets the room interrupt at the right moments. After the session, the docs in this folder are what you reach for; they exist *because* the live session happened, not as a substitute for it.
+
+## Audience
+
+Mixed engineering + PM/design, varied Claude Code experience. The deck deliberately:
+
+- Teaches **principles** before vocabulary (engages PM/design fully).
+- Teaches **vocabulary** before the demo (so the demo's terms have slots in your head).
+- Puts the **conventions vote** after the demo (the room can't vote on `tddMode: enforce` until they've felt it).
+- Puts **hands-on** before Q&A (everyone leaves with a running plugin, not the intent to install tomorrow).
+
+If only one concept lands, it should be **verdict-judge information isolation** (slide 22, pause beat 2). PM/design will ask "but how does the agent know if it's right?" and that's the answer.
+
+## What's the deliverable?
+
+Two:
+
+1. A team-wide shared mental model of how flow works — measurable by everyone being able to explain in one sentence what the verdict-judge does NOT see.
+2. A committed `CONVENTIONS-DECIDED.md` that drives `.claude/settings.flow.json` — and a follow-up PR for any non-default values within one week.
+
+If the session ends with no decisions captured: the session was theatre. The forcing function in section 6 prevents that.
+
+## Source-of-truth alignment
+
+Everything in these docs is grounded in `plugins/flow/`. When the plugin source and these docs disagree, the source wins — file an issue with `documentation` label so we can resync.
+
+Quoted material is verbatim from the noted file:line. The verification check (in the original plan) greps each `[QUOTE]` block against its source. If you change a skill's iron law, expect the corresponding slide to need an update.
+
+## Renaming and rerunning
+
+Want to use this workshop format for a different plugin or a different team? Copy this folder, search-and-replace `flow` for the new plugin name, regenerate the conventions worksheet against the new plugin's `settings.json` defaults, re-record the walkthrough using the new plugin's daily five. The structure (principles → skeletons → vocabulary → demo → commands → conventions → hands-on → close) generalizes.

--- a/docs/flow-team-session/faq-and-glossary.md
+++ b/docs/flow-team-session/faq-and-glossary.md
@@ -8,7 +8,7 @@ Anticipated questions from a mixed audience (engineering + PM/design) and a quic
 
 ### Why a 90-min workshop instead of a doc?
 
-We tried docs first. The mental model — particularly the verdict-judge isolation — needs to be **shown**, not described. The recording solves the "demos break in front of audiences" problem; the live narration lets the room interrupt at the right moments.
+Docs alone don't land the mental model — particularly the verdict-judge isolation, which needs to be **shown**, not described. The recording solves the "demos break in front of audiences" problem; the live narration lets the room interrupt at the right moments.
 
 ### "TDD enforce" means I can't write code without a test?
 
@@ -26,7 +26,7 @@ This is the answer to the most common PM/design question. It's worth landing twi
 
 It returns `NEEDS-HUMAN-REVIEW` for ambiguous cases. The judge doesn't have authority to ship — the human always does. The judge has authority to **block**, and that's enough to prevent silent regressions.
 
-If you think the judge is systematically wrong, that's a bug — file an issue, attach the AC + evidence + verdict, and we'll examine the prompt construction.
+If you think the judge is systematically wrong, that's a bug — file an issue, attach the AC + evidence + verdict, and the prompt construction can be examined against the failure case.
 
 ### "Spec Validation Gate" — does this mean we need rigorous specs for every issue?
 
@@ -46,11 +46,11 @@ Note: `debugging-patterns` skill activates **automatically** when any verificati
 
 ### Can I disable individual hooks?
 
-Yes — edit `plugins/flow/hooks/hooks.json` or shadow it via local override. But seriously consider: the hooks exist *because* commands occasionally have bugs. `block-force-push` saved one of us last quarter when a custom command tried to push --force from a script. Don't disable them lightly.
+Yes — edit `plugins/flow/hooks/hooks.json` or shadow it via local override. But seriously consider: the hooks exist as a structural backstop for command bugs. `block-force-push` is what catches the recovery attempt when a command-level guard fails. Don't disable them lightly.
 
 ### Why is the recording synthetic instead of using our real codebase?
 
-Two reasons. First, the lifecycle stays visible — nobody drags the demo into "but how does this apply to *our* auth service." Second, the recording is reusable — we can hire a new engineer in six months and the demo will still make sense.
+Two reasons. First, the lifecycle stays visible — nobody drags the demo into "but how does this apply to *our* auth service." Second, the recording is reusable — a new hire six months from now can still follow the demo without it being repo-specific.
 
 If you want a session against the real codebase, run one — but plan more time and accept that it'll be tangent-prone.
 

--- a/docs/flow-team-session/faq-and-glossary.md
+++ b/docs/flow-team-session/faq-and-glossary.md
@@ -54,9 +54,9 @@ Two reasons. First, the lifecycle stays visible — nobody drags the demo into "
 
 If you want a session against the real codebase, run one — but plan more time and accept that it'll be tangent-prone.
 
-### The README mentions `gate-merge.sh` and `gate-release.sh` — where are they?
+### Are `gate-merge.sh` and `gate-release.sh` hook scripts?
 
-They don't exist. The README's "Hooks (10 scripts)" section is stale. Eight scripts are wired (see `plugins/flow/hooks/hooks.json`). Merge and release confirmation is at the **command** level via `AskUserQuestion` (see `plugins/flow/references/three-tier-safety.md` line 80). This is mentioned on slide 24 and again in HANDBOOK §7.
+No — and they aren't supposed to be. Eight scripts are wired (see `plugins/flow/hooks/hooks.json` and the matching `HOOKS (8 scripts)` box in `plugins/flow/README.md` lines 133–139). Merge and release confirmation lives at the **command** level via `AskUserQuestion` (see `plugins/flow/references/three-tier-safety.md` line 80). This is mentioned on slide 24 and again in HANDBOOK §7.
 
 ### Is the marketplace `gh-workflow` plugin going away?
 

--- a/docs/flow-team-session/faq-and-glossary.md
+++ b/docs/flow-team-session/faq-and-glossary.md
@@ -133,7 +133,7 @@ The plugin gets better when the team tells it where it failed.
 
 - **FLOW_REVIEW_CYCLE** — marker in PR review bodies; captures findings per cycle.
 - **FLOW_RESOLUTION_CYCLE** — marker in PR comments; captures resolved + escalated findings per cycle. Merge gate's substrate.
-- **ESCALATED** — was "DEFERRED" pre-v2.0. P3 escalated via the six-field structure, not silently dropped.
+- **ESCALATED** — terminal state for a P3 finding the engineer chose not to fix in-PR. Requires a six-field escalation in the PR comment, accepted by the reviewer. Auditable; not silently dropped.
 - **Per-Task Verification Gate** — a task can't move to `completed` until tests pass, evidence captured, no out-of-context files, TDD cycle observed. (`autonomous-workflow/SKILL.md` lines 44–59)
 
 ### Decision journal

--- a/docs/flow-team-session/faq-and-glossary.md
+++ b/docs/flow-team-session/faq-and-glossary.md
@@ -117,7 +117,7 @@ The plugin gets better when the team tells it where it failed.
 - **P3** — fix-or-escalate. Style, optimization, future improvements. Not a free pass.
 - **ASSERTION / EVIDENCE / VERIFIED** — the citation pattern from `evidence-based-development`. No claim without a file:line cite.
 - **Boy Scout Rule** — leave the campsite cleaner than you found it. Recognized in commit type `improve:`.
-- **5-facet review** — quality, security, conventions, tests, requirements. See `code-review-methodology`.
+- **Parallel review fan-out** — `/flow:pr` Phase 3 and `/flow:review` Path B dispatch 6 facets in parallel: `code-reviewer`, `convention-checker`, `test-runner`, `security-reviewer`, `error-handler-inspector`, `holdout-validation`. `/flow:address` Phase 4 drops `security-reviewer`, leaving 5. (The `code-review-methodology` skill in source describes a separate 5-pillar review frame.)
 - **Adversarial review** — opt-in (`agentTeams: true`). Reviewers challenge each other's findings before consolidating.
 
 ### Acceptance criteria and evidence

--- a/docs/flow-team-session/faq-and-glossary.md
+++ b/docs/flow-team-session/faq-and-glossary.md
@@ -1,0 +1,167 @@
+# FAQ and Glossary
+
+Anticipated questions from a mixed audience (engineering + PM/design) and a quick lookup for terms.
+
+---
+
+## FAQ
+
+### Why a 90-min workshop instead of a doc?
+
+We tried docs first. The mental model — particularly the verdict-judge isolation — needs to be **shown**, not described. The recording solves the "demos break in front of audiences" problem; the live narration lets the room interrupt at the right moments.
+
+### "TDD enforce" means I can't write code without a test?
+
+Means a task can't be marked completed without observing the RED-GREEN-REFACTOR cycle (see `plugins/flow/skills/autonomous-workflow/SKILL.md` lines 44–59). The agent enforces this on itself when it's writing code. You as a human can still write whatever you want — but if the agent is implementing for you under `/flow:start`, it will write the failing test first.
+
+If that's too strict for your workflow, the team can vote `tddMode: suggest` in section 6.
+
+### Why does the verdict-judge get to decide if the code is "right"?
+
+Because it has the only complete view of "what was asked." The code-writing agent has goals, rationale, journaling, and ego in the loop. The judge is given **only** the acceptance criteria and the evidence bundle. If you can prove the AC against the evidence, it's right. If you can't, it isn't — even if the code looks fine.
+
+This is the answer to the most common PM/design question. It's worth landing twice (slide 22, pause beat 2).
+
+### What if the verdict-judge is wrong?
+
+It returns `NEEDS-HUMAN-REVIEW` for ambiguous cases. The judge doesn't have authority to ship — the human always does. The judge has authority to **block**, and that's enough to prevent silent regressions.
+
+If you think the judge is systematically wrong, that's a bug — file an issue, attach the AC + evidence + verdict, and we'll examine the prompt construction.
+
+### "Spec Validation Gate" — does this mean we need rigorous specs for every issue?
+
+Means: every AC needs a runnable verification command. "Works correctly" doesn't qualify. "Returns 200 on a valid request" does (`curl -w '%{http_code}' …`).
+
+Issues labeled `documentation` or `chore` (configurable — decision 8) skip this requirement.
+
+### Do PMs need to write the verification commands?
+
+No. The PM writes ACs in observable-behavior language ("when X, then Y"). The agent classifies each AC against `criterion-verification-map`'s table (behavioral / API / UI / error / performance / configuration / data / contract) and produces the runnable command at plan time. The PM reviews the resulting plan, but doesn't author bash.
+
+### What's the difference between `/flow:debug` and just running `/flow:start` on a bug?
+
+`/flow:debug` is for bugs you can't reproduce yet — structured root-cause analysis, evidence gathering, hypothesis testing. `/flow:start` (with a `bug` label) is for a known-reproducible bug going through the full lifecycle.
+
+Note: `debugging-patterns` skill activates **automatically** when any verification step fails — test, build, server start, smoke test. You don't need a `bug` label to get debugging help (`commands/start.md` lines 70–73).
+
+### Can I disable individual hooks?
+
+Yes — edit `plugins/flow/hooks/hooks.json` or shadow it via local override. But seriously consider: the hooks exist *because* commands occasionally have bugs. `block-force-push` saved one of us last quarter when a custom command tried to push --force from a script. Don't disable them lightly.
+
+### Why is the recording synthetic instead of using our real codebase?
+
+Two reasons. First, the lifecycle stays visible — nobody drags the demo into "but how does this apply to *our* auth service." Second, the recording is reusable — we can hire a new engineer in six months and the demo will still make sense.
+
+If you want a session against the real codebase, run one — but plan more time and accept that it'll be tangent-prone.
+
+### The README mentions `gate-merge.sh` and `gate-release.sh` — where are they?
+
+They don't exist. The README's "Hooks (10 scripts)" section is stale. Eight scripts are wired (see `plugins/flow/hooks/hooks.json`). Merge and release confirmation is at the **command** level via `AskUserQuestion` (see `plugins/flow/references/three-tier-safety.md` line 80). This is mentioned on slide 24 and again in HANDBOOK §7.
+
+### Is the marketplace `gh-workflow` plugin going away?
+
+Not immediately. They coexist. flow is the recommended path forward; gh-workflow remains for repos that aren't ready to migrate. `/flow:setup` warns on coexistence.
+
+### What if `/flow:setup` doesn't detect our build?
+
+File an issue with your project's `package.json` / `pyproject.toml` / `Cargo.toml` etc. Setup is heuristic. The fallback is to manually populate `.claude/settings.flow.json` with the right commands.
+
+### Can two of us run `/flow:start` on the same issue?
+
+Don't. `/flow:start` assigns the issue. Branch creation will conflict. The `block-destructive` hook will catch overwrites, but you'll waste time.
+
+If you genuinely need parallel work, file two issues for the two pieces and `/flow:start` each separately.
+
+### What's the right cadence for `/flow:learn`?
+
+Decision 10 in the worksheet. Suggestion: monthly, rotating owner. A proposal nobody triages is a missed pattern.
+
+### Can we customize the verdict-judge?
+
+No. **Independence is the feature**, not a constraint. Customizing what the judge sees would defeat the purpose. The only knobs:
+
+- `verdict.enabled` — turn it off entirely (not recommended)
+- `verdict.requireAllPass` — decision 2 in the worksheet
+
+If you want stricter judgment, write better completeness subsections in the evidence bundle (Principle 5).
+
+### What if I disagree with a P3?
+
+Rewrite it as a six-field escalation in the PR comment. Reviewer accepts (becomes a real escalation in `FLOW_RESOLUTION_CYCLE`) or rejects (the original P3 stands and you fix it). See implicit 11th decision in worksheet.
+
+### How do I file confusion?
+
+GitHub issue, `documentation` label. Specifically log:
+
+- Slides that needed extra explanation we didn't anticipate.
+- Conventions we voted on that turn out to be wrong in practice.
+- Skills that activate when they shouldn't (or don't when they should).
+- Failure modes not in HANDBOOK §11.
+
+The plugin gets better when the team tells it where it failed.
+
+---
+
+## Glossary
+
+### Tiers and safety
+
+- **Tier 1 / 2 / 3** — autonomous / journal / confirm. See `plugins/flow/references/three-tier-safety.md`.
+- **Block-force-push / block-destructive / block-secrets** — the three PreToolUse Bash hooks. Exit 2 = block.
+- **`--force-with-lease`** — explicitly allowed; treated as Tier 2 (journal).
+
+### Findings and review
+
+- **P1** — must fix; blocks merge. Security, data loss, broken functionality.
+- **P2** — should fix; logic errors, missing edge cases, test gaps, convention violations.
+- **P3** — fix-or-escalate. Style, optimization, future improvements. Not a free pass.
+- **ASSERTION / EVIDENCE / VERIFIED** — the citation pattern from `evidence-based-development`. No claim without a file:line cite.
+- **Boy Scout Rule** — leave the campsite cleaner than you found it. Recognized in commit type `improve:`.
+- **5-facet review** — quality, security, conventions, tests, requirements. See `code-review-methodology`.
+- **Adversarial review** — opt-in (`agentTeams: true`). Reviewers challenge each other's findings before consolidating.
+
+### Acceptance criteria and evidence
+
+- **Spec Validation Gate** — fires if a criterion lacks a runnable verification command. Blocks PLAN.
+- **Stranger Test** — gate at end of PLAN. Plan must be executable by someone with zero prior context.
+- **Eval-as-spec** — every AC produces a runnable verification command at plan time, not verify time.
+- **Does NOT promise** — first-class field on every AC. Fences scope so a narrow PASS isn't inflated to a broad guarantee.
+- **Evidence bundle** — structured per-AC document fed to the verdict-judge. Three required completeness subsections.
+- **Holdout validation** — hidden scenarios cross-referenced against actual file state. Catches "test added" claims that aren't true.
+
+### Lifecycle markers
+
+- **FLOW_REVIEW_CYCLE** — marker in PR review bodies; captures findings per cycle.
+- **FLOW_RESOLUTION_CYCLE** — marker in PR comments; captures resolved + escalated findings per cycle. Merge gate's substrate.
+- **ESCALATED** — was "DEFERRED" pre-v2.0. P3 escalated via the six-field structure, not silently dropped.
+- **Per-Task Verification Gate** — a task can't move to `completed` until tests pass, evidence captured, no out-of-context files, TDD cycle observed. (`autonomous-workflow/SKILL.md` lines 44–59)
+
+### Decision journal
+
+- **`.decisions/`** — default journal directory. Configurable via `journal.dir`.
+- **Auto-log entry** — HTML comment written by hooks: `<!-- auto-log: timestamp action target -->`.
+- **Structured entry** — Markdown written by skills with category / decision / rationale / alternatives / evidence.
+- **Sensitivity** — `public` (default; included in PR body) or `internal` (redacted).
+- **Categories** — Architecture, Implementation, Convention, Quality, Risk.
+
+### Phases
+
+- **EXPLORE** — gather context. Parallel reads, agent dispatch, capability discovery, LSP trace.
+- **PLAN** — decompose. TaskCreate per deliverable, verification command per AC, Stranger Test gate.
+- **CODE** — execute tasks. Per-Task Gate, TDD cycle, incremental commits.
+- **VERIFY** — four layers: static, runtime, review (fix-forward), verdict (independent).
+
+### Roles
+
+- **Verdict-judge** — independent agent. Sees only ACs + evidence bundle + holdout. No diff, no journal.
+- **Implementation-planner** — agent that parses ACs into tasks with dependencies.
+- **Code-reviewer / security-reviewer / convention-checker / error-handler-inspector / integration-verifier / test-runner** — the other 6 agents.
+- **Six-field escalation** — Situation / What I tried / Options (one Recommended) / My recommendation / Time sensitivity / Risk if wrong.
+
+### Settings
+
+- **Cascade** — `plugins/flow/settings.json` → `~/.claude/settings.flow.json` → `.claude/settings.flow.json` → `.claude/settings.flow.local.json`. Later wins.
+- **Schema** — full reference in `plugins/flow/schema.json`.
+- **`tddMode: enforce` / `suggest`** — strict default vs opt-out. Decision 1.
+- **`verdict.requireAllPass: true / false`** — strict default vs opt-out. Decision 2.
+- **`agentTeams: false / true`** — adversarial review opt-in. Decision 3. Requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`.

--- a/docs/flow-team-session/slides.md
+++ b/docs/flow-team-session/slides.md
@@ -530,12 +530,12 @@ Pure bash. No LLM calls. Fails fast before spending tokens.
 
 push (T2)
    ↓
-parallel agent fan-out:
+parallel agent fan-out (Phase 3):
    ├── code-reviewer         (quality + correctness)
-   ├── security-reviewer     (OWASP, secrets, auth)
    ├── convention-checker    (commit format, branch, PR shape)
+   ├── test-runner           (lint, test, typecheck)
+   ├── security-reviewer     (OWASP, secrets, auth)
    ├── error-handler-inspector  (unhandled, silent failures)
-   ├── integration-verifier  (E2E smoke)
    └── holdout-validation    (claim verification)
    ↓
 findings deduplicated by file:line, sorted P1 → P3

--- a/docs/flow-team-session/slides.md
+++ b/docs/flow-team-session/slides.md
@@ -282,7 +282,7 @@ Skills, agents, commands. Different containers, different reuse profiles.
 ```
 [ASCII]  (source: plugins/flow/README.md lines 86–112)
 
-FOUNDATION (always loaded, ≤100 lines each)
+FOUNDATION (always loaded, stable shape)
 ├── evidence-based-development      ── citations, P1/P2/P3, ASSERTION/EVIDENCE/VERIFIED
 ├── autonomous-workflow             ── EPCV, tiers, six-field escalation
 └── code-quality-principles         ── Boy Scout, no mocks/TODOs in prod
@@ -728,46 +728,69 @@ Everyone runs `/flow:setup` and `/flow:status` now. Five minutes. We don't move 
 ## `/flow:setup` — what to expect
 
 ```
-[MOCKUP]
+[MOCKUP]  (matches commands/setup.md flow)
 
 > /flow:setup
-flow: detecting tech stack...
+Phase 1 — detecting environment...
   • language: TypeScript (tsconfig.json found)
-  • test runner: jest (package.json scripts.test)
-  • lint: eslint (eslint.config.js)
-  • type check: tsc --noEmit
-flow: LSP servers available — typescript-language-server (auto-configured)
-flow: writing .claude/settings.flow.json with detected commands
-flow: warning — gh-workflow plugin also installed; commands coexist, see HANDBOOK §12
+  • test/lint/typecheck: jest, eslint, tsc --noEmit
+  • CLAUDE.md: present
+  • gh-workflow plugin also installed (commands coexist; see HANDBOOK §12)
+
+Phase 2 — generating .claude/settings.flow.json (merge with existing if present)
+
+Phase 3 — LSP setup
+  ⚠ INTERACTIVE: setup will ask:
+    1. Which LSP servers to install for your stack? (all / pick / skip)
+    2. Register the Piebald-AI/claude-code-lsps marketplace? (yes / skip)
+    3. ENABLE_LSP_TOOL not set — add to ~/.claude/settings.json? (yes / no)
+
 flow: setup complete. Try /flow:status next.
 ```
 
-Re-run is idempotent. Won't overwrite an existing settings.flow.json without confirmation.
+**Heads-up for hands-on**: the LSP phase is interactive — accept defaults to keep moving. Re-run is safe (won't overwrite settings without confirmation).
 
 ---
 
 ## `/flow:status` — what to expect
 
 ```
-[MOCKUP]
+[MOCKUP]  (matches commands/status.md output structure)
 
 > /flow:status
-ASSIGNED ISSUES
-  #142  Add JSON output to /sync command           [feature/issue-142-...]
-  #156  Investigate flaky session test             [unassigned branch]
 
-OPEN PRS (mine)
-  #43   feat: rate-limit middleware     ✅ approved · checks ✓ · ready to merge
+## Flow Status
 
-PENDING REVIEWS
-  #44   ⏳ requested 6 hours ago
+### Current Branch
+- Branch: feature/issue-142-sync-json-flag
+- Commits ahead: 4 ahead of main
+- Uncommitted changes: 0 files
 
-JOURNAL HEALTH
-  .decisions/issue-142.md  — 12 entries, last 14:32 (1h ago)
-  ~/.claude/flow-proposals/ — 3 unreviewed proposals
+### My Issues (Open)
+| #   | Title                                   | Labels       |
+|-----|-----------------------------------------|--------------|
+| 142 | Add JSON output to /sync command        | enhancement  |
+| 156 | Investigate flaky session test          | bug          |
+
+### My PRs
+| #  | Title                       | Status      | Checks |
+|----|-----------------------------|-------------|--------|
+| 43 | feat: rate-limit middleware | APPROVED    | passed |
+
+### Awaiting My Review
+| #  | Title                  | Author     |
+|----|------------------------|------------|
+| 44 | refactor session store | @teammate  |
+
+### Decision Journal
+- Journals: 1 active
+- Learning: 3 proposals pending in ~/.claude/flow-proposals/
+
+### Suggested Next Action
+PR #43 is approved with passing checks → `/flow:merge 43`
 ```
 
-Read-only. Safe to run anywhere, anytime.
+Read-only. Safe to run anywhere, anytime. The "Suggested Next Action" line picks the most useful next command from the table in `commands/status.md`.
 
 ---
 

--- a/docs/flow-team-session/slides.md
+++ b/docs/flow-team-session/slides.md
@@ -1,0 +1,899 @@
+---
+marp: true
+theme: default
+paginate: true
+header: 'Flow Plugin Team Workshop · 90 min'
+footer: 'docs/flow-team-session/slides.md'
+style: |
+  section { font-size: 24px; }
+  section.lead h1 { font-size: 56px; }
+  section h1 { font-size: 36px; }
+  section h2 { font-size: 28px; }
+  pre { font-size: 18px; }
+  table { font-size: 20px; }
+  blockquote { border-left: 6px solid #888; padding-left: 12px; color: #444; }
+---
+
+<!-- _class: lead -->
+<!-- _paginate: false -->
+
+# Flow Plugin Team Workshop
+
+A 90-min walkthrough of `/flow` v2.0.1 — for engineers, PMs, and designers.
+
+By the end of this session: you'll share a mental model, you'll have voted on 10 conventions, and you'll have the plugin running.
+
+---
+
+## The one promise
+
+By 1:30, every engineer has flow installed and the team has a checked-in `CONVENTIONS-DECIDED.md` that drives `.claude/settings.flow.json`.
+
+That's it. If we don't deliver that, we wasted your morning.
+
+---
+
+## Before / after a flow PR
+
+```
+[MOCKUP]
+
+BEFORE                              AFTER
+─────                               ─────
+Issue: "Add JSON output"            Issue: 4 ACs, each with verification command
+PR: "Adds --json flag"              PR: comprehension report + 4 verdicts (PASS×4)
+                                       review findings table sorted P1→P3
+                                       FLOW_RESOLUTION_CYCLE: empty
+                                       finding-ledger: clean
+                                       merge: confirmed
+```
+
+The shape of "done" is the difference. Strict by default — opt out, don't opt in.
+
+---
+
+## Agenda — 90 min
+
+| Time | Mins | What |
+|------|------|------|
+| 0:00–0:05 | 5 | Open + the one promise |
+| 0:05–0:13 | 8 | 6 Excellence Principles |
+| 0:13–0:21 | 8 | 3-tier safety + Explore-Plan-Code-Verify |
+| 0:21–0:28 | 7 | Skills / Agents / Commands |
+| 0:28–0:53 | 25 | **Pre-recorded walkthrough** (4 pause beats) |
+| 0:53–1:03 | 10 | Command depth |
+| 1:03–1:18 | 15 | **Conventions vote** (10 decisions, live worksheet) |
+| 1:18–1:25 | 7 | **Hands-on** — `/flow:setup` + `/flow:status` |
+| 1:25–1:30 | 5 | Q&A + Monday checklist |
+
+---
+
+<!-- _class: lead -->
+
+# Section B — The 6 Excellence Principles
+
+Mental model first. Without these, the rest of the plugin reads as bureaucracy.
+
+---
+
+## Principle 1 — Stranger Test
+
+Every plan must be executable by someone with **zero prior context**. If it requires "you know what I mean" reasoning, the PLAN phase blocks until rewritten.
+
+**Failure mode it prevents**: implementer joins the PR mid-cycle, can't tell what "fix the auth thing" means, makes the wrong fix.
+
+> Source: `plugins/flow/README.md` line 11.
+
+---
+
+## Principle 2 — Spec-as-Eval-Suite
+
+[QUOTE] `plugins/flow/skills/criterion-verification-map/SKILL.md` line 15:
+
+> **EVERY ACCEPTANCE CRITERION IS AN EVAL SOURCE.** At plan time, each criterion must produce a runnable verification command. No criterion is deferred to verify time with "we'll figure out how to test this later." No criterion passes by assumption. No criterion is "too obvious to verify."
+
+**Failure mode**: tests pass, criteria are never actually verified, the PR ships and breaks production.
+
+---
+
+## Principle 3 — Proactive Autonomy
+
+The six-field escalation template (`plugins/flow/skills/autonomous-workflow/SKILL.md` lines 162–173):
+
+| Field | Purpose |
+|-------|---------|
+| **Situation** | What happened — the specific state or finding that requires a decision |
+| **What I tried** | What you attempted before escalating — research, alternatives, commands run |
+| **Options** | 2–3 concrete paths forward, each with trade-offs. Label one "(Recommended)" |
+| **My recommendation** | Which option you recommend and why — never blank |
+| **Time sensitivity** | Blocking? Urgent? Safe to defer? |
+| **Risk if wrong** | Consequence of wrong choice, and who is affected |
+
+"What should I do?" is blocked. Always.
+
+---
+
+## Principle 4 — Quality > Speed
+
+Strict defaults (`plugins/flow/README.md` lines 35–39):
+
+| Setting | Old Default | New Default |
+|---------|-------------|-------------|
+| `testing.tddMode` | `"suggest"` | `"enforce"` |
+| `verdict.requireAllPass` | `false` | `true` |
+
+**P3 findings are no longer deferrable** — fix in-PR or file a six-field escalation.
+
+**Failure mode**: "tests pass" treated as proof of correctness when only the happy path was tested.
+
+---
+
+## Principle 5 — No Lazy Verification
+
+Every criterion's evidence MUST include three completeness subsections:
+
+- **What was NOT tested** — explicit list of related behaviors not covered.
+- **Known limitations of this evidence** — how it could be misleading even though it looks positive.
+- **Negative/adversarial cases covered** — specific failure modes the system rejects.
+
+Source: `plugins/flow/skills/criterion-verification-map/SKILL.md` lines 89–106.
+
+The verdict-judge FAILs any criterion missing these subsections. Don't omit them. Write "none" if there's nothing — never blank.
+
+---
+
+## Principle 6 — No Incomplete Shipments
+
+From `plugins/flow/CHANGELOG.md` v2.0.0:
+
+- Pre-existing findings keep natural priority — no longer capped at P3.
+- Merge gate blocks when `FLOW_RESOLUTION_CYCLE` markers contain unresolved or escalated items.
+- **"DEFERRED" markers renamed to "ESCALATED"** to signal that deferral is not an option.
+
+If a finding matters enough to mention, it matters enough to act on.
+
+---
+
+<!-- _class: lead -->
+
+# Section C — The two skeletons
+
+Three-tier safety + Explore-Plan-Code-Verify. Tiers are the *consequence* of the principles; EPCV is their *shape*.
+
+---
+
+## Three-tier safety — the table
+
+```
+[ASCII]  (source: plugins/flow/references/three-tier-safety.md)
+
+┌──────────┬────────────────────────────────┬──────────────────────────────┐
+│ Tier 1   │ AUTONOMOUS                     │ Local + reversible           │
+│          │ edits, commits, branches, tests│ → Execute. Don't ask.        │
+├──────────┼────────────────────────────────┼──────────────────────────────┤
+│ Tier 2   │ JOURNAL                        │ Team-visible + recoverable   │
+│          │ push, PR create, issue assign  │ → Execute, log, move on.     │
+├──────────┼────────────────────────────────┼──────────────────────────────┤
+│ Tier 3   │ CONFIRM                        │ Hard to reverse + high blast │
+│          │ merge, release, force-push     │ → Always ask. Non-negotiable.│
+└──────────┴────────────────────────────────┴──────────────────────────────┘
+```
+
+**Promotion rule**: actions can be promoted, never demoted. Safety can never accidentally be reduced.
+
+---
+
+## Three-tier safety — by command
+
+```
+[ASCII]
+
+/flow:start ─── creates branch (T1) ─── assigns issue (T2)
+/flow:commit ── commit (T1)
+/flow:pr ────── push (T2) ─── PR create (T2) ─── parallel review (T1)
+/flow:address ─ commits (T1) ─── push (T2) ─── re-request review (T2)
+/flow:merge ─── PREREQUISITE CHECK ─── ASK USER (T3) ─── merge
+/flow:release ─ CHANGELOG ─── ASK USER (T3) ─── tag + release
+```
+
+**Important**: merge/release confirmation is in the **command** files via `AskUserQuestion`. There is no `gate-merge` or `gate-release` hook script. Hooks block force-push, destructive ops, and inline secrets at the Bash layer (`three-tier-safety.md` line 80).
+
+---
+
+## Explore — Plan — Code — Verify
+
+```
+[ASCII]
+
+┌───────────────────┐  ┌───────────────────┐  ┌───────────────────┐  ┌───────────────────┐
+│ EXPLORE           │  │ PLAN              │  │ CODE              │  │ VERIFY            │
+│                   │  │                   │  │                   │  │                   │
+│ parallel reads    │→ │ TaskCreate × N    │→ │ Per-Task Gate     │→ │ 4 layers below    │
+│ Skill(            │  │ verification      │  │ TDD red/green/    │  │ verdict-judge     │
+│ capability-       │  │ command per AC    │  │ refactor          │  │ INDEPENDENT       │
+│ discovery)        │  │ Stranger Test     │  │ commit incremental│  │                   │
+│ LSP trace         │  │ gate              │  │ journal auto-log  │  │                   │
+└───────────────────┘  └───────────────────┘  └───────────────────┘  └───────────────────┘
+```
+
+---
+
+## VERIFY — the four layers
+
+```
+[ASCII]  (source: plugins/flow/skills/autonomous-workflow/SKILL.md lines 24–28)
+
+a. STATIC      lint + test + typecheck (parallel) + LSP diagnostics
+b. RUNTIME     build + start + smoke test (debug-fix-retest, bounded)
+c. REVIEW      self-review with FIX-FORWARD (P1/P2 fixed, not just reported)
+d. VERDICT     dispatch verdict-judge agent
+                  ├─ receives: ACs + evidence bundle + holdout output
+                  └─ does NOT receive: diff, journal, planning notes, self-review
+```
+
+---
+
+## The Iron Law
+
+[QUOTE] `plugins/flow/skills/autonomous-workflow/SKILL.md` line 13:
+
+> **NO SKIPPING PHASES. Explore before Plan, Plan before Code, Code before Verify. Every phase produces an artifact.**
+
+Jumping to code without exploration is the #1 cause of rework. Jumping to "done" without verification is the #1 cause of bugs reaching review.
+
+---
+
+<!-- _class: lead -->
+
+# Section D — Vocabulary
+
+Skills, agents, commands. Different containers, different reuse profiles.
+
+---
+
+## Skills / Agents / Commands
+
+```
+[ASCII]
+
+         ┌────── COMMANDS ──────┐    "things you type"
+         │  17 entry points     │    /flow:start  /flow:pr  ...
+         │  drive workflow phase│
+         └──────┬───────────────┘
+                │ dispatches
+                ▼
+         ┌────── AGENTS ────────┐    "specialists you hire"
+         │  8 forked contexts   │    verdict-judge, security-reviewer
+         │  narrow tool budgets │    (own context, own memory none)
+         └──────┬───────────────┘
+                │ load
+                ▼
+         ┌────── SKILLS ────────┐    "playbooks Claude reads"
+         │  22 + learned/       │    autonomous-workflow,
+         │  reusable knowledge  │    criterion-verification-map, ...
+         │  iron laws + protocols│
+         └──────────────────────┘
+```
+
+---
+
+## Skill library tree
+
+```
+[ASCII]  (source: plugins/flow/README.md lines 86–112)
+
+FOUNDATION (always loaded, ≤100 lines each)
+├── evidence-based-development      ── citations, P1/P2/P3, ASSERTION/EVIDENCE/VERIFIED
+├── autonomous-workflow             ── EPCV, tiers, six-field escalation
+└── code-quality-principles         ── Boy Scout, no mocks/TODOs in prod
+
+DOMAIN (contextually invoked, max 3 concurrent)
+├── issue-crafting                  ── solution-agnostic AC drafting
+├── branch-and-task-management      ── start work, decompose ACs
+├── change-classification           ── in-context vs out-of-context commits
+├── convention-enforcement          ── git conventions per project
+├── capability-discovery            ── tech stack + LSP probing
+├── code-review-methodology         ── 2-stage review, dedup by file:line
+├── criterion-verification-map      ── eval-as-spec, evidence bundle
+├── pr-lifecycle                    ── push, PR body, comprehension narrative
+├── preflight-checks                ── pure bash gates
+├── feedback-resolution             ── address reviewer comments surgically
+├── holdout-validation              ── hidden scenarios, claim verification
+├── merge-and-release               ── Tier 3 prereq verification
+├── merge-conflict-resolution       ── classify + resolve + verify
+├── runtime-verification            ── build, run, smoke test
+├── team-coordination               ── adversarial review (opt-in)
+├── architecture-patterns           ── design-from-functionality, C4
+├── brainstorming                   ── option generation, trade-off analysis
+├── debugging-patterns              ── on any verification failure (not bug-only)
+├── tdd-patterns                    ── Red-Green-Refactor, runner discipline
+└── learned/                        ── promoted proposals from /flow:learn
+```
+
+---
+
+## The 8 agents
+
+| Agent | What it does |
+|-------|-------------|
+| **implementation-planner** | Parse ACs, decompose tasks, identify parallel work |
+| **test-runner** | Run lint/test/typecheck, return structured pass/fail |
+| **code-reviewer** | Quality + correctness, P1/P2/P3 with file:line |
+| **convention-checker** | Git conventions — commits, branches, PR format |
+| **security-reviewer** | OWASP, secrets, auth, input validation, deps |
+| **error-handler-inspector** | Unhandled errors, missing edge cases, silent failures |
+| **integration-verifier** | E2E — dev server, smoke tests, ACs at runtime |
+| **verdict-judge** | **Independent** AC evaluation — sees only ACs + evidence + holdout |
+
+---
+
+## Verdict-judge — information isolation
+
+```
+[ASCII]  (source: plugins/flow/skills/criterion-verification-map/SKILL.md lines 127–138)
+
+         INPUTS                                  NOT INPUTS
+         ──────                                  ──────────
+    ┌─ Acceptance Criteria                  ┌─ The diff
+    │  (from the issue)                     │  (no code changes)
+    │                                       │
+    ├─ Evidence Bundle                      ├─ Decision journal
+    │  (verification commands + outputs +   │  (no rationale)
+    │   completeness subsections)           │
+    │                                       ├─ Planning notes
+    └─ Holdout-validation output            │  (no approach choices)
+                                            │
+                                            ├─ Self-review findings
+                                            │  (no "I think it works")
+                                            │
+                                            └─ Memory from prior sessions
+```
+
+This is the answer to "but how does the agent know if it's right?". By limiting what the judge sees, PASS becomes a function of evidence alone.
+
+---
+
+## Holdout validation in 30 seconds
+
+The `holdout-validation` skill maintains hidden scenarios the executing agent never sees.
+
+After self-review, it cross-references the agent's claims against actual file state.
+
+> "I added a test for X" without a test that actually tests X is a P1.
+
+Behavioral verifier — grep the files, read the test assertions, check the error handlers. Skeptical, secure, fair.
+
+---
+
+## Hooks — what's actually wired
+
+```
+[ASCII]  (source: plugins/flow/hooks/hooks.json — 8 scripts)
+
+PreToolUse   Bash   block-force-push.sh         exit 2 on git push --force
+PreToolUse   Bash   block-destructive.sh        exit 2 on rm -rf, git reset --hard
+PreToolUse   Bash   block-secrets.sh            exit 2 on inline credentials
+PostToolUse  Edit   log-file-changes.sh         <!-- auto-log: ... -->
+PostToolUse  Bash   log-commits.sh              <!-- auto-log: commit ... -->
+TaskCompleted (any) verify-task-completion.sh   per-task verification gate
+TeammateIdle (any)  nudge-idle-teammate.sh      experimental, agent-teams
+SessionEnd   (any)  session-end-learn.sh        feeds learning loop
+```
+
+**Note**: `gate-merge` / `gate-release` are not wired and don't exist as scripts. Merge/release confirmation is at the **command** level via `AskUserQuestion`. README's "10 hooks" is stale; the wired count is 8.
+
+---
+
+<!-- _class: lead -->
+
+# Section E — The walkthrough
+
+20 min recorded · 4 pause beats for narration · synthetic scenario.
+
+---
+
+## Demo scenario — `--json` flag for `/sync`
+
+> **Issue**: Add `--json` flag to `/sync` command emitting structured output for CI.
+>
+> **Acceptance Criteria** (4 types in 4 lines):
+> 1. AC1 — `sync --json` exits 0 + emits JSON `{ status, items, errors }` against healthy remote
+> 2. AC2 — `sync --json` exits non-zero + emits `{ status: "error", message }` on auth failure
+> 3. AC3 — `--help` lists `--json` with description
+> 4. AC4 — non-JSON output unchanged when `--json` absent
+
+Each AC has a runnable verification command, decided **at plan time**.
+
+---
+
+## What to watch for in the recording
+
+1. **Phase 0 PRE-FLIGHT** runs as pure bash, fails fast before any LLM tokens.
+2. **Spec Validation Gate** rejecting "works correctly" — the principle in action.
+3. **Verdict-judge prompt** — see what it does NOT receive.
+4. **FLOW_RESOLUTION_CYCLE** marker — the merge gate's substrate.
+
+If only one of these lands: the verdict-judge prompt. That's where independence becomes operational.
+
+---
+
+## Pause beat 1 — eval-as-spec (after PLAN)
+
+[PAUSE 75s]
+
+We've just watched `criterion-verification-map` produce a verification command for each AC.
+
+Look at AC1's row: the command was decided **right now, at plan time**. We are not going to write the test and then claim it covers the criterion. We're committing to a check before any code is written.
+
+That's eval-as-spec.
+
+---
+
+## Pause beat 2 — independence (after VERIFY)
+
+[PAUSE 75s]
+
+Read what the judge sees: acceptance criteria, evidence bundle, holdout output. That's it.
+
+No diff. No journal. No "here's why we chose this approach."
+
+If your evidence doesn't prove the AC, the judge will say FAIL — and that's the point. The judge is independent because it can be.
+
+---
+
+## Pause beat 3 — fix or escalate (after /flow:address)
+
+[PAUSE 60s]
+
+`FLOW_RESOLUTION_CYCLE` marker — the finding-ledger.
+
+DEFERRED is gone. ESCALATED is what's left. P3 used to be a polite note you could ignore. Now it's fix in this PR or file a six-field escalation. The merge gate enforces it.
+
+---
+
+## Pause beat 4 — structural confirmation (before merge)
+
+[PAUSE 45s]
+
+Tier 3. Merge is hard to reverse — once it's on the default branch, getting it off is a revert commit visible to everyone.
+
+The plugin will not auto-merge. The hooks will not auto-merge. Even if a custom command tried, `block-force-push` and `block-destructive` catch the recovery attempt.
+
+Confirmation here is structural. The user has to say yes.
+
+---
+
+<!-- _class: lead -->
+
+# Section F — Command depth
+
+17 commands, grouped. Daily five, Tier 3, supporting, entry-point variants, rare.
+
+---
+
+## The daily five
+
+```
+[MOCKUP]
+
+/flow:start <issue>     ─── EXPLORE → PLAN → branch + tasks
+/flow:commit            ─── classify → atomic conventional commit
+/flow:pr                ─── push → parallel agent review → PR with body
+/flow:review <pr>       ─── 5-facet review (or adversarial team)
+/flow:address <pr>      ─── categorize comments → surgical fix → re-request
+```
+
+Every other command exists to *not* interrupt the daily five. If you find yourself reaching for them often, the convention defaults need tuning, not the workflow.
+
+---
+
+## `/flow:start` — Phase 0 preflight
+
+[QUOTE] `plugins/flow/commands/start.md` lines 36–62 (verbatim):
+
+```bash
+ERRORS=0
+WARNINGS=0
+
+# 1. Clean git state
+[ -n "$(git status --porcelain)" ] && echo "PREFLIGHT FAIL: Uncommitted changes" && ERRORS=$((ERRORS+1))
+
+# 2. Not detached HEAD
+git symbolic-ref HEAD >/dev/null 2>&1 || { echo "PREFLIGHT FAIL: Detached HEAD"; ERRORS=$((ERRORS+1)); }
+
+# 3. gh CLI authenticated
+gh auth status >/dev/null 2>&1 || { echo "PREFLIGHT FAIL: gh CLI not authenticated"; ERRORS=$((ERRORS+1)); }
+
+# 4. Issue exists and is open
+ISSUE_STATE=$(gh issue view $ARGUMENTS --json state --jq '.state' 2>/dev/null)
+[ "$ISSUE_STATE" != "OPEN" ] && echo "PREFLIGHT FAIL: Issue #$ARGUMENTS not found or not open (state: ${ISSUE_STATE:-not found})" && ERRORS=$((ERRORS+1))
+
+# 5. Remote accessible
+git ls-remote --exit-code origin >/dev/null 2>&1 || { echo "PREFLIGHT FAIL: Cannot reach remote 'origin'"; ERRORS=$((ERRORS+1)); }
+
+# 6. Already on feature branch (warning only)
+git branch --show-current | grep -q "issue-$ARGUMENTS" && echo "PREFLIGHT WARN: Already on branch for issue #$ARGUMENTS" && WARNINGS=$((WARNINGS+1))
+
+echo "PREFLIGHT: $ERRORS error(s), $WARNINGS warning(s)"
+[ $ERRORS -gt 0 ] && echo "PREFLIGHT: BLOCKED" && exit 1
+echo "PREFLIGHT: PASSED"
+```
+
+Pure bash. No LLM calls. Fails fast before spending tokens.
+
+---
+
+## `/flow:pr` — parallel review
+
+```
+[MOCKUP]
+
+push (T2)
+   ↓
+parallel agent fan-out:
+   ├── code-reviewer         (quality + correctness)
+   ├── security-reviewer     (OWASP, secrets, auth)
+   ├── convention-checker    (commit format, branch, PR shape)
+   ├── error-handler-inspector  (unhandled, silent failures)
+   ├── integration-verifier  (E2E smoke)
+   └── holdout-validation    (claim verification)
+   ↓
+findings deduplicated by file:line, sorted P1 → P3
+   ↓
+PR body assembled (templates/pr-body.md)
+   ↓
+public journal entries → comprehension report
+```
+
+---
+
+## Supporting three
+
+| Command | Purpose | When to reach for it |
+|---------|---------|---------------------|
+| **`/flow:status`** | Read-only workflow overview — assigned issues, open PRs, branch state, journal health | Mondays. After lunch. Whenever you've context-switched. |
+| **`/flow:explain`** | Q&A about decisions on the current branch/issue, loads journal + diff | "Why did we do it this way?" |
+| **`/flow:learn`** | Analyze the journal for patterns, generate skill proposals | Quarterly. After a project ships. After 10+ issues with similar mistakes. |
+
+---
+
+## Entry-point variants
+
+| Command | Use when |
+|---------|---------|
+| **`/flow:issue`** | Filing a new issue. Solution-agnostic AC drafting, duplicate detection, label discovery. Spec Validation Gate fires here. |
+| **`/flow:brainstorm`** | Before committing to an approach. Multiple options + trade-off analysis. |
+| **`/flow:debug`** | A bug report you can't reproduce yet. Structured root-cause analysis. |
+| **`/flow:design`** | A feature where the architecture matters. C4 thinking, coupling analysis. |
+
+These shape work *before* the daily five. They prevent the daily five from being applied to ill-formed inputs.
+
+---
+
+## Rare / bootstrap
+
+| Command | When |
+|---------|------|
+| **`/flow:setup`** | Once per repo. Detect tech stack, generate `.claude/settings.flow.json`, configure LSP, optionally add CLAUDE.md sections, warn about plugin coexistence. |
+| **`/flow:resolve`** | Merge conflicts on a branch or PR. Detect conflict type, classify, per-file strategy, post-resolution verification. |
+| **`/flow:flow`** | Universal dispatcher — `/flow <verb> <target>`. Useful in scripts; humans should type the specific verb. |
+
+---
+
+<!-- _class: lead -->
+
+# Section G — Conventions vote
+
+10 decisions. 90 sec each. Worksheet on screen — we don't advance past a row until it has an answer.
+
+---
+
+## Why these are team decisions
+
+Defaults in `plugins/flow/settings.json` are deliberately strict (Excellence Principle 4). But strict-by-default only works if the team has consciously chosen to live with strict.
+
+Cascading override locations:
+
+1. `plugins/flow/settings.json` — plugin defaults
+2. `~/.claude/settings.flow.json` — user global
+3. `.claude/settings.flow.json` — **project shared (committed)** ← we'll write to this
+4. `.claude/settings.flow.local.json` — project local (gitignored)
+
+If you vote anything non-default, that vote lands in #3 as part of the post-session PR.
+
+---
+
+## Decision 1 — TDD mode
+
+**Default**: `enforce`
+
+**Options**: `enforce` (test-first required, RED-GREEN-REFACTOR observed) | `suggest` (test-first encouraged, not gated)
+
+**Lands in**: `settings.flow.json` → `testing.tddMode`
+
+**Forcing question**: do we want the Per-Task Verification Gate to block merge on missing tests?
+
+---
+
+## Decision 2 — Verdict requires all pass
+
+**Default**: `true`
+
+**Options**: `true` (all ACs must PASS for verdict to be PASS) | `false` (PR can proceed with FAIL/NEEDS-HUMAN-REVIEW criteria)
+
+**Lands in**: `settings.flow.json` → `verdict.requireAllPass`
+
+**Forcing question**: do we trust the judge to fail us when we deserve it?
+
+---
+
+## Decision 3 — Agent teams (adversarial review)
+
+**Default**: `false` (off)
+
+**Options**: `false` | `true` (requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` env var)
+
+**Lands in**: `settings.flow.json` → `agentTeams` + env
+
+**Forcing question**: do we want `/flow:review` to spawn an adversarial team where reviewers challenge each other's findings? Higher signal, higher cost.
+
+---
+
+## Decision 4 — Branch naming patterns
+
+**Default**: `feature/issue-{N}-{desc}`, `fix/issue-{N}-{desc}`, `docs/issue-{N}-{desc}`
+
+**Options**: keep defaults | adjust prefixes (e.g. `feat/`, `bugfix/`) | add new categories
+
+**Lands in**: `settings.flow.json` → `conventions.branchPatterns`
+
+---
+
+## Decision 5 — Commit type vocabulary
+
+**Default** (12 types from `plugins/flow/settings.json` line 18):
+
+`feat, fix, docs, style, refactor, test, chore, perf, ci, build, revert, improve`
+
+**Options**: keep all 12 | drop ones we won't use | add team-specific types
+
+**Lands in**: `settings.flow.json` → `conventions.commitTypes`
+
+---
+
+## Decision 6 — Journal sensitivity default
+
+**Default**: `public` (entries go into PR bodies)
+
+**Options**: `public` (transparent default) | `internal` (redacted by default, must opt-in to public)
+
+**Lands in**: `settings.flow.json` → `journal.sensitivityDefault`
+
+**Forcing question**: do we want PR bodies to expose decision rationale by default, or hide it by default?
+
+---
+
+## Decision 7 — Tier overrides
+
+**Defaults**: push=journal, prCreate=journal, issueAssign=journal, issueCreate=journal, merge=confirm, release=confirm
+
+**Options**: keep defaults | promote any to `confirm` (more friction, more safety)
+
+**Reminder**: tiers can be promoted, never demoted. Once `merge: confirm` is set, you can't go back to autonomous.
+
+**Lands in**: `settings.flow.json` → `tiers`
+
+---
+
+## Decision 8 — Spec-free label list
+
+**Default**: `["documentation", "chore"]` — issues with these labels can skip the AC requirement
+
+**Options**: keep defaults | add labels (e.g. `dependency-bump`) | remove (force AC for everything)
+
+**Lands in**: `settings.flow.json` → `specFirst.allowSpecFreeLabels`
+
+---
+
+## Decision 9 — Reviewer routing (policy)
+
+**Default**: n/a — this is policy, not config.
+
+**Options**: round-robin | by area (frontend/backend/infra) | by author preference | least-recently-reviewed
+
+**Lands in**: `CONVENTIONS-DECIDED.md` (policy section). The plugin doesn't enforce — humans do.
+
+---
+
+## Decision 10 — Learning-loop cadence (policy)
+
+**Default**: n/a — this is policy.
+
+**Options**: who runs `/flow:learn` and how often? who triages `~/.claude/flow-proposals/`? who promotes to `skills/learned/`?
+
+**Lands in**: `CONVENTIONS-DECIDED.md` (policy section).
+
+**Suggestion**: monthly cadence, rotating owner. A proposal that nobody triages is a missed pattern.
+
+---
+
+<!-- _class: lead -->
+
+# Section H — Hands-on
+
+Everyone runs `/flow:setup` and `/flow:status` now. Five minutes. We don't move on until everyone has a green status.
+
+---
+
+## `/flow:setup` — what to expect
+
+```
+[MOCKUP]
+
+> /flow:setup
+flow: detecting tech stack...
+  • language: TypeScript (tsconfig.json found)
+  • test runner: jest (package.json scripts.test)
+  • lint: eslint (eslint.config.js)
+  • type check: tsc --noEmit
+flow: LSP servers available — typescript-language-server (auto-configured)
+flow: writing .claude/settings.flow.json with detected commands
+flow: warning — gh-workflow plugin also installed; commands coexist, see HANDBOOK §12
+flow: setup complete. Try /flow:status next.
+```
+
+Re-run is idempotent. Won't overwrite an existing settings.flow.json without confirmation.
+
+---
+
+## `/flow:status` — what to expect
+
+```
+[MOCKUP]
+
+> /flow:status
+ASSIGNED ISSUES
+  #142  Add JSON output to /sync command           [feature/issue-142-...]
+  #156  Investigate flaky session test             [unassigned branch]
+
+OPEN PRS (mine)
+  #43   feat: rate-limit middleware     ✅ approved · checks ✓ · ready to merge
+
+PENDING REVIEWS
+  #44   ⏳ requested 6 hours ago
+
+JOURNAL HEALTH
+  .decisions/issue-142.md  — 12 entries, last 14:32 (1h ago)
+  ~/.claude/flow-proposals/ — 3 unreviewed proposals
+```
+
+Read-only. Safe to run anywhere, anytime.
+
+---
+
+## Common gotchas
+
+1. **`gh` CLI not authenticated** — preflight fails. Fix: `gh auth login`.
+2. **Dirty worktree on `/flow:start`** — preflight fails. Fix: stash or commit before starting.
+3. **No `CLAUDE.md`** — `/flow:setup` will offer to add a `CLAUDE-flow.md` section. Accept it or compose your own.
+4. **`block-force-push` blocks a legitimate rebase push** — use `--force-with-lease`. Allowed and journaled (`three-tier-safety.md` line 41).
+5. **Auto-log seems to duplicate commits** — make sure `plugin.json` shows `2.0.1`. The fix landed in v2.0.1.
+
+---
+
+## Where to look when broken
+
+| Symptom | First place to look |
+|---------|--------------------|
+| Plan got blocked | `.decisions/issue-N.md` — search "Stranger Test" or "Spec Validation" |
+| Verdict FAIL but code works | Evidence bundle — missing completeness subsection? |
+| Hooks aren't firing | `~/.claude/logs/` for hook stderr |
+| `/flow:learn` empty | `learning.enabled`? `journal.dir` populated? |
+| Agent teams not spawning | Both `agentTeams: true` AND `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` env var |
+| Tier 3 prompt missing | `tiers.merge` / `tiers.release` in your settings cascade |
+
+When in doubt, `/flow:status` first, then `~/.claude/logs/`.
+
+---
+
+<!-- _class: lead -->
+
+# Section I — Close
+
+Monday checklist · the docs · glossary · Q&A.
+
+---
+
+## Monday checklist
+
+- [ ] Pull this branch — `docs/flow-team-session/` is now in the repo.
+- [ ] Read `HANDBOOK.md` cover to cover (15 min). Bookmark it.
+- [ ] Read `CHEATSHEET.md` (1 page). Print it if that helps.
+- [ ] Confirm `/flow:status` works in your daily repo.
+- [ ] Pick one in-flight issue and run `/flow:start` against it. Write down what surprises you.
+- [ ] If you voted non-default conventions, the follow-up PR will land Wednesday. Review it.
+
+---
+
+## The eight docs
+
+| File | Use it when |
+|------|-------------|
+| `README.md` (this folder) | Onboarding new teammates — start here |
+| `slides.md` | This deck — re-skim sections you missed |
+| `HANDBOOK.md` | Something doesn't make sense; deep reference |
+| `CHEATSHEET.md` | Daily — pin to the wall |
+| `CONVENTIONS-WORKSHEET.md` | The session — fillable template |
+| `CONVENTIONS-DECIDED.md` | Source of truth for our `.claude/settings.flow.json` overrides |
+| `walkthrough-script.md` | Re-recording the demo or running an offshoot session |
+| `faq-and-glossary.md` | "What does ESCALATED mean again?" |
+
+---
+
+## File confusion → file an issue
+
+Confusion is a finding. If something in the docs reads as bureaucracy, it's miscalibrated — file an issue with `documentation` label.
+
+Specifically log:
+
+- A slide that needed extra explanation we didn't anticipate.
+- A convention we voted on that turns out to be wrong in practice.
+- A skill that activates when it shouldn't (or doesn't when it should).
+- A failure mode that wasn't in §11 of the handbook.
+
+The plugin gets better when we tell it where it failed.
+
+---
+
+## Migrating from gh-workflow
+
+Both plugins coexist at the marketplace level. `/flow:setup` warns when both are installed.
+
+Verb mapping:
+
+| gh-workflow | flow | Notes |
+|-------------|------|-------|
+| `/gh-start` | `/flow:start` | flow has Phase 0 preflight + Spec Validation Gate |
+| `/gh-commit` | `/flow:commit` | same vocabulary, different autonomy |
+| `/gh-pr` | `/flow:pr` | flow runs parallel agent review |
+| `/gh-review` | `/flow:review` | flow supports adversarial teams (opt-in) |
+| `/gh-merge` | `/flow:merge` | both Tier 3 |
+
+If you preferred gh-workflow's interactive style: opt out of strict defaults (HANDBOOK §12). Don't fight the plugin — configure it.
+
+---
+
+## Glossary
+
+- **P1 / P2 / P3** — finding priority. P1 blocks merge; P2 fix-in-PR; P3 fix-or-escalate.
+- **ESCALATED** — was "DEFERRED" pre-v2.0. Means: a P3 escalated via the six-field structure, not silently dropped.
+- **FLOW_RESOLUTION_CYCLE** — marker in PR comments capturing per-cycle resolved + escalated findings. The merge gate's substrate.
+- **Holdout** — a hidden test scenario the executing agent never sees. Used by `holdout-validation` to verify self-review claims.
+- **Stranger Test** — the gate at end of PLAN. Plan must be executable by someone with zero prior context.
+- **Six-field escalation** — Situation / Tried / Options / Recommendation / Time sensitivity / Risk. Mandatory shape for every escalation.
+- **Eval-as-spec** — acceptance criteria are eval sources. Each AC produces a runnable verification command at plan time.
+
+---
+
+## Q&A — seed questions
+
+We expect at least one of these. If not, we'll seed it.
+
+- "Can we keep using gh-workflow for legacy repos?" — yes, they coexist. See HANDBOOK §12.
+- "What if `/flow:setup` doesn't detect our build?" — file an issue with the project's `package.json` / `pyproject.toml`. Setup is heuristic.
+- "What if I disagree with a P3?" — rewrite it as a six-field escalation in the PR. Reviewer accepts/rejects.
+- "Can we customize the verdict-judge?" — no. Independence is the feature, not a constraint.
+- "What if the recording's demo repo isn't representative?" — that's deliberate (synthetic, not real). The lifecycle is the point, not the language.
+
+---
+
+<!-- _class: lead -->
+<!-- _paginate: false -->
+
+# Thanks
+
+Plugin source: `plugins/flow/`
+Workshop docs: `docs/flow-team-session/`
+File confusion: GitHub issues, `documentation` label.
+
+Now: open a terminal, run `/flow:setup`. Then `/flow:status`. Five minutes.

--- a/docs/flow-team-session/slides.md
+++ b/docs/flow-team-session/slides.md
@@ -19,7 +19,7 @@ style: |
 
 # Flow Plugin Team Workshop
 
-A 90-min walkthrough of `/flow` v2.0.1 — for engineers, PMs, and designers.
+A 90-min walkthrough of the `/flow` plugin — for engineers, PMs, and designers.
 
 By the end of this session: you'll share a mental model, you'll have voted on 10 conventions, and you'll have the plugin running.
 
@@ -115,14 +115,14 @@ The six-field escalation template (`plugins/flow/skills/autonomous-workflow/SKIL
 
 ## Principle 4 — Quality > Speed
 
-Strict defaults (`plugins/flow/README.md` lines 35–39):
+Strict defaults (source: `plugins/flow/settings.json`):
 
-| Setting | Old Default | New Default |
-|---------|-------------|-------------|
-| `testing.tddMode` | `"suggest"` | `"enforce"` |
-| `verdict.requireAllPass` | `false` | `true` |
+| Setting | Default | Why |
+|---------|---------|-----|
+| `testing.tddMode` | `"enforce"` | Catches test-first violations at write-time, which is cheaper than catching them at review-time. RED-GREEN-REFACTOR is observed before a task can complete. |
+| `verdict.requireAllPass` | `true` | The judge must return PASS for every acceptance criterion or the verdict is FAIL. Partial coverage is a FAIL, not a "mostly done." |
 
-**P3 findings are no longer deferrable** — fix in-PR or file a six-field escalation.
+**P3 findings are fix-or-escalate** — fix in this PR or file a six-field escalation. They are not a polite note you can ignore.
 
 **Failure mode**: "tests pass" treated as proof of correctness when only the happy path was tested.
 
@@ -144,11 +144,11 @@ The verdict-judge FAILs any criterion missing these subsections. Don't omit them
 
 ## Principle 6 — No Incomplete Shipments
 
-From `plugins/flow/CHANGELOG.md` v2.0.0:
+Three rules hold the line (source: `plugins/flow/README.md` lines 29–31):
 
-- Pre-existing findings keep natural priority — no longer capped at P3.
-- Merge gate blocks when `FLOW_RESOLUTION_CYCLE` markers contain unresolved or escalated items.
-- **"DEFERRED" markers renamed to "ESCALATED"** to signal that deferral is not an option.
+- Pre-existing findings in touched files keep their natural priority — they are not capped at P3 just because they were already there.
+- The merge gate blocks when `FLOW_RESOLUTION_CYCLE` markers contain unresolved or escalated items.
+- The lifecycle uses **ESCALATED** (not "deferred"). The word choice is the policy: a P3 either gets fixed in this PR or it gets escalated through the six-field structure. Silent deferral is not an option.
 
 If a finding matters enough to mention, it matters enough to act on.
 
@@ -196,7 +196,7 @@ Three-tier safety + Explore-Plan-Code-Verify. Tiers are the *consequence* of the
 /flow:release ─ CHANGELOG ─── ASK USER (T3) ─── tag + release
 ```
 
-**Important**: merge/release confirmation is in the **command** files via `AskUserQuestion`. There is no `gate-merge` or `gate-release` hook script. Hooks block force-push, destructive ops, and inline secrets at the Bash layer (`three-tier-safety.md` line 80).
+**Important**: merge/release confirmation is in the **command** files via `AskUserQuestion`. There is no `gate-merge` or `gate-release` hook script — Tier 3 confirmation is a structural prompt at command time, not a hook. Hooks block force-push, destructive ops, and inline secrets at the Bash layer (`three-tier-safety.md` line 80).
 
 ---
 
@@ -258,22 +258,25 @@ Skills, agents, commands. Different containers, different reuse profiles.
 
          ┌────── COMMANDS ──────┐    "things you type"
          │  17 entry points     │    /flow:start  /flow:pr  ...
-         │  drive workflow phase│
+         │  carry executable    │    bash blocks live here, not in skills
+         │  bash + workflow     │
          └──────┬───────────────┘
                 │ dispatches
                 ▼
          ┌────── AGENTS ────────┐    "specialists you hire"
          │  8 forked contexts   │    verdict-judge, security-reviewer
-         │  narrow tool budgets │    (own context, own memory none)
+         │  narrow tool budgets │    (own context, memory: none)
          └──────┬───────────────┘
                 │ load
                 ▼
-         ┌────── SKILLS ────────┐    "playbooks Claude reads"
+         ┌────── SKILLS ────────┐    "reference docs Claude reads"
          │  22 + learned/       │    autonomous-workflow,
-         │  reusable knowledge  │    criterion-verification-map, ...
-         │  iron laws + protocols│
+         │  policy + philosophy │    criterion-verification-map, ...
+         │  iron laws + rationale│
          └──────────────────────┘
 ```
+
+**Design choice**: skills are reference documents — they encode policy, philosophy, and rationale that compounds across sessions. Commands carry the executable bash that runs at workflow time. Keeping these separate means a skill can be re-read by a new command without forking logic, and a command can change its bash without rewriting team knowledge (`plugins/flow/README.md` line 3).
 
 ---
 
@@ -380,7 +383,7 @@ TeammateIdle (any)  nudge-idle-teammate.sh      experimental, agent-teams
 SessionEnd   (any)  session-end-learn.sh        feeds learning loop
 ```
 
-**Note**: `gate-merge` / `gate-release` are not wired and don't exist as scripts. Merge/release confirmation is at the **command** level via `AskUserQuestion` (`plugins/flow/README.md` lines 138–139). README's HOOKS box correctly counts 8 scripts and matches `hooks.json`.
+**Note**: `gate-merge` / `gate-release` are not hook scripts. Merge and release confirmation runs at the **command** level via `AskUserQuestion` (`plugins/flow/README.md` lines 138–139). The hook layer (Bash exit-2 blocks) catches the dangerous primitives — `git push --force`, `rm -rf`, inline credentials — that any recovery attempt would have to use.
 
 ---
 
@@ -447,7 +450,7 @@ If your evidence doesn't prove the AC, the judge will say FAIL — and that's th
 
 `FLOW_RESOLUTION_CYCLE` marker — the finding-ledger.
 
-DEFERRED is gone. ESCALATED is what's left. P3 used to be a polite note you could ignore. Now it's fix in this PR or file a six-field escalation. The merge gate enforces it.
+The lifecycle has two states for a P3: **resolved** or **escalated**. Both are auditable; neither is silent. Escalation means the engineer wrote the six-field structure into the PR comment and the reviewer accepted it. The merge gate reads this marker — unresolved or unaccompanied items block merge.
 
 ---
 
@@ -489,7 +492,7 @@ Every other command exists to *not* interrupt the daily five. If you find yourse
 
 ## `/flow:start` — Phase 0 preflight
 
-[QUOTE] `plugins/flow/commands/start.md` lines 36–62 (verbatim):
+[QUOTE] `plugins/flow/commands/start.md` lines 38–62 (verbatim):
 
 ```bash
 ERRORS=0
@@ -800,7 +803,7 @@ Read-only. Safe to run anywhere, anytime. The "Suggested Next Action" line picks
 2. **Dirty worktree on `/flow:start`** — preflight fails. Fix: stash or commit before starting.
 3. **No `CLAUDE.md`** — `/flow:setup` will offer to add a `CLAUDE-flow.md` section. Accept it or compose your own.
 4. **`block-force-push` blocks a legitimate rebase push** — use `--force-with-lease`. Allowed and journaled (`three-tier-safety.md` line 41).
-5. **Auto-log seems to duplicate commits** — make sure `plugin.json` shows `2.0.1`. The fix landed in v2.0.1.
+5. **Auto-log seems to duplicate commits** — `log-commits.sh` is idempotent: it skips lines that already carry the `auto-log` marker. If you see duplication, your `plugin.json` is out of date — `claude plugins update flow`.
 
 ---
 
@@ -889,7 +892,7 @@ If you preferred gh-workflow's interactive style: opt out of strict defaults (HA
 ## Glossary
 
 - **P1 / P2 / P3** — finding priority. P1 blocks merge; P2 fix-in-PR; P3 fix-or-escalate.
-- **ESCALATED** — was "DEFERRED" pre-v2.0. Means: a P3 escalated via the six-field structure, not silently dropped.
+- **ESCALATED** — a P3 escalated via the six-field structure into `FLOW_RESOLUTION_CYCLE`. Auditable; not silently dropped.
 - **FLOW_RESOLUTION_CYCLE** — marker in PR comments capturing per-cycle resolved + escalated findings. The merge gate's substrate.
 - **Holdout** — a hidden test scenario the executing agent never sees. Used by `holdout-validation` to verify self-review claims.
 - **Stranger Test** — the gate at end of PLAN. Plan must be executable by someone with zero prior context.

--- a/docs/flow-team-session/slides.md
+++ b/docs/flow-team-session/slides.md
@@ -218,6 +218,19 @@ Three-tier safety + Explore-Plan-Code-Verify. Tiers are the *consequence* of the
 
 ---
 
+## What each phase leaves behind
+
+| Phase | Artifact you can open afterwards |
+|-------|----------------------------------|
+| **EXPLORE** | `.decisions/issue-N.md` with `## Specification` (non-goals, failure modes, contracts) + Spec Validation Gate mapping each AC to a verification command |
+| **PLAN** | Atomic TaskList (impl + test + verify cmd + expected evidence per task) + feature branch + Stranger Test result in the journal |
+| **CODE** | Per-task commits (impl + test + captured evidence) + `<!-- auto-log: ... -->` journal entries + Per-Task Gate satisfied per task |
+| **VERIFY** | Evidence bundle (per-AC: `Does NOT promise` + 3 completeness subsections) + holdout output + verdict-judge PASS/FAIL/NEEDS-HUMAN-REVIEW |
+
+Sources: `autonomous-workflow/SKILL.md`, `criterion-verification-map/SKILL.md`, `commands/start.md`.
+
+---
+
 ## VERIFY — the four layers
 
 ```
@@ -482,7 +495,7 @@ Confirmation here is structural. The user has to say yes.
 /flow:start <issue>     ─── EXPLORE → PLAN → branch + tasks
 /flow:commit            ─── classify → atomic conventional commit
 /flow:pr                ─── push → parallel agent review → PR with body
-/flow:review <pr>       ─── 5-facet review (or adversarial team)
+/flow:review <pr>       ─── 6-facet parallel review (or adversarial team)
 /flow:address <pr>      ─── categorize comments → surgical fix → re-request
 ```
 
@@ -738,7 +751,7 @@ Phase 1 — detecting environment...
   • language: TypeScript (tsconfig.json found)
   • test/lint/typecheck: jest, eslint, tsc --noEmit
   • CLAUDE.md: present
-  • gh-workflow plugin also installed (commands coexist; see HANDBOOK §12)
+  • gh-workflow plugin also installed (commands coexist; see HANDBOOK Appendix A)
 
 Phase 2 — generating .claude/settings.flow.json (merge with existing if present)
 
@@ -885,7 +898,7 @@ Verb mapping:
 | `/gh-review` | `/flow:review` | flow supports adversarial teams (opt-in) |
 | `/gh-merge` | `/flow:merge` | both Tier 3 |
 
-If you preferred gh-workflow's interactive style: opt out of strict defaults (HANDBOOK §12). Don't fight the plugin — configure it.
+If you preferred gh-workflow's interactive style: opt out of strict defaults (HANDBOOK Appendix A). Don't fight the plugin — configure it.
 
 ---
 
@@ -905,7 +918,7 @@ If you preferred gh-workflow's interactive style: opt out of strict defaults (HA
 
 We expect at least one of these. If not, we'll seed it.
 
-- "Can we keep using gh-workflow for legacy repos?" — yes, they coexist. See HANDBOOK §12.
+- "Can we keep using gh-workflow for legacy repos?" — yes, they coexist. See HANDBOOK Appendix A.
 - "What if `/flow:setup` doesn't detect our build?" — file an issue with the project's `package.json` / `pyproject.toml`. Setup is heuristic.
 - "What if I disagree with a P3?" — rewrite it as a six-field escalation in the PR. Reviewer accepts/rejects.
 - "Can we customize the verdict-judge?" — no. Independence is the feature, not a constraint.

--- a/docs/flow-team-session/slides.md
+++ b/docs/flow-team-session/slides.md
@@ -330,7 +330,7 @@ DOMAIN (contextually invoked, max 3 concurrent)
 ## Verdict-judge — information isolation
 
 ```
-[ASCII]  (source: plugins/flow/skills/criterion-verification-map/SKILL.md lines 127–138)
+[ASCII]  (source: plugins/flow/skills/criterion-verification-map/SKILL.md lines 127–139)
 
          INPUTS                                  NOT INPUTS
          ──────                                  ──────────
@@ -380,7 +380,7 @@ TeammateIdle (any)  nudge-idle-teammate.sh      experimental, agent-teams
 SessionEnd   (any)  session-end-learn.sh        feeds learning loop
 ```
 
-**Note**: `gate-merge` / `gate-release` are not wired and don't exist as scripts. Merge/release confirmation is at the **command** level via `AskUserQuestion`. README's "10 hooks" is stale; the wired count is 8.
+**Note**: `gate-merge` / `gate-release` are not wired and don't exist as scripts. Merge/release confirmation is at the **command** level via `AskUserQuestion` (`plugins/flow/README.md` lines 138–139). README's HOOKS box correctly counts 8 scripts and matches `hooks.json`.
 
 ---
 

--- a/docs/flow-team-session/walkthrough-script.md
+++ b/docs/flow-team-session/walkthrough-script.md
@@ -1,0 +1,186 @@
+# Walkthrough Script — Flow Plugin 90-min Workshop
+
+**Format**: pre-recorded asciinema (terminal) + screen capture (GitHub PR view), composited to ≤20 minutes. Live narration during the 25-min slot. **No voiceover on the recording** — the room can interrupt at pause beats.
+
+**Recording path**: `docs/flow-team-session/recordings/flow-walkthrough.cast` + `flow-walkthrough-pr.mp4`. Composite output at `flow-walkthrough.mp4`.
+
+---
+
+## Scenario
+
+A synthetic issue against a fictional `sync-cli` repo. Nothing in the recording references the team's real codebase — that's deliberate, so the lifecycle stays visible and nobody drags the demo into a tangent.
+
+> **Issue title**: Add `--json` flag to `/sync` command emitting structured output for CI.
+>
+> **Body** (uses `plugins/flow/templates/issue-body.md` structure):
+>
+> **Context**: CI consumers want to gate deploys on sync results. Today they parse human-readable output, which breaks every time the message text changes.
+>
+> **Current State**: `sync` prints status lines like `Synced 3 items, 0 errors` to stdout and exits 0 on success.
+>
+> **Objective**: A machine-readable output mode that downstream tools can rely on without parsing prose.
+>
+> **Acceptance Criteria**
+> - [ ] AC1: `sync --json` exits 0 and emits valid JSON with keys `{ status, items, errors }` against a healthy remote.
+> - [ ] AC2: `sync --json` exits non-zero and emits `{ status: "error", message }` JSON on auth failure.
+> - [ ] AC3: `sync --help` lists `--json` with its description.
+> - [ ] AC4: Existing non-JSON output unchanged when `--json` is absent.
+
+The four criteria deliberately span four verification types from `criterion-verification-map/SKILL.md`: behavioral (AC1), error handling (AC2), contract (AC3), regression/behavioral (AC4).
+
+## Recording shotlist
+
+Total target: **19:30**. Hard cap: **20:00**.
+
+| Phase | Command | Recorded | Cumulative | Cut order |
+|-------|---------|----------|------------|-----------|
+| A | `/flow:issue` | 2:30 | 2:30 | **Cut first** if slot is tight (use a pre-existing issue) |
+| B | `/flow:start` | 4:00 | 6:30 | NEVER cut |
+| C | CODE (TDD cycle) | 3:00 | 9:30 | NEVER cut |
+| D | VERIFY | 4:00 | 13:30 | NEVER cut |
+| E | `/flow:pr` | 2:30 | 16:00 | Cut to static screenshot if slot is tight |
+| F | `/flow:address` | 2:30 | 18:30 | Keep |
+| G | `/flow:merge` | 1:30 | 20:00 | NEVER cut |
+
+### Phase A — `/flow:issue` (00:00–02:30)
+
+What to show:
+
+- 00:00 — Type `/flow:issue Add --json flag to sync command`.
+- 00:20 — Duplicate detection: agent searches existing issues, finds none.
+- 00:40 — Label discovery: lists candidate labels (`enhancement`, `cli`).
+- 01:00 — First-pass acceptance criteria draft includes "works correctly" — **Spec Validation Gate fires**, blocks. Show the rejection message.
+- 01:20 — Re-draft with concrete criteria (AC1–AC4 above).
+- 01:50 — Issue created. Visible URL.
+- 02:10 — `gh issue view N` showing the body matches `plugins/flow/templates/issue-body.md`.
+
+**Why this matters for narration**: this is where Excellence Principle #2 (Spec-as-Eval) bites. The room sees the gate reject "works correctly" before they hear the principle.
+
+### Phase B — `/flow:start <issue-N>` (02:30–06:30)
+
+- 02:30 — Phase 0 PRE-FLIGHT bash block runs (the exact one quoted on slide 33, from `plugins/flow/commands/start.md` lines 36–62). Show clean `PREFLIGHT: PASSED`.
+- 03:00 — EXPLORE: parallel `gh issue view`, `gh issue ... comments`, `git status`, `Skill(capability-discovery)`. Output stacks fast — let it scroll.
+- 03:40 — PLAN: `Skill(criterion-verification-map)` produces, for each AC, a `Verification command` and an `Expected evidence` shape. Highlight one row on screen.
+- 04:30 — TaskCreate × 4 (one per criterion). TaskList renders.
+- 05:00 — Stranger Test gate runs against the plan output. Passes.
+- 05:30 — Branch created (`feature/issue-N-sync-json-flag`), journal initialized at `.decisions/issue-N.md`.
+- 06:00 — TaskUpdate(in_progress) on the first task. Buffer.
+
+**Pause beat 1** (live narration, ~75 sec): scroll back to the criterion verification map. Read AC1's verification command aloud. "This command was decided right now, at plan time. We're not going to write the test and then claim it covers the criterion — we're committing to a check before any code is written. That's eval-as-spec."
+
+### Phase C — CODE / TDD cycle (06:30–09:30)
+
+- 06:30 — RED: write failing test for AC1 (JSON shape on healthy sync). Run it, watch it fail. Output is on screen.
+- 07:15 — GREEN: minimal `--json` output emission in `cmd/sync.go`. Run test, passes.
+- 08:00 — REFACTOR: extract a small `formatJSON` helper. Tests still pass.
+- 08:30 — Commit. PostToolUse log-commits hook fires, journal entry appears.
+- 08:50 — Show `cat .decisions/issue-N.md` — auto-log entry visible.
+- 09:10 — Repeat the loop in 20 seconds for AC2 (error JSON). Just show the commit log, not the full cycle.
+
+**No pause beat here** — keep momentum. The TDD principle was set in section 1; this is the proof.
+
+### Phase D — VERIFY (09:30–13:30)
+
+All four layers from `autonomous-workflow/SKILL.md` lines 24–28.
+
+- 09:30 — **Static**: `Skill(test-runner)` dispatches lint + test + typecheck in parallel. All green.
+- 10:15 — **Runtime**: `runtime-verification` skill builds the binary, runs `./sync --json` against a stub server, captures output. Show the JSON on screen.
+- 11:00 — **Review**: self-review with fix-forward. The agent finds **one P2** — a missing test for AC4 (regression case). It fixes it inline, doesn't escalate.
+- 11:45 — **Verdict**: `Agent(verdict-judge)` dispatched. Show the prompt construction — the agent sees only the AC list and the evidence bundle. Show that the diff and journal are NOT in the prompt.
+- 12:30 — Verdict-judge returns: AC1 PASS, AC2 PASS, AC3 PASS, AC4 PASS. Per-criterion evidence summarized.
+- 13:15 — Self-review summary uses `plugins/flow/templates/self-review-comment.md` format.
+
+**Pause beat 2** (live narration, ~75 sec): pause on the verdict-judge prompt. Point at the black box around it. "Read what the judge sees. Acceptance criteria. Evidence bundle. That's it. No diff. No journal. No 'here's why we chose this approach.' If your evidence doesn't prove the AC, the judge will say FAIL — and that's the point. The judge is independent because it can be."
+
+### Phase E — `/flow:pr` (13:30–16:00)
+
+- 13:30 — `/flow:pr`. Push happens (Tier 2 — journal entry, no prompt).
+- 13:50 — Parallel agent fan-out: `code-reviewer`, `security-reviewer`, `convention-checker`, `error-handler-inspector`, `integration-verifier`, plus a re-run of `holdout-validation`.
+- 14:30 — Agents return. Findings table renders, sorted P1 → P2 → P3.
+- 15:00 — One P3 surfaces: "missing example in README." Agent fixes inline (P3 fix-or-escalate — Excellence Principle #6).
+- 15:30 — PR body assembled from `plugins/flow/templates/pr-body.md` + public journal entries. URL visible.
+
+**Cut option**: if slot is tight, replace 13:30–16:00 with a single screenshot of the assembled PR body. Recording drops to 16:30 cumulative.
+
+### Phase F — `/flow:address` (16:00–18:30)
+
+A reviewer (a second persona, off-screen) drops two comments:
+- Comment 1: "What if the server returns a 5xx? Should that emit `{status: 'error'}` too?" (P1 — gap in AC2 coverage)
+- Comment 2: "Consider naming the helper `marshalSyncResult` to match other helpers." (P2 — convention)
+
+- 16:00 — `/flow:address`. Categorizes both comments.
+- 16:30 — Surgical fix for P1: add 5xx branch + test. Commit.
+- 17:15 — P2: rename helper, update callers. Commit.
+- 17:50 — `feedback-resolution` skill drafts a re-review request comment.
+- 18:15 — Reviewer is re-requested. FLOW_RESOLUTION_CYCLE marker visible in the PR body.
+
+**Pause beat 3** (live narration, ~60 sec): pause on the FLOW_RESOLUTION_CYCLE marker. Open `plugins/flow/CHANGELOG.md` v2.0.0 in a side window. "DEFERRED is gone. ESCALATED is what's left. P3 used to be a polite note you could ignore. Now it's fix in this PR or file a six-field escalation. The merge gate enforces it."
+
+### Phase G — `/flow:merge` (18:30–20:00)
+
+- 18:30 — `/flow:merge <pr>`. Prerequisite check runs.
+- 18:50 — Display: approval ✓, checks ✓, conversations resolved ✓, finding-ledger empty ✓ (no unresolved or ESCALATED items in FLOW_RESOLUTION_CYCLE).
+- 19:10 — **Tier 3 confirmation prompt** via AskUserQuestion. Show the structured options panel.
+
+**Pause beat 4** (live narration, ~45 sec): freeze on the confirmation prompt. "This is Tier 3. Merge is hard to reverse — once it's on the default branch, getting it off is a revert commit visible to everyone. The plugin will not auto-merge. The hooks will not auto-merge. Even if you somehow wrote a command that tried, `block-force-push` and `block-destructive` would catch the recovery attempt. Confirmation here is structural. The user has to say yes."
+
+- 19:30 — User confirms. Squash merge per `merge.strategy: squash`. Branch deleted per `merge.deleteBranch: true`.
+- 19:55 — Done. Final shot of the closed PR + closed issue.
+
+## Pre-recording checklist (run before hitting record)
+
+```bash
+# Scratch dir — do not record from inside the marketplace repo
+mkdir -p /tmp/flow-demo && cd /tmp/flow-demo
+
+# 1. Plugin installed and active
+claude plugins list | grep -q "^flow " || { echo "FAIL: flow not installed"; exit 1; }
+
+# 2. Demo repo prepared
+test -d sync-cli || git clone <synthetic-sync-cli-repo> sync-cli
+cd sync-cli && git status --porcelain && [ -z "$(git status --porcelain)" ] || { echo "FAIL: dirty worktree"; exit 1; }
+
+# 3. gh CLI authenticated
+gh auth status >/dev/null 2>&1 || { echo "FAIL: gh not authenticated"; exit 1; }
+
+# 4. Asciinema configured
+asciinema --version >/dev/null 2>&1 || { echo "FAIL: asciinema missing"; exit 1; }
+
+# 5. Stub remote for AC2 auth-failure scenario reachable
+curl -sf http://localhost:9999/health || { echo "FAIL: stub server not running"; exit 1; }
+
+# 6. Dry-run /flow:setup and /flow:status from cold (per hands-on slide)
+/flow:setup
+/flow:status
+```
+
+If any check fails, the slide is wrong, not the engineer. Update the slide before recording.
+
+## Live-narration timing budget
+
+| Beat | Duration | Cumulative wall-clock |
+|------|----------|----------------------|
+| Pre-roll setup | 30s | 0:00–0:30 |
+| Phase A play | 2:30 | 0:30–3:00 |
+| Phase B play | 4:00 | 3:00–7:00 |
+| **Pause beat 1** | 75s | 7:00–8:15 |
+| Phase C play | 3:00 | 8:15–11:15 |
+| Phase D play | 4:00 | 11:15–15:15 |
+| **Pause beat 2** | 75s | 15:15–16:30 |
+| Phase E play | 2:30 | 16:30–19:00 |
+| Phase F play | 2:30 | 19:00–21:30 |
+| **Pause beat 3** | 60s | 21:30–22:30 |
+| Phase G play | 1:30 | 22:30–24:00 |
+| **Pause beat 4** | 45s | 24:00–24:45 |
+| Recap on slide 30 | 15s | 24:45–25:00 |
+
+**Total**: 25:00 — fits the 25-min slot exactly. Recording itself: 19:30–20:00.
+
+## What the room must take away (in order)
+
+1. **Eval-as-spec** — verification commands are decided at plan time, not verify time. (Pause beat 1)
+2. **Independent judgment** — verdict-judge sees outcomes, not process. (Pause beat 2)
+3. **No incomplete shipments** — P3 is fix or escalate. (Pause beat 3)
+4. **Structural safety** — Tier 3 confirmation is enforced; force-push is hook-blocked. (Pause beat 4)
+
+If only one lands, it should be #2. That's the question PM/design will ask, and the answer that justifies the rest of the architecture.

--- a/docs/flow-team-session/walkthrough-script.md
+++ b/docs/flow-team-session/walkthrough-script.md
@@ -95,7 +95,7 @@ All four layers from `autonomous-workflow/SKILL.md` lines 24–28.
 ### Phase E — `/flow:pr` (13:30–16:00)
 
 - 13:30 — `/flow:pr`. Push happens (Tier 2 — journal entry, no prompt).
-- 13:50 — Parallel agent fan-out: `code-reviewer`, `security-reviewer`, `convention-checker`, `error-handler-inspector`, `integration-verifier`, plus a re-run of `holdout-validation`.
+- 13:50 — Parallel agent fan-out (Phase 3): `code-reviewer`, `convention-checker`, `test-runner`, `security-reviewer`, `error-handler-inspector`, plus a re-run of `holdout-validation`.
 - 14:30 — Agents return. Findings table renders, sorted P1 → P2 → P3.
 - 15:00 — One P3 surfaces: "missing example in README." Agent fixes inline (P3 fix-or-escalate — Excellence Principle #6).
 - 15:30 — PR body assembled from `plugins/flow/templates/pr-body.md` + public journal entries. URL visible.

--- a/docs/flow-team-session/walkthrough-script.md
+++ b/docs/flow-team-session/walkthrough-script.md
@@ -58,7 +58,7 @@ What to show:
 
 ### Phase B — `/flow:start <issue-N>` (02:30–06:30)
 
-- 02:30 — Phase 0 PRE-FLIGHT bash block runs (the exact one quoted on slide 33, from `plugins/flow/commands/start.md` lines 36–62). Show clean `PREFLIGHT: PASSED`.
+- 02:30 — Phase 0 PRE-FLIGHT bash block runs (the exact one quoted on slide 33, from `plugins/flow/commands/start.md` lines 38–62). Show clean `PREFLIGHT: PASSED`.
 - 03:00 — EXPLORE: parallel `gh issue view`, `gh issue ... comments`, `git status`, `Skill(capability-discovery)`. Output stacks fast — let it scroll.
 - 03:40 — PLAN: `Skill(criterion-verification-map)` produces, for each AC, a `Verification command` and an `Expected evidence` shape. Highlight one row on screen.
 - 04:30 — TaskCreate × 4 (one per criterion). TaskList renders.
@@ -114,7 +114,7 @@ A reviewer (a second persona, off-screen) drops two comments:
 - 17:50 — `feedback-resolution` skill drafts a re-review request comment.
 - 18:15 — Reviewer is re-requested. FLOW_RESOLUTION_CYCLE marker visible in the PR body.
 
-**Pause beat 3** (live narration, ~60 sec): pause on the FLOW_RESOLUTION_CYCLE marker. Open `plugins/flow/CHANGELOG.md` v2.0.0 in a side window. "DEFERRED is gone. ESCALATED is what's left. P3 used to be a polite note you could ignore. Now it's fix in this PR or file a six-field escalation. The merge gate enforces it."
+**Pause beat 3** (live narration, ~60 sec): pause on the FLOW_RESOLUTION_CYCLE marker. "Two states for any P3: resolved or escalated. Both are auditable; neither is silent. Escalation means the engineer wrote the six-field structure into the PR comment and the reviewer accepted it. The merge gate reads this marker — unresolved or unaccepted items block merge. That's the policy: a finding worth mentioning is a finding worth acting on."
 
 ### Phase G — `/flow:merge` (18:30–20:00)
 

--- a/docs/flow-team-session/walkthrough-script.md
+++ b/docs/flow-team-session/walkthrough-script.md
@@ -133,8 +133,8 @@ A reviewer (a second persona, off-screen) drops two comments:
 # Scratch dir — do not record from inside the marketplace repo
 mkdir -p /tmp/flow-demo && cd /tmp/flow-demo
 
-# 1. Plugin installed and active
-claude plugins list | grep -q "^flow " || { echo "FAIL: flow not installed"; exit 1; }
+# 1. Plugin installed and active (real output format: "  ❯ flow@<source>")
+claude plugins list 2>&1 | grep -qE 'flow@' || { echo "FAIL: flow not installed"; exit 1; }
 
 # 2. Demo repo prepared
 test -d sync-cli || git clone <synthetic-sync-cli-repo> sync-cli
@@ -147,7 +147,11 @@ gh auth status >/dev/null 2>&1 || { echo "FAIL: gh not authenticated"; exit 1; }
 asciinema --version >/dev/null 2>&1 || { echo "FAIL: asciinema missing"; exit 1; }
 
 # 5. Stub remote for AC2 auth-failure scenario reachable
-curl -sf http://localhost:9999/health || { echo "FAIL: stub server not running"; exit 1; }
+#    (Set up separately — provision a small local HTTP server returning 401 for
+#    `/sync` and 200 for `/health`. Any tool works: `python -m http.server` with a
+#    reverse proxy, or a 30-line Express/Bottle/Flask script. Document the chosen
+#    setup at recordings/stub-server-README.md before recording day.)
+curl -sf http://localhost:9999/health || { echo "FAIL: stub server not running — see recordings/stub-server-README.md"; exit 1; }
 
 # 6. Dry-run /flow:setup and /flow:status from cold (per hands-on slide)
 /flow:setup


### PR DESCRIPTION
## Summary

Adds `docs/flow-team-session/` with 8 artifacts for a 90-min mixed-audience workshop on the flow plugin (v2.0.1): Marp slide deck (63 slides), long-form handbook covering all 17 commands / 8 agents / 22 skills, 1-page cheatsheet, 10-decision conventions worksheet + post-session template, walkthrough script with synthetic `/sync --json` scenario and 4 pause-beat narrations, FAQ + glossary, and an index README.

Quotes pull verbatim from `plugins/flow/` source files; the slide deck's hooks slide reflects the 8 wired scripts in `hooks/hooks.json` (not the stale "10 scripts" line in `plugins/flow/README.md`). Merge/release confirmation is documented as command-level `AskUserQuestion`, matching `references/three-tier-safety.md`.

## What's in the folder

| File | Lines | Purpose |
|------|-------|---------|
| `slides.md` | 899 | Marp deck, 63 slides — render with `npx -y @marp-team/marp-cli --pdf slides.md` |
| `HANDBOOK.md` | 439 | Long-form reference; covers every command/agent/skill |
| `walkthrough-script.md` | 186 | Pre-recording shotlist + live-narration timing + dry-run checklist |
| `faq-and-glossary.md` | 167 | Anticipated questions + term lookup |
| `CHEATSHEET.md` | 160 | One-page printable, two-column |
| `CONVENTIONS-DECIDED.md` | 69 | Empty post-session template |
| `README.md` | 59 | Folder index + how-to-run-the-session |
| `CONVENTIONS-WORKSHEET.md` | 42 | 10-row fillable, projected during section 6 |

## Test plan

- [ ] `npx -y @marp-team/marp-cli --pdf docs/flow-team-session/slides.md` renders cleanly; PDF page count is 60–65.
- [ ] Spot-check 3 `[QUOTE]` blocks against the cited source files.
- [ ] Confirm `HANDBOOK.md` mentions every command/agent/skill name (loop in plan ran 0 missing).
- [ ] Walk `walkthrough-script.md` against a scratch repo before recording.