### PR TITLE
docs(flow): fix 3 source-of-truth drifts (#58)

### DIFF
--- a/plugins/flow/README.md
+++ b/plugins/flow/README.md
@@ -84,7 +84,7 @@ claude plugins add ./plugins/flow
 
 ```
 SKILL LIBRARY (22 skills)
-  ├── Foundation (always loaded, <=100 lines each)
+  ├── Foundation (always loaded, stable shape)
   │   ├── evidence-based-development
   │   ├── autonomous-workflow
   │   └── code-quality-principles
@@ -130,11 +130,13 @@ COMMANDS (17)
   ├── setup, explain
   └── brainstorm, debug, design
 
-HOOKS (10 scripts)
+HOOKS (8 scripts)
   ├── Safety: block-force-push, block-destructive, block-secrets
-  ├── Gates: gate-merge, gate-release
   ├── Audit: log-file-changes, log-commits
   └── Experimental: verify-task-completion, nudge-idle-teammate, session-end-learn
+
+  Note: merge/release confirmation gates run at the COMMAND level via
+  AskUserQuestion (see references/three-tier-safety.md), not as hooks.
 ```
 
 ## Commands

--- a/plugins/flow/skills/criterion-verification-map/SKILL.md
+++ b/plugins/flow/skills/criterion-verification-map/SKILL.md
@@ -136,6 +136,7 @@ The bundle is passed to the verdict-judge agent, which must judge independently.
 The judge receives ONLY:
 1. The acceptance criteria (from the issue)
 2. The evidence bundle (from this skill)
+3. The holdout-validation output (from the holdout-validation skill — added in v2.0 to detect self-review claims that don't match file state)
 
 ## Verification Method Examples
 


### PR DESCRIPTION
## Summary

Closes #58. Three drifts between README/criterion-verification-map and post-v2.0 source of truth.

- **Drift 1**: `criterion-verification-map/SKILL.md` said the verdict-judge receives 2 inputs; truth is 3 (holdout-validation added in v2.0). Updated to match `agents/verdict-judge.md`.
- **Drift 2**: README claimed foundation skills are `<=100 lines each` — all 3 exceeded it. Dropped the line-count framing in favor of "always loaded, stable shape" — the meaningful distinction.
- **Drift 3**: README architecture box listed 10 hook scripts; only 8 are wired. `gate-merge`/`gate-release` are command-level gates (per `three-tier-safety.md:80`), not hook scripts. Updated count and added a one-liner so readers don't think the gates are missing.

## Verification

- [x] `criterion-verification-map/SKILL.md` lists 3 verdict-judge inputs including holdout-validation
- [x] README "Foundation" line no longer claims <=100 lines each
- [x] README hook list matches `hooks.json` wired scripts (8 scripts on disk = 8 unique commands wired = README claim of 8)