### PR TITLE
docs(flow): unify settings cascade direction across docs (#63)

### DIFF
--- a/plugins/flow/README.md
+++ b/plugins/flow/README.md
@@ -199,7 +199,14 @@ Flow captures development decisions in a journal (`.decisions/`) and analyzes th
 
 ## Configuration
 
-Settings in `.claude/settings.flow.json`:
+Settings cascade in priority order; later layers override earlier ones:
+
+1. `plugins/flow/settings.json` — plugin defaults
+2. `~/.claude/settings.flow.json` — user defaults
+3. `.claude/settings.flow.json` — project settings (committed)
+4. `.claude/settings.flow.local.json` — local overrides (gitignored, highest priority)
+
+Example project settings in `.claude/settings.flow.json`:
 
 ```json
 {

--- a/plugins/flow/references/decision-journal-schema.md
+++ b/plugins/flow/references/decision-journal-schema.md
@@ -69,12 +69,14 @@ Written by skills (e.g., `autonomous-workflow`, `change-classification`).
 
 ## Journal Directory
 
-Configurable in settings cascade:
+Configurable in the settings cascade (later layers override earlier ones):
 
-1. `.claude/settings.flow.local.json`
-2. `.claude/settings.flow.json`
-3. `~/.claude/settings.flow.json`
-4. `plugins/flow/settings.json`
+1. `plugins/flow/settings.json`
+2. `~/.claude/settings.flow.json`
+3. `.claude/settings.flow.json`
+4. `.claude/settings.flow.local.json` (highest priority)
+
+See [gate-configuration.md](gate-configuration.md#settings-file-locations) for the canonical cascade reference.
 
 ```json
 {

--- a/plugins/flow/references/gate-configuration.md
+++ b/plugins/flow/references/gate-configuration.md
@@ -4,12 +4,12 @@ Configuration reference for flow's safety gates and tier settings.
 
 ## Settings File Locations
 
-Settings are read in cascading order (first found wins):
+Settings cascade in priority order; later layers override earlier ones:
 
-1. `.claude/settings.flow.local.json` — local overrides (gitignored)
-2. `.claude/settings.flow.json` — project settings (committed)
-3. `~/.claude/settings.flow.json` — user defaults
-4. `plugins/flow/settings.json` — plugin defaults
+1. `plugins/flow/settings.json` — plugin defaults
+2. `~/.claude/settings.flow.json` — user defaults
+3. `.claude/settings.flow.json` — project settings (committed)
+4. `.claude/settings.flow.local.json` — local overrides (gitignored, highest priority)
 
 ## Tier Settings
 


### PR DESCRIPTION
## Summary

Closes #63. Settings cascade was described in opposite directions across docs — same behavior, opposite narration. Unified on the industry-conventional phrasing.

- **Canonical narration**: "Settings cascade in priority order; later layers override earlier ones" — list ordered most-general to most-specific (matches package.json extends, ESLint, Git config).
- **Sites updated**: `references/gate-configuration.md`, `references/decision-journal-schema.md` (also now points back to gate-configuration.md as the single source of truth), `README.md` Configuration section (cascade was previously not described explicitly).
- **commands/setup.md**: reviewed — does not narrate the cascade direction (only writes `.claude/settings.flow.json`), so no edit needed.
- **Removed**: "first found wins" phrasing that read backwards from the conventional cascade direction.

## Verification

- [x] `grep -rn 'first found wins' plugins/flow/` -> 0 matches
- [x] `grep -rn 'later layers override earlier' plugins/flow/` -> matches in every cascade reference (3)
- [x] All cascade lists order `plugins/flow/settings.json` FIRST and `.claude/settings.flow.local.json` LAST

## Note on conflicts

May conflict at merge with #58 (also touches README.md) and #60 (also touches gate-configuration.md). Trivial textual conflicts — flag for human resolution at merge time.