### PR TITLE
docs(flow): document Required Skills vs Skill() convention (#66)

### DIFF
--- a/plugins/flow/README.md
+++ b/plugins/flow/README.md
@@ -137,6 +137,22 @@ HOOKS (10 scripts)
   └── Experimental: verify-task-completion, nudge-idle-teammate, session-end-learn
 ```
 
+### Required Skills vs Skill() invocation convention
+
+Commands declare their skill dependencies in two complementary ways:
+
+- **`## Required Skills`** (declarative) — skills that inform the WHOLE command. Loaded as context at the start, applied throughout. Example: `code-review-methodology` for `/flow:review`.
+- **`Skill(X)`** (imperative) — explicit forks at specific phase boundaries where the command hands off to a skill for a discrete sub-task. Example: `Skill(capability-discovery)` invoked once during Phase 1 detection.
+
+Rules:
+
+1. Every command either has a `## Required Skills` section, or an explicit `_None — {reason}_` marker so the absence is intentional.
+2. Every `Skill(X)` invocation in a command body must resolve cleanly: `X` MUST also appear in that command's `## Required Skills` list. Invocation is a phase-specific call; the Required Skills list is the canonical dependency manifest, so all skill dependencies are visible in one place.
+3. A skill listed as Required does NOT need an explicit `Skill()` invocation — the command operates with it loaded as ambient context.
+4. Read-only / dispatcher commands (`status`, `learn`, `explain`, `flow`) typically have no domain skills and use the `_None_` marker.
+
+When auditing: grep for `Skill(` in command bodies and confirm each name appears in Required Skills.
+
 ## Commands
 
 | Command | Purpose |

--- a/plugins/flow/commands/explain.md
+++ b/plugins/flow/commands/explain.md
@@ -7,6 +7,10 @@ allowed-tools: Bash, Read, AskUserQuestion, Grep, Glob
 
 Interactive Q&A mode for understanding what was built and why. Read-only — no changes made.
 
+## Required Skills
+
+_None — explanatory Q&A over journal and diff context. No skill invocations._
+
 ## Phase 1: Load Context
 
 **Parallel operations:**

--- a/plugins/flow/commands/flow.md
+++ b/plugins/flow/commands/flow.md
@@ -14,6 +14,10 @@ simultaneously in a single message rather than sequentially.
 
 Universal dispatcher for the flow plugin. Parses intent from `$ARGUMENTS` and routes to the appropriate sub-command with required skills.
 
+## Required Skills
+
+_None — dispatcher only. Sub-commands declare their own Required Skills (see Skill Manifests below)._
+
 ## Skill Manifests
 
 Each verb requires specific domain skills. The dispatcher invokes these deterministically:

--- a/plugins/flow/commands/learn.md
+++ b/plugins/flow/commands/learn.md
@@ -7,6 +7,10 @@ allowed-tools: Bash, Read, Write, Grep, Glob
 
 Analyze the decision journal for recurring patterns and generate skill proposals.
 
+## Required Skills
+
+_None — retrospective pattern analysis over the decision journal. No skill invocations._
+
 ## Phase 1: Gather Journal Entries
 
 ```bash

--- a/plugins/flow/commands/setup.md
+++ b/plugins/flow/commands/setup.md
@@ -7,6 +7,10 @@ allowed-tools: Bash, Read, Write, Edit, AskUserQuestion, Skill, Glob, Grep, LSP
 
 Initialize the flow plugin for the current repository. On re-run, detects changes and offers to update settings and install missing LSP servers.
 
+## Required Skills
+
+- `capability-discovery` — detect tech stack, quality commands, existing agents/skills, and LSP capabilities (Phase 1)
+
 ## Phase 1: Detect Environment
 
 **Parallel operations:**

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -28,6 +28,7 @@ This command operates with these domain skills loaded:
 - `preflight-checks` — pure bash pre-flight validation (Phase 0)
 - `criterion-verification-map` — per-criterion evidence collection (Phase 2 + Phase 4)
 - `holdout-validation` — cross-reference self-review claims against file state (Phase 4)
+- `issue-crafting` — invoked when the issue body is missing acceptance criteria or needs reframing
 
 ## Phase 0: PRE-FLIGHT
 

--- a/plugins/flow/commands/status.md
+++ b/plugins/flow/commands/status.md
@@ -7,6 +7,10 @@ allowed-tools: Bash, Read
 
 Read-only overview of the current development state. No skills needed — pure observation.
 
+## Required Skills
+
+_None — read-only status command. No skill invocations._
+
 ## Gather State
 
 Execute all queries in parallel:


### PR DESCRIPTION
## Summary

Closes #66. Three patterns coexisted across `plugins/flow/commands/` with no rule. Documented the convention and reconciled inconsistencies.

- **Convention**: `Required Skills` = command-wide context; `Skill()` = explicit phase forks. All `Skill(X)` calls SHOULD have a corresponding Required Skills entry so the dependency manifest is visible in one place.
- **Doc**: added the convention as a new subsection under `## Architecture` in `plugins/flow/README.md` (sits next to the existing skill library tree).
- **Fixes**:
  - `setup.md` — added `## Required Skills` section listing `capability-discovery` (it invoked but never listed it)
  - `start.md` — added `issue-crafting` to its Required Skills (invoked at issue parsing but missing from the list)
- **Read-only / dispatcher commands** marked with explicit `_None — {reason}_` so absence is intentional:
  - `status.md` — read-only status command
  - `explain.md` — explanatory Q&A over journal and diff context
  - `learn.md` — retrospective pattern analysis over the decision journal
  - `flow.md` — dispatcher only; sub-commands declare their own skills

## Audit findings

Pre-fix violations (Skill() invocations missing from Required Skills):
- `setup.md`: invoked `Skill(capability-discovery)` but had NO Required Skills section at all
- `start.md`: invoked `Skill(issue-crafting)` but it was missing from the Required Skills list (the other two invocations, `capability-discovery` and `holdout-validation`, were already listed)

Post-fix verification: every `Skill(X)` invocation in every command resolves cleanly to a Required Skills entry. Commands with no skills carry an explicit `_None_` marker.

Note (per issue): `address.md` lists `change-classification`, `feedback-resolution`, `tdd-patterns` as Required without explicit `Skill()` invocations. Under the documented convention, that is correct: those skills inform the whole command rather than being invoked at a specific phase boundary. No change needed there.

## Verification

- [x] Every `Skill(X)` invocation in a command resolves to a Required Skills entry (or documented exemption)
- [x] Convention is documented in one canonical location (`plugins/flow/README.md` under Architecture)
- [x] Read-only / dispatcher commands have explicit None markers
- [x] All 17 commands have either a populated Required Skills section or an explicit `_None_` marker

## Conflict notice

May conflict with #61, #62, #64 at merge time (those touch `commands/pr.md`, `commands/review.md`, `commands/address.md`). This PR does not modify those three files, so conflicts should be limited to other dimensions; resolve at merge.