### PR TITLE
fix(flow): dedupe skill bodies that duplicate command bash (#65)

### DIFF
--- a/plugins/flow/README.md
+++ b/plugins/flow/README.md
@@ -1,6 +1,6 @@
 # Flow: Skill-Driven Workflow Plugin
 
-A Claude Code plugin that replaces command-driven GitHub workflow automation with a skill-driven, agent-team-powered approach. Skills encode reusable team knowledge that compounds across sessions.
+A Claude Code plugin that replaces command-driven GitHub workflow automation with a skill-driven, agent-team-powered approach. Skills encode reusable team knowledge — policy, philosophy, and rationale — as reference documents that compound across sessions; commands carry the executable bash that runs at workflow time.
 
 ## Excellence Principles
 

--- a/plugins/flow/skills/merge-and-release/SKILL.md
+++ b/plugins/flow/skills/merge-and-release/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: merge-and-release
-description: "Guide PR merges and releases through prerequisite verification (approval, checks, resolved conversations), semantic versioning, changelog generation, and release notes. Tier 3 — always requires human confirmation. Use when merging PRs or creating releases."
-allowed-tools: Bash, Read
+description: "Reference for the merge and release policy: prerequisite checklist (approval, checks, mergeable, conversations, stale approval), Tier 3 confirmation requirement, semantic versioning rules, and changelog generation. Use to understand why merges and releases are non-autonomous."
+allowed-tools: Read
 context: fork
 agent: Explore
 disable-model-invocation: true
@@ -9,119 +9,114 @@ disable-model-invocation: true
 
 # Merge and Release
 
-Domain skill for merge and release operations. Both are Tier 3 — **always require human confirmation**, even in autonomous mode. This is non-negotiable.
+Reference document for merge and release policy. The executable bash lives in `plugins/flow/commands/merge.md` and `plugins/flow/commands/release.md`. This skill describes **what those commands enforce and why**.
+
+Both merge and release are **Tier 3** — they always require explicit human confirmation, even in autonomous mode. This is non-negotiable.
 
 ## Iron Law
 
 **MERGE IS IRREVERSIBLE IN PRACTICE. Treat every merge as permanent. Every prerequisite must be verified with fresh evidence, not memory.**
 
-Reverting a merge is possible in git but disruptive in practice. Prevention is the only reliable strategy.
+Reverting a merge is technically possible in git but disruptive in practice — downstream branches rebase off the merge, deploys propagate it, and history grows confusing. Prevention is the only reliable strategy. The Tier 3 confirmation requirement is the structural expression of that fact.
 
-## Merge Prerequisites
+## Merge Prerequisites — The Five-Check Gate
 
-Before merging, verify ALL of these:
+Before a merge proceeds, all five checks must pass. The runnable verification is in `plugins/flow/commands/merge.md` Phase 1.
 
-```bash
-PR_NUM=$ARGUMENTS
-# All checks in parallel
-gh pr view $PR_NUM --json reviewDecision,statusCheckRollup,mergeable,mergeStateStatus
+| # | Check | Requirement | What it protects against |
+|---|-------|-------------|--------------------------|
+| 1 | Approval | At least one approval, no outstanding requested changes | Merging code that no human has signed off on |
+| 2 | CI Checks | All status checks pass (`statusCheckRollup` all success) | Merging code that fails the project's automated tests |
+| 3 | Mergeable | No merge conflicts (`mergeable == "MERGEABLE"`) | Merging a PR whose content cannot cleanly land on the base branch |
+| 4 | Conversations | All review threads resolved (unresolved count == 0) | Closing reviewer concerns by ignoring them |
+| 5 | Stale approval | No commits after the last approval timestamp | Merging code that was approved before the latest changes existed |
 
-# Review status
-gh pr view $PR_NUM --json reviews --jq '.reviews[] | "\(.state) by \(.author.login)"'
+The conversation-resolution check requires GitHub's GraphQL API (the REST `reviewThreads` field is incomplete). The exact GraphQL query used is in `plugins/flow/commands/merge.md`.
 
-# Unresolved conversations (reviewThreads requires GraphQL API)
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-OWNER=$(echo $REPO | cut -d/ -f1)
-NAME=$(echo $REPO | cut -d/ -f2)
-gh api graphql -f query="query { repository(owner: \"$OWNER\", name: \"$NAME\") { pullRequest(number: $PR_NUM) { reviewThreads(first: 100) { nodes { isResolved } } } } }" --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length'
-```
+## Stop Conditions — Non-Negotiable
 
-### Prerequisite Checklist
+When any of these conditions is detected, the command **stops without asking "merge anyway?"**:
 
-| Check | Requirement | Detection |
-|-------|-------------|-----------|
-| Approval | At least 1 approval, no outstanding request-changes | `reviewDecision == "APPROVED"` |
-| CI Checks | All status checks pass | `statusCheckRollup` all success |
-| Mergeable | No merge conflicts | `mergeable == "MERGEABLE"` |
-| Conversations | All review threads resolved | Unresolved count == 0 |
-| Stale approval | No commits after last approval | Compare approval date vs last commit |
+- ANY of the five prerequisites fails
+- Stale approval detected — request re-review, do not merge
+- Unresolved conversations > 0 — resolve first, do not merge
+- Finding-ledger check fails (see `pr-lifecycle` skill for details)
 
-### Merge Stop Conditions
+There is no "override the gate" option in autonomous mode. Overrides require the human user to take the action themselves outside the command.
 
-- ANY prerequisite fails — stop, do not ask "merge anyway?"
-- Stale approval detected — stop, request re-review
-- Unresolved conversations > 0 — stop, resolve first
+## Stale Approval Detection
 
-### Stale Approval Detection
+A "stale" approval is one that predates the most recent commit on the PR. The check compares:
 
-```bash
-# Last approval timestamp
-gh pr view $PR_NUM --json reviews --jq '[.reviews[] | select(.state == "APPROVED")] | sort_by(.submittedAt) | last | .submittedAt'
+- The latest `submittedAt` timestamp among reviews where `state == "APPROVED"`
+- The `committedDate` of the most recent commit on the PR
 
-# Last commit timestamp
-gh pr view $PR_NUM --json commits --jq '.commits | last | .committedDate'
-```
-
-If commits exist after the last approval, warn: "Approval may be stale."
+If commits exist after the last approval, the command warns: "Approval may be stale." Stale approvals are a stop condition because the approver has not actually seen what is being merged.
 
 ## Merge Execution
 
-After prerequisites pass, display assessment and **require confirmation**:
+After all prerequisites pass, the command displays a **Merge Assessment** table and explicitly asks the user to confirm. Only after a clear "yes" does the merge proceed:
 
-```markdown
-## Merge Assessment for PR #N
+- Strategy is read from settings (`squash` | `merge` | `rebase`, default `squash`)
+- Branch deletion is read from settings (default `true`)
+- The `gh pr merge` invocation is in `plugins/flow/commands/merge.md` Phase 3
 
-- Approvals: {N} (latest: @{reviewer})
-- CI Checks: {all pass / N failing}
-- Conversations: {all resolved / N unresolved}
-- Stale approval: {no / yes — warn}
-
-**Strategy**: {squash | merge | rebase} (from settings)
-**Delete branch**: {yes | no} (from settings)
-```
-
-Then ask user to confirm. Only after explicit "yes":
-
-```bash
-gh pr merge $PR_NUM --{strategy} --delete-branch
-```
+The user-visible assessment lists every prerequisite's status, the chosen strategy, and the branch-delete decision so the human can verify before approving.
 
 ## Release Process
 
-### Changelog Generation
-
-```bash
-# Get merged PRs since last release
-LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-[ -n "$LAST_TAG" ] && gh pr list --state merged --search "merged:>=$(git log -1 --format=%ai $LAST_TAG)" --json number,title,labels --limit 50
-```
+Releases follow the same Tier 3 confirmation discipline as merges. The runnable bash is in `plugins/flow/commands/release.md`.
 
 ### Version Calculation
 
-| Type | Bump | When |
-|------|------|------|
-| patch | 0.0.X | Bug fixes only |
-| minor | 0.X.0 | New features, no breaking changes |
-| major | X.0.0 | Breaking changes |
+| Bump type | Format | When to use |
+|-----------|--------|-------------|
+| `patch` | 0.0.X+1 | Bug fixes only, no behavior change |
+| `minor` | 0.X+1.0 | New features, no breaking changes |
+| `major` | X+1.0.0 | Breaking changes |
+
+The first release defaults to `v1.0.0` if no prior tag exists.
+
+### Changelog Generation
+
+The changelog is built from merged PRs since the last release tag, categorized by conventional commit prefix:
+
+- **Features** — `feat:` PRs
+- **Bug Fixes** — `fix:` PRs
+- **Other Changes** — `docs:`, `chore:`, etc.
+
+Each entry includes the PR number and author. A "Full Changelog" link compares the previous tag to the new one.
 
 ### Release Execution
 
-Display changelog and version, **require confirmation**, then:
+After the changelog and version are displayed, the command asks the user to confirm. Only after explicit confirmation:
 
-```bash
-TAG="${TAG_PREFIX}${VERSION}"
-git tag -a "$TAG" -m "Release $TAG"
-git push origin "$TAG"
-gh release create "$TAG" --title "$TAG" --notes "$CHANGELOG"
-```
+1. Create annotated tag: `git tag -a "$TAG" -m "Release $TAG"`
+2. Push tag: `git push origin "$TAG"`
+3. Create GitHub release: `gh release create "$TAG" --title "$TAG" --notes "$CHANGELOG"`
 
-## Post-Merge/Release
+These three operations together are the release. They are not split across multiple agent turns — the user confirms once and the command performs them in sequence.
 
-```bash
-# Verify
-gh pr view $PR_NUM --json state  # should be MERGED
-# or
-gh release view $TAG
-```
+## Post-Merge / Post-Release
 
-Suggest cleanup: switch to default branch, pull latest.
+After either operation completes, the command verifies state:
+
+- Merge: `gh pr view $PR_NUM --json state` should return `MERGED`
+- Release: `gh release view $TAG` should succeed
+
+The command then suggests cleanup: switch to the default branch, pull latest, and (for releases) update plugin version files if applicable.
+
+## Why Tier 3 Is Structural, Not Optional
+
+Merges and releases produce visible, durable artifacts: a merge commit on `main`, a published tag, a GitHub release page that subscribers may receive notifications for. The cost of an unwanted merge or release is paid by everyone downstream — other developers rebasing, users seeing a notification for a release that was a mistake, package managers fetching the new version.
+
+Tier 3 is not gatekeeping for its own sake. It is the structural expression of: **the cost of an unwanted action is borne by people who are not in this conversation.** The human in the loop is the only person who can speak for those downstream people.
+
+## Where the Bash Lives
+
+This skill is reference-only. The runnable implementations are:
+
+- **Merge prerequisites + execution**: `plugins/flow/commands/merge.md`
+- **Release version calculation + tagging + GitHub release creation**: `plugins/flow/commands/release.md`
+
+When the policy needs to evolve — a new prerequisite, a new release strategy, a different versioning scheme — update the command and update this reference together. The bash is the runtime; this document is the rationale.

--- a/plugins/flow/skills/pr-lifecycle/SKILL.md
+++ b/plugins/flow/skills/pr-lifecycle/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: pr-lifecycle
-description: "Create pull requests with pre-flight verification, PR body generation, reviewer suggestion, comprehension narrative, and label selection. Handle push and PR creation as Tier 2 operations. Use when preparing or creating a pull request."
-allowed-tools: Bash, Read, Write, Edit, Grep, Glob
+description: "Reference for the pull-request lifecycle policy: pre-flight gates, body structure, reviewer-suggestion algorithm, verification gate, finding-ledger merge prerequisite, and rationalization prevention. Use to understand the rules that PR creation enforces."
+allowed-tools: Read
 context: fork
 agent: general-purpose
 ---
 
 # PR Lifecycle
 
-Domain skill for the full PR creation process.
+Reference document for the PR creation and pre-merge policy. The executable bash lives in `plugins/flow/commands/pr.md` (full creation flow) and `plugins/flow/commands/merge.md` (finding-ledger check). This skill describes **what those commands enforce and why**, so reviewers can audit the policy without reading shell.
 
 ## Iron Law
 
@@ -16,143 +16,109 @@ Domain skill for the full PR creation process.
 
 If you can't show test results, lint output, or verification evidence in the PR body, the PR is not ready.
 
-## Pre-Flight Checks
+## Pre-Flight Gate
 
-All checks run in parallel:
+Before any PR is created, four conditions are verified:
 
-```bash
-# 1. Not on default branch
-BRANCH=$(git branch --show-current)
-DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
-[ "$BRANCH" = "$DEFAULT_BRANCH" ] && echo "ERROR: On default branch" && exit 1
+| # | Condition | Failure handling |
+|---|-----------|------------------|
+| 1 | Not on the default branch | Hard error — PRs are made from feature branches, never from `main` |
+| 2 | At least one commit ahead of the default branch | Hard error — empty PRs are noise |
+| 3 | No uncommitted changes | Warning — offer to commit first via `/flow:commit` |
+| 4 | No existing open PR for this branch | Hard error — update the existing PR instead of creating a duplicate |
 
-# 2. Commits ahead
-git rev-list --count "$DEFAULT_BRANCH"..HEAD
-
-# 3. No uncommitted changes
-git status --porcelain
-
-# 4. No existing PR
-gh pr list --head "$BRANCH" --state open --json number
-```
-
-Fail if: on default branch, no commits ahead, or PR already exists.
-
-Warn if: uncommitted changes (offer to commit first).
-
-## PR Body Structure
-
-Generate from template + review findings + decision journal:
-
-```markdown
-## Summary
-{2-3 sentence description of what changed and why}
-
-Closes #{issue_number}
-
-## Changes
-{Bullet list of key changes, grouped by area}
-
-## Comprehension Report
-{Generated narrative: what was built, why, architecture decisions}
-
-### Requirements Adherence
-| # | Criterion | Status | Evidence |
-|---|-----------|--------|----------|
-| 1 | {criterion} | Met | {file:line} |
-
-### Key Decisions
-{From decision journal — public entries only, internal redacted}
-
-## Review Findings
-{P1/P2/P3 summary from code review}
-
-## Verification
-- [ ] Quality checks pass (lint, test, typecheck)
-- [ ] Self-review completed
-- [ ] Runtime verification (if applicable)
-
-## Files Changed
-{Grouped by area with brief description per group}
-```
+The runnable checks are in `plugins/flow/commands/pr.md` Phase 1 (EXPLORE). The command is the single source of truth.
 
 ## Verification Gate
 
-Before creating the PR, confirm ALL of these. If any fail, stop:
+Before the PR is created, every one of the following must hold. If any fail, stop:
 
-1. All quality commands (lint, test, typecheck) pass — show output
-2. Self-review completed (code-quality-principles checklist)
+1. All quality commands (lint, test, typecheck) pass — output captured for the PR body
+2. Self-review completed against the `code-quality-principles` checklist
 3. Change classification shows no out-of-context files
-4. Every acceptance criterion has a "Met" or "Interpreted" status with evidence
+4. Every acceptance criterion has a "Met" or "Interpreted" status with concrete evidence
 5. No P1 findings remain from code review
 
-This gate is mandatory. Skipping it to "get the PR up quickly" creates reviewer burden.
+This gate is **mandatory**. Skipping it to "get the PR up quickly" creates reviewer burden and shifts the verification cost to whoever reads the PR.
 
-## Reviewer Suggestion
+## PR Body Structure
 
-Algorithm: CODEOWNERS match → file expertise → recent activity → workload balancing.
+The PR body is generated from a fixed template plus review findings plus the decision journal. Sections, in order:
 
-```bash
-# Get contributors for changed files
-git log --format='%an' --since='30 days ago' -- $(git diff --name-only $DEFAULT_BRANCH...HEAD) | sort | uniq -c | sort -rn | head -5
-# Check CODEOWNERS
-cat .github/CODEOWNERS 2>/dev/null
-```
+- **Summary** — 2-3 sentence description of what changed and why
+- **Closes** — issue link
+- **Changes** — bulleted list of key changes, grouped by area
+- **Comprehension Report** — what was built, why, architecture decisions
+- **Requirements Adherence** — table mapping each acceptance criterion to status and evidence (file:line)
+- **Key Decisions** — public entries from the decision journal; internal redacted
+- **Review Findings** — P1/P2/P3 summary from code review
+- **Verification** — checklist confirming quality checks, self-review, runtime verification
+- **Files Changed** — grouped by area with a brief description per group
 
-Present top 2-3 suggestions with rationale.
+Why this shape: reviewers should be able to skim **Summary → Requirements Adherence → Verification** in under thirty seconds and decide whether to do a deep read. A PR body that buries the acceptance-criterion mapping or omits verification evidence forces every reviewer to reconstruct context the author already had.
 
-## Push and Create
+## Reviewer Suggestion Algorithm
 
-Both are Tier 2 (journal-and-proceed):
+Reviewer selection follows this priority cascade:
 
-```bash
-# Push (Tier 2)
-git push -u origin $BRANCH
+1. **CODEOWNERS match** — if the file paths in the diff have CODEOWNERS entries, those owners are first-priority candidates.
+2. **File expertise** — recent contributors (last 30 days) to the same files in the diff.
+3. **Recent activity** — contributors who have shipped to adjacent areas of the codebase recently.
+4. **Workload balancing** — among equally-qualified candidates, prefer the one with fewer outstanding review requests.
 
-# Create PR (Tier 2)
-gh pr create --title "$TITLE" --body "$BODY" --label "$LABELS"
-```
+The PR command surfaces the top 2-3 candidates with a one-line rationale per candidate. The author makes the final call.
 
-## Post-Creation Verification
+## Push and Create — Tier 2
 
-```bash
-gh pr view --json number,url,state,title
-```
+Both `git push -u origin <branch>` and `gh pr create` are **Tier 2** (journal-and-proceed): the agent executes them and logs the action, but does not require explicit human confirmation each time. This tier classification is recorded in `plugins/flow/commands/pr.md`.
 
-Display PR URL and suggest: `/flow:review {number}` for self-review or share with team.
+After creation, the command verifies the PR exists via `gh pr view --json number,url,state,title` and surfaces the PR URL plus a suggested next step (`/flow:review {number}`).
 
 ## Merge Prerequisite: Finding-Ledger Check
 
-Before a PR can be merged via `/flow:merge`, the finding ledger is checked to ensure all review findings have been resolved.
+Before a PR can be merged via `/flow:merge`, the **finding ledger** is checked to ensure all review findings have been resolved. The runnable parser lives in `plugins/flow/commands/merge.md` Phase 1 (Finding-Ledger Check).
 
-### What it does
+### What the ledger tracks
 
-Parses PR comments for `FLOW_RESOLUTION_CYCLE` and `FLOW_REVIEW_CYCLE` markers:
+PR comments carry two markers:
 
-- **`FLOW_REVIEW_CYCLE:{N} FINDINGS:[...]`** — the finding IDs emitted during review
+- **`FLOW_REVIEW_CYCLE:{N} FINDINGS:[...]`** — the finding IDs emitted during review cycle N
 - **`FLOW_RESOLUTION_CYCLE:{N} RESOLVED:[...] ESCALATED:[...] DISPUTED:[...]`** — the disposition of each finding after `/flow:address`
 
-The check extracts the latest of each marker and compares them.
+The latest comment of each kind is parsed and compared.
 
-### What triggers a block
+### What blocks a merge
 
-1. **Non-empty ESCALATED array** — `ESCALATED:[F3]` means at least one finding was escalated but not resolved. The merge gate blocks until every escalated item is resolved or the ESCALATED array is empty.
-2. **Unmatched FINDINGS** — any finding ID present in `FLOW_REVIEW_CYCLE:FINDINGS` that has no corresponding entry in `FLOW_RESOLUTION_CYCLE:RESOLVED` is considered unresolved. The merge gate blocks until every finding has a matching RESOLVED entry.
+1. **Non-empty `ESCALATED` array** — `ESCALATED:[F3]` means at least one finding was escalated but not resolved. The merge gate blocks until every escalated item is resolved or the array is empty.
+2. **Unmatched `FINDINGS`** — any finding ID present in `FLOW_REVIEW_CYCLE:FINDINGS` that has no corresponding entry in `FLOW_RESOLUTION_CYCLE:RESOLVED` is considered unresolved. The merge gate blocks until every finding has a matching `RESOLVED` entry.
 
-### How to resolve
+### How to clear the gate
 
 1. Run `/flow:address {pr_number}` to address remaining findings
-2. Fix or respond to each unresolved finding until all are in the RESOLVED array
-3. Ensure the ESCALATED array is empty in the latest resolution comment
+2. Fix or respond to each unresolved finding until all appear in the `RESOLVED` array
+3. Ensure the `ESCALATED` array is empty in the latest resolution comment
 4. Re-run `/flow:merge {pr_number}`
 
-This gate enforces the "no incomplete shipments" hard boundary from organizational governance.
+This gate enforces the **"no incomplete shipments"** hard boundary from organizational governance. Merging with unresolved findings is a violation, not a judgment call.
 
 ## Rationalization Prevention
+
+The PR pipeline blocks these recurring excuses by structure, not by exhortation:
 
 | Excuse | Response |
 |--------|----------|
 | "I'll fix it after the PR is up" | Fix it now. Draft PRs accumulate, they don't improve. |
 | "The reviewer will catch any issues" | You are the first reviewer. Don't outsource your job. |
-| "It's a small change, no need for full pre-flight" | Small changes, same process. |
-| "CI will validate it" | CI validates what it tests. Pre-flight validates what it doesn't. |
+| "It's a small change, no need for full pre-flight" | Small changes, same process. The cost of pre-flight is small; the cost of a malformed PR is reviewer time. |
+| "CI will validate it" | CI validates what it tests. Pre-flight validates what CI doesn't. |
+
+## Where the Bash Lives
+
+This skill is reference-only. The runnable implementations are:
+
+- **Pre-flight checks**: `plugins/flow/commands/pr.md` Phase 1 (EXPLORE)
+- **PR body assembly + push + create**: `plugins/flow/commands/pr.md` Phase 4 (VERIFY)
+- **Reviewer suggestion**: `plugins/flow/commands/pr.md` Phase 4 step 11
+- **Finding-ledger merge gate**: `plugins/flow/commands/merge.md` Phase 1
+
+When the policy needs to change — a new pre-flight check, a new PR body section, a new ledger marker — update the command and update this reference together. Keeping the bash and the rationale in lockstep prevents the silent drift that motivated this consolidation.

--- a/plugins/flow/skills/preflight-checks/SKILL.md
+++ b/plugins/flow/skills/preflight-checks/SKILL.md
@@ -1,78 +1,58 @@
 ---
 name: preflight-checks
-description: "Validate environment prerequisites including clean git state, issue existence, gh CLI authentication, and remote accessibility using fast bash checks with no LLM calls. Use when starting any workflow to fail fast before planning begins."
-allowed-tools: Bash
+description: "Reference for the pre-flight validation policy: clean git state, issue existence, gh CLI authentication, and remote accessibility — all enforced via fast bash with no LLM calls. Use to understand why pre-flight exists and what each check protects."
+allowed-tools: Read
 context: fork
 agent: general-purpose
 ---
 
 # Pre-flight Checks
 
-Pure bash validation that runs before any LLM reasoning. Fail fast, save tokens.
+Reference document for the pre-flight policy. The executable bash lives in `plugins/flow/commands/start.md` (Phase 0) — that is the single source of truth that runs at workflow start. This skill describes **what each check enforces and why**, so the policy can be reviewed, audited, and extended without untangling shell logic.
 
 ## Iron Law
 
 **NO LLM CALLS IN PRE-FLIGHT.** Every check is a bash command with a pass/fail exit code. If pre-flight fails, the workflow stops before spending any tokens on planning.
 
-## Checks
+## What Pre-flight Protects
 
-Run all checks in a single Bash call:
+Pre-flight is the cheapest possible filter. It runs before EXPLORE, before any agent dispatch, and before any token-spending reasoning. The goal is to fail fast on conditions that would invalidate everything downstream — saving both wall-clock time and LLM cost.
 
-```bash
-ERRORS=0
-WARNINGS=0
+If pre-flight is honest about what it can and cannot prove, downstream phases can trust their preconditions and stop re-checking them.
 
-# 1. Git state is clean (no uncommitted changes that could conflict)
-if [ -n "$(git status --porcelain)" ]; then
-  echo "PREFLIGHT FAIL: Uncommitted changes detected. Commit or stash before starting."
-  ERRORS=$((ERRORS+1))
-fi
+## The Six Checks (and why each exists)
 
-# 2. Not on detached HEAD
-if ! git symbolic-ref HEAD >/dev/null 2>&1; then
-  echo "PREFLIGHT FAIL: Detached HEAD. Checkout a branch first."
-  ERRORS=$((ERRORS+1))
-fi
+| # | Check | Failure mode it prevents |
+|---|-------|--------------------------|
+| 1 | Clean git state (no uncommitted changes) | Starting a feature branch on top of unrelated dirty state, then accidentally including those changes in the PR. |
+| 2 | Not on detached HEAD | Creating commits that have no branch reference and silently disappear when the workflow checks out something else. |
+| 3 | `gh` CLI authenticated | Spending tokens on planning, then failing at the first `gh issue view` call because auth was never established. |
+| 4 | Issue exists and is OPEN | Working an issue that was already closed, deleted, or mistyped — produces a PR with nothing to close. |
+| 5 | Remote `origin` reachable | Reaching the push step after hours of work and discovering the network is down or the remote is misconfigured. |
+| 6 | Already on a feature branch for this issue (warning only) | Accidentally re-starting an issue that is already in progress on the current branch — recoverable, so warning not error. |
 
-# 3. gh CLI authenticated
-if ! gh auth status >/dev/null 2>&1; then
-  echo "PREFLIGHT FAIL: gh CLI not authenticated. Run 'gh auth login'."
-  ERRORS=$((ERRORS+1))
-fi
+Checks 1–5 are **errors**: any one fails, the workflow halts. Check 6 is a **warning**: noted in output, workflow proceeds.
 
-# 4. Issue exists and is open
-ISSUE_STATE=$(gh issue view $ARGUMENTS --json state --jq '.state' 2>/dev/null)
-if [ "$ISSUE_STATE" != "OPEN" ]; then
-  echo "PREFLIGHT FAIL: Issue #$ARGUMENTS not found or not open (state: ${ISSUE_STATE:-not found})."
-  ERRORS=$((ERRORS+1))
-fi
+## Behavior Contract
 
-# 5. Remote is accessible
-if ! git ls-remote --exit-code origin >/dev/null 2>&1; then
-  echo "PREFLIGHT FAIL: Cannot reach remote 'origin'."
-  ERRORS=$((ERRORS+1))
-fi
+- **ERRORS > 0**: halt the workflow. Do not proceed to EXPLORE. Do not spend tokens on planning.
+- **WARNINGS only**: surface in output, proceed normally.
+- **No LLM calls, no Agent dispatches, no Skill invocations** during pre-flight. Pre-flight is pure bash.
+- **Total execution**: one Bash call, sub-second. If pre-flight is slow, it has scope creep.
 
-# 6. Already on a feature branch for this issue (warning only)
-CURRENT_BRANCH=$(git branch --show-current)
-if echo "$CURRENT_BRANCH" | grep -q "issue-$ARGUMENTS"; then
-  echo "PREFLIGHT WARN: Already on branch '$CURRENT_BRANCH' for issue #$ARGUMENTS."
-  WARNINGS=$((WARNINGS+1))
-fi
+## Where the Bash Lives
 
-echo ""
-echo "PREFLIGHT RESULT: $ERRORS error(s), $WARNINGS warning(s)"
-[ $ERRORS -gt 0 ] && echo "PREFLIGHT: BLOCKED — fix errors above before proceeding." && exit 1
-echo "PREFLIGHT: PASSED"
-```
+The runnable implementation is the bash block in `plugins/flow/commands/start.md` under "Phase 0: PRE-FLIGHT". `$ARGUMENTS` is substituted with the issue number from command arguments. That is the copy that actually runs.
 
-## Behavior
+This skill intentionally does **not** duplicate the bash. Two copies of the same checks drift silently — when a check is added to one and not the other, the gap is invisible until pre-flight either misses a real failure or fires on a condition that was already removed. Keeping the policy here and the implementation in the command means there is one place to read the shell, and one place to read the rationale.
 
-- **ERRORS** (any > 0): Halt workflow. Do not proceed to EXPLORE.
-- **WARNINGS** (errors = 0): Note in output, proceed normally.
-- No LLM calls, no Agent dispatches, no Skill invocations.
-- Total execution: one Bash call, sub-second.
+## Extending Pre-flight
 
-## When to Use
+When adding a new check, the policy contract is:
 
-Invoked as Phase 0 of `/flow:start` before the EXPLORE phase. Substitute `$ARGUMENTS` with the issue number from command arguments.
+1. **It must be representable as a single bash exit code** — no LLM judgment, no multi-step reasoning.
+2. **It must be cheap** — sub-second, no network calls beyond `gh` and `git` that pre-flight already performs.
+3. **It must protect against a concrete failure mode** — add a row to the table above explaining what goes wrong without it.
+4. **It must classify cleanly as ERROR or WARNING** — errors halt, warnings surface. Anything in between belongs in EXPLORE, not pre-flight.
+
+If a proposed check cannot meet all four, it does not belong in pre-flight. Push it to a later phase or to a domain skill.


### PR DESCRIPTION
## Summary

Closes #65.

- Removed duplicate bash from `preflight-checks`, `pr-lifecycle`, `merge-and-release` SKILL.md bodies
- Skills now describe policy + philosophy; commands carry the executable bash (single source of truth)
- Updated README "skills encode reusable team knowledge" framing to match the reality (skills = reference docs, commands = runtime)

## Why Option 2 (not Option 1)

The issue noted that `Skill(name)` invocation is a no-op for `context: fork` skills today (anthropics/claude-code#17283). Option 1 would have made commands reference skills, but the skill code still wouldn't run — it would just hide the duplication. Option 2 is honest: skills are reference docs, commands are runtime.

## Acceptance Criteria

- [x] No skill body contains verbatim bash duplicating its command's inline bash
- [x] Each skill is reference-only (no executable bash)
- [x] HANDBOOK/README "skills encode team knowledge" claim remains accurate (README updated to clarify reference vs. executable split; no HANDBOOK.md exists in this plugin)

## Files Changed

- `plugins/flow/skills/preflight-checks/SKILL.md` — replaced bash block with policy table + behavior contract + extension rules
- `plugins/flow/skills/pr-lifecycle/SKILL.md` — replaced 4 bash blocks (pre-flight, contributor query, push/create, finding-ledger lookup) with prose policy
- `plugins/flow/skills/merge-and-release/SKILL.md` — replaced 6 bash blocks (prerequisite checks, GraphQL query, stale-approval lookup, merge invocation, changelog query, release tag/push) with prose policy
- `plugins/flow/README.md` — softened the "Skills encode reusable team knowledge" sentence
- All three SKILL.md files now declare `allowed-tools: Read` reflecting their reference-only role

## Other Duplication Candidates (Follow-Up)

Audited all 22 flow skills. Beyond the three named in #65, these also duplicate command bash. Scoping per the issue's "don't sprawl" guidance — flagging here for a follow-up issue:

- `plugins/flow/skills/merge-conflict-resolution/SKILL.md` <-> `plugins/flow/commands/resolve.md` — orphaned-marker grep, conflict-detection bash, stage-and-continue
- `plugins/flow/skills/feedback-resolution/SKILL.md` <-> `plugins/flow/commands/address.md` — review-comment fetch via `gh api`, resolution-comment posting

The other high-bash skills (`runtime-verification`, `convention-enforcement`, `criterion-verification-map`, `capability-discovery`, etc.) contain bash that is genuinely reusable across multiple commands or is policy-shaped (per-stack build commands, port detection cascades) rather than verbatim duplication of a single command.

## Test plan

- [x] Each skill SKILL.md still parses (frontmatter intact)
- [x] Skill body length is now meaningfully shorter and bash-free
- [x] grep for bash code fences in the three skills returns nothing
- [x] `jq empty plugins/flow/schema.json` passes
- [x] Diff stat: 4 files changed, 187 insertions(+), 246 deletions(-) — net -59 lines