### PR TITLE
docs(slides): post-PR-95 corrections — clarify CLAUDE.md gotcha + mark adversarial team active

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ dist/
 ai-first-kit-workspace/*
 .claude/agents/*
 .claude/skills/*
+
+# Workshop slide renders (regenerate via Marp from .md sources)
+docs/flow-team-session/*.pdf

--- a/docs/flow-team-session/slides.md
+++ b/docs/flow-team-session/slides.md
@@ -495,7 +495,7 @@ Confirmation here is structural. The user has to say yes.
 /flow:start <issue>     ─── EXPLORE → PLAN → branch + tasks
 /flow:commit            ─── classify → atomic conventional commit
 /flow:pr                ─── push → parallel agent review → PR with body
-/flow:review <pr>       ─── 6-facet parallel review (adversarial team: roadmap v2.2)
+/flow:review <pr>       ─── 6-facet parallel review (adversarial team: not yet implemented)
 /flow:address <pr>      ─── categorize comments → surgical fix → re-request
 ```
 
@@ -653,7 +653,7 @@ If you vote anything non-default, that vote lands in #3 as part of the post-sess
 
 **Forcing question**: do we want `/flow:review` to spawn an adversarial team where reviewers challenge each other's findings? Higher signal, higher cost.
 
-**Status**: the `agentTeams` flag is present today, but the reviewer-vs-reviewer challenge protocol is roadmap (planned for v2.2). Voting `true` today sets the flag; behavior changes once the build lands.
+**Status**: the `agentTeams` flag is present today, but the reviewer-vs-reviewer challenge protocol is not yet implemented. Voting `true` today sets the flag; behavior changes once the build lands.
 
 ---
 
@@ -897,7 +897,7 @@ Verb mapping:
 | `/gh-start` | `/flow:start` | flow has Phase 0 preflight + Spec Validation Gate |
 | `/gh-commit` | `/flow:commit` | same vocabulary, different autonomy |
 | `/gh-pr` | `/flow:pr` | flow runs parallel agent review |
-| `/gh-review` | `/flow:review` | flow ships parallel multi-facet review; adversarial teams are roadmap (v2.2) |
+| `/gh-review` | `/flow:review` | flow ships parallel multi-facet review; adversarial teams are not yet implemented |
 | `/gh-merge` | `/flow:merge` | both Tier 3 |
 
 If you preferred gh-workflow's interactive style: opt out of strict defaults (HANDBOOK Appendix A). Don't fight the plugin — configure it.

--- a/docs/flow-team-session/slides.md
+++ b/docs/flow-team-session/slides.md
@@ -318,7 +318,7 @@ DOMAIN (contextually invoked, max 3 concurrent)
 ├── merge-and-release               ── Tier 3 prereq verification
 ├── merge-conflict-resolution       ── classify + resolve + verify
 ├── runtime-verification            ── build, run, smoke test
-├── team-coordination               ── adversarial review (opt-in)
+├── team-coordination               ── adversarial review (opt-in, active)
 ├── architecture-patterns           ── design-from-functionality, C4
 ├── brainstorming                   ── option generation, trade-off analysis
 ├── debugging-patterns              ── on any verification failure (not bug-only)
@@ -495,7 +495,7 @@ Confirmation here is structural. The user has to say yes.
 /flow:start <issue>     ─── EXPLORE → PLAN → branch + tasks
 /flow:commit            ─── classify → atomic conventional commit
 /flow:pr                ─── push → parallel agent review → PR with body
-/flow:review <pr>       ─── 6-facet parallel review (adversarial team: not yet implemented)
+/flow:review <pr>       ─── 6-facet parallel review (adversarial team: opt-in via agentTeams)
 /flow:address <pr>      ─── categorize comments → surgical fix → re-request
 ```
 
@@ -653,7 +653,7 @@ If you vote anything non-default, that vote lands in #3 as part of the post-sess
 
 **Forcing question**: do we want `/flow:review` to spawn an adversarial team where reviewers challenge each other's findings? Higher signal, higher cost.
 
-**Status**: the `agentTeams` flag is present today, but the reviewer-vs-reviewer challenge protocol is not yet implemented. Voting `true` today sets the flag; behavior changes once the build lands.
+**Status (2026-05-06)**: paired-reviewer dispatch + challenge round shipped in PR #95. Voting `true` enables the protocol when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set: 5 agent facets dispatch as skeptic + verifier pairs, the variants challenge each other's findings (AGREE/DISAGREE/REFINE), and the consolidated output emits a 7-field `FLOW_REVIEW_CYCLE` marker with `Confidence` + `Disposition` columns. Cost is ≈3.8× a single-session review; opt-in only.
 
 ---
 
@@ -816,7 +816,7 @@ Read-only. Safe to run anywhere, anytime. The "Suggested Next Action" line picks
 
 1. **`gh` CLI not authenticated** — preflight fails. Fix: `gh auth login`.
 2. **Dirty worktree on `/flow:start`** — preflight fails. Fix: stash or commit before starting.
-3. **`/flow:setup` doesn't add a CLAUDE.md section** — setup only appends to an *existing* `CLAUDE.md`. If you have none, setup skips the integration step. Create `CLAUDE.md` first (or copy `templates/CLAUDE-flow.md` manually) and re-run.
+3. **`CLAUDE.md` integration depends on file existence** — `/flow:setup` Phase 5 asks via AskUserQuestion whether to add the flow section. If you say yes, it appends `templates/CLAUDE-flow.md` to your existing `CLAUDE.md`. If `CLAUDE.md` doesn't exist yet, create it first (or copy the template manually) before answering yes.
 4. **`block-force-push` blocks a legitimate rebase push** — use `--force-with-lease`. Allowed and journaled (`three-tier-safety.md` line 41).
 5. **Auto-log seems to duplicate commits** — `log-commits.sh` is idempotent: it skips lines that already carry the `auto-log` marker. If you see duplication, your `plugin.json` is out of date — `claude plugins update flow`.
 
@@ -897,7 +897,7 @@ Verb mapping:
 | `/gh-start` | `/flow:start` | flow has Phase 0 preflight + Spec Validation Gate |
 | `/gh-commit` | `/flow:commit` | same vocabulary, different autonomy |
 | `/gh-pr` | `/flow:pr` | flow runs parallel agent review |
-| `/gh-review` | `/flow:review` | flow ships parallel multi-facet review; adversarial teams are not yet implemented |
+| `/gh-review` | `/flow:review` | flow ships parallel multi-facet review (adversarial teams opt-in) |
 | `/gh-merge` | `/flow:merge` | both Tier 3 |
 
 If you preferred gh-workflow's interactive style: opt out of strict defaults (HANDBOOK Appendix A). Don't fight the plugin — configure it.

--- a/docs/flow-team-session/slides.md
+++ b/docs/flow-team-session/slides.md
@@ -816,7 +816,7 @@ Read-only. Safe to run anywhere, anytime. The "Suggested Next Action" line picks
 
 1. **`gh` CLI not authenticated** — preflight fails. Fix: `gh auth login`.
 2. **Dirty worktree on `/flow:start`** — preflight fails. Fix: stash or commit before starting.
-3. **CLAUDE.md present** — `/flow:setup` offers to append the workflow section from `templates/CLAUDE-flow.md` to your existing `CLAUDE.md`. If no `CLAUDE.md` exists, setup skips this step — create one first or copy the template manually.
+3. **`/flow:setup` doesn't add a CLAUDE.md section** — setup only appends to an *existing* `CLAUDE.md`. If you have none, setup skips the integration step. Create `CLAUDE.md` first (or copy `templates/CLAUDE-flow.md` manually) and re-run.
 4. **`block-force-push` blocks a legitimate rebase push** — use `--force-with-lease`. Allowed and journaled (`three-tier-safety.md` line 41).
 5. **Auto-log seems to duplicate commits** — `log-commits.sh` is idempotent: it skips lines that already carry the `auto-log` marker. If you see duplication, your `plugin.json` is out of date — `claude plugins update flow`.
 

--- a/docs/flow-team-session/slides.md
+++ b/docs/flow-team-session/slides.md
@@ -495,7 +495,7 @@ Confirmation here is structural. The user has to say yes.
 /flow:start <issue>     ─── EXPLORE → PLAN → branch + tasks
 /flow:commit            ─── classify → atomic conventional commit
 /flow:pr                ─── push → parallel agent review → PR with body
-/flow:review <pr>       ─── 6-facet parallel review (or adversarial team)
+/flow:review <pr>       ─── 6-facet parallel review (adversarial team: roadmap v2.2)
 /flow:address <pr>      ─── categorize comments → surgical fix → re-request
 ```
 
@@ -652,6 +652,8 @@ If you vote anything non-default, that vote lands in #3 as part of the post-sess
 **Lands in**: `settings.flow.json` → `agentTeams` + env
 
 **Forcing question**: do we want `/flow:review` to spawn an adversarial team where reviewers challenge each other's findings? Higher signal, higher cost.
+
+**Status**: the `agentTeams` flag is present today, but the reviewer-vs-reviewer challenge protocol is roadmap (planned for v2.2). Voting `true` today sets the flag; behavior changes once the build lands.
 
 ---
 
@@ -814,7 +816,7 @@ Read-only. Safe to run anywhere, anytime. The "Suggested Next Action" line picks
 
 1. **`gh` CLI not authenticated** — preflight fails. Fix: `gh auth login`.
 2. **Dirty worktree on `/flow:start`** — preflight fails. Fix: stash or commit before starting.
-3. **No `CLAUDE.md`** — `/flow:setup` will offer to add a `CLAUDE-flow.md` section. Accept it or compose your own.
+3. **CLAUDE.md present** — `/flow:setup` offers to append the workflow section from `templates/CLAUDE-flow.md` to your existing `CLAUDE.md`. If no `CLAUDE.md` exists, setup skips this step — create one first or copy the template manually.
 4. **`block-force-push` blocks a legitimate rebase push** — use `--force-with-lease`. Allowed and journaled (`three-tier-safety.md` line 41).
 5. **Auto-log seems to duplicate commits** — `log-commits.sh` is idempotent: it skips lines that already carry the `auto-log` marker. If you see duplication, your `plugin.json` is out of date — `claude plugins update flow`.
 
@@ -895,7 +897,7 @@ Verb mapping:
 | `/gh-start` | `/flow:start` | flow has Phase 0 preflight + Spec Validation Gate |
 | `/gh-commit` | `/flow:commit` | same vocabulary, different autonomy |
 | `/gh-pr` | `/flow:pr` | flow runs parallel agent review |
-| `/gh-review` | `/flow:review` | flow supports adversarial teams (opt-in) |
+| `/gh-review` | `/flow:review` | flow ships parallel multi-facet review; adversarial teams are roadmap (v2.2) |
 | `/gh-merge` | `/flow:merge` | both Tier 3 |
 
 If you preferred gh-workflow's interactive style: opt out of strict defaults (HANDBOOK Appendix A). Don't fight the plugin — configure it.


### PR DESCRIPTION
## Summary

Targeted slide corrections from a comprehensive review of the workshop deck (`docs/flow-team-session/slides.md`) against the actual flow plugin implementation. Updated 2026-05-06 cycle 1 to reflect that the adversarial challenge phase **shipped today** in PR #95.

## Changes

- **Slide 321** (Foundation/Domain skill tree): `team-coordination` annotated as "(opt-in, active)" to mark the protocol as live, not just opt-in-able.
- **Slide 498** (Daily five): `/flow:review` row says "(adversarial team: opt-in via agentTeams)" — neither stale nor over-promising.
- **Slide 656** (Decision 3 — Agent teams): Status note now reflects PR #95 ship: paired (skeptic + verifier) dispatch, disposition-only challenge round, 7-field marker emission, and ≈3.8× cost — opt-in only.
- **Slide 819** (Common gotchas #3 — CLAUDE.md): rewrite to match actual setup.md Phase 5 behavior (Phase 5 asks via AskUserQuestion; the integration is conditional on user consent + existing `CLAUDE.md`).
- **Slide 900** (gh-workflow migration table): `/flow:review` cell shortened to "parallel multi-facet review (adversarial teams opt-in)".
- **`.gitignore`**: ignore `docs/flow-team-session/*.pdf` (Marp build artifacts; regenerate from `.md` sources).

## Followups

- ~~#82~~ — `code-review-methodology` SKILL.md "5-facet" — closed (PR #88).
- ~~#86~~ — adversarial challenge phase — closed today (PR #95).
- #81, #84, #85 — other plugin-internal corrections from the same review (status pending).

## Test plan

- [x] Inspected diff: only the targeted slide segments and the `.gitignore` line changed.
- [x] Confirmed no other slides reference behaviors made stale by PR #95 merge.
- [x] Cycle-1 paired-reviewer review (Path A end-to-end test, posted as review `4234710205` on this PR) — 23 findings, addressed in fix-forward.

Refs #86 (closed via PR #95)
