### PR TITLE
fix(flow): sync schema.json defaults with post-v2.0 settings (#59)

### DIFF
--- a/plugins/flow/schema.json
+++ b/plugins/flow/schema.json
@@ -116,7 +116,7 @@
         },
         "requireAllPass": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "When true, ALL criteria must PASS for the completion gate. When false, NEEDS-HUMAN-REVIEW verdicts can be user-approved."
         }
       }
@@ -124,7 +124,12 @@
     "testing": {
       "type": "object",
       "properties": {
-        "tddMode": { "enum": ["enforce", "suggest", "off"], "default": "suggest" }
+        "tddMode": { "enum": ["enforce", "suggest", "off"], "default": "enforce" },
+        "tddModeOptOut": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true with tddMode=suggest, suppresses warnings about missing tests."
+        }
       }
     },
     "debugging": {


### PR DESCRIPTION
## Summary

Closes #59. Three schema.json drifts vs settings.json/README synced.

- `testing.tddMode.default`: `"suggest"` → `"enforce"`
- `testing.tddModeOptOut`: added (`{"type": "boolean", "default": false}`)
- `verdict.requireAllPass.default`: added (`true`)

## Verification

- [x] `jq '.properties.testing.properties.tddMode.default' plugins/flow/schema.json` → `"enforce"`
- [x] `jq '.properties.testing.properties.tddModeOptOut' plugins/flow/schema.json` → non-null, `default: false`
- [x] `jq '.properties.verdict.properties.requireAllPass.default' plugins/flow/schema.json` → `true`
- [x] All three match `plugins/flow/settings.json`
- [x] `jq empty plugins/flow/schema.json` passes