### PR TITLE
fix(flow): wire security-reviewer into default review fan-out (#61)

### DIFF
--- a/plugins/flow/commands/pr.md
+++ b/plugins/flow/commands/pr.md
@@ -83,7 +83,7 @@ git diff "$DEFAULT_BRANCH"...HEAD
 
 ## Phase 3: CODE (Review Execution)
 
-**Parallel Agent dispatch** — 3 agents in a single message:
+**Parallel Agent dispatch** — 4 agents in a single message:
 
 ```
 Agent(code-reviewer):
@@ -98,6 +98,11 @@ Agent(convention-checker):
 Agent(test-runner):
   "Discover and run quality commands (lint, test, typecheck).
    Return structured results table."
+
+Agent(security-reviewer):
+  "Review the branch diff against $DEFAULT_BRANCH for OWASP Top 10,
+   secrets, auth/authz, input validation, dependency vulnerabilities.
+   Return P1/P2/P3 findings with file:line."
 ```
 
 **Main thread** (while agents run in parallel if using background agents, or after if foreground):

--- a/plugins/flow/commands/review.md
+++ b/plugins/flow/commands/review.md
@@ -95,7 +95,7 @@ Adversarial protocol:
 
 ### Path B: Single Session (default)
 
-**Parallel Agent dispatch** — 3 agents in single message:
+**Parallel Agent dispatch** — 5 agents in single message:
 
 ```
 Agent(code-reviewer):
@@ -111,6 +111,10 @@ Agent(test-runner):
 Agent(error-handler-inspector):
   "Inspect changed files in PR #$ARGUMENTS for error handling gaps,
    silent failures, unhandled exceptions. Return P1/P2/P3 findings."
+
+Agent(security-reviewer):
+  "Review PR #$ARGUMENTS diff for OWASP Top 10, secrets, auth/authz,
+   input validation, dependency vulnerabilities. Return P1/P2/P3 with file:line."
 
 Skill(holdout-validation):
   Inputs:


### PR DESCRIPTION
## Summary

Closes #61. `Agent(security-reviewer)` was documented as one of 8 agents but never invoked in default mode — it only fired when agentTeams: true (off by default).

- Added `Agent(security-reviewer)` to `commands/pr.md` Phase 3 parallel dispatch
- Added `Agent(security-reviewer)` to `commands/review.md` Path B parallel dispatch
- Both prompts focus the agent on OWASP Top 10, secrets, auth/authz, input validation, dependency vulnerabilities (matching `agents/security-reviewer.md`)

## Why Option 1 (wire in) over Option 2 (mark agent-teams-only)

The README architecture box advertises 8 agents. Marking one agent-teams-only undermines that promise. One extra agent context per review is acceptable for materially better security signal. Related: #62 broadens /flow:pr review depth in the same direction.

## Verification

- [x] Default-mode grep confirms `Agent(security-reviewer)` now appears in commands
- [x] PR creation will dispatch security-reviewer alongside code-reviewer/convention-checker/test-runner
- [x] Same fan-out parity in /flow:review Path B