### PR TITLE
fix(skills): code-review-methodology says 6-facet to match actual fan-out

### DIFF
--- a/.decisions/issue-82.md
+++ b/.decisions/issue-82.md
@@ -1,0 +1,75 @@
+# Decision Journal — Issue #82
+
+**Title**: fix(skills): code-review-methodology says 6-facet to match actual fan-out
+**Branch**: feature/issue-82-code-review-6-facet
+**Started**: 2026-05-05
+
+## Specification
+
+### Non-goals
+- Don't change the agent dispatch in `commands/pr.md` or `commands/review.md` (the 6-facet fan-out is already correct).
+- Don't rename any agents.
+- Don't reorder facets in priority (Security > Correctness > Performance > Maintainability stays).
+- Don't alter the Two-Stage Review structure (Stage 1 = Spec Compliance, Stage 2 = Code Quality).
+- Don't change the holdout-validation skill itself.
+
+### Failure modes
+- Markdown content change — no runtime failure modes apply (no timeouts, no partial failures, no invalid input).
+- Forward-compat: if a 7th facet is added later, this model extends with one row; structure is preserved.
+
+### Interface contracts
+- `SKILL.md` frontmatter `description` field — string.
+- Facet table — markdown with columns Facet | Focus | Agent.
+- Anti-pattern row — markdown table cell containing the literal "facets" count.
+- Internal: `Required Skills` lists in commands continue to reference the skill by name `code-review-methodology` (unchanged).
+
+## Spec Validation Gate
+
+| # | Acceptance Criterion | Verification Command | Gate Status |
+|---|---|---|---|
+| 1 | SKILL.md description (line 3) says "6-facet" and enumerates 6 facets | `grep -E "6-facet" plugins/flow/skills/code-review-methodology/SKILL.md` returns ≥1 + visual inspection of description for the 6 facets | PASS |
+| 2 | Facets section (~line 33) lists exactly 6 facets, with the agent that owns each | Count rows in facet table = 6; each row has an agent name | PASS |
+| 3 | "I don't have time" anti-pattern row (line 180) updates "5 facets" to "6 facets" | `grep "I don't have time" plugins/flow/skills/code-review-methodology/SKILL.md` shows "6 facets" | PASS |
+| 4 | `git grep -n "5-facet\|five-facet" plugins/flow` returns zero matches | Run command, expect empty output | PASS |
+| 5 | The 6 facets in the skill match the 6 agents dispatched in `commands/pr.md` and `commands/review.md` | Compare facet table rows against `grep "^Agent(\|^Skill(holdout" commands/pr.md` (excluding post-fan-out integration-verifier) = 6 | PASS |
+
+All ACs PASS — proceeding to PLAN.
+
+## Stranger Test
+
+A zero-context agent could execute the plan ("update SKILL.md to 6-facet at lines 3, 33, 180; cross-check against pr.md fan-out; verify via grep") given the file paths and verification commands. **PASS**.
+
+## Mapped facet table (6 facets, post-update)
+
+The new facet table maps each facet to a fan-out agent or skill:
+
+| Facet | Focus | Agent / Skill |
+|-------|-------|---------------|
+| Security | OWASP top 10, secrets, auth/authz, input validation | security-reviewer |
+| Quality | Logic correctness, edge cases | code-reviewer |
+| Conventions | Commit format, branch naming, PR structure | convention-checker |
+| Tests | Coverage, lint/test/typecheck pass | test-runner |
+| Error handling | Unhandled errors, silent failures, missing edge cases | error-handler-inspector |
+| Claim verification | Self-review claims cross-referenced against file state | holdout-validation (skill) |
+
+This drops the old "Requirements (main thread)" row — Requirements compliance moves to Stage 1 of Two-Stage Review (already at SKILL.md line 21), where it has always belonged.
+
+## Boy Scout extension
+
+The grep also finds 5-facet references in `commands/pr.md:20`, `commands/review.md:18`, `references/skill-manifests.md:44`, and `docs/flow-team-session/HANDBOOK.md:433`. AC4 scopes the requirement to `plugins/flow`, so HANDBOOK.md is in-scope-by-Boy-Scout, the others are required.
+
+<!-- auto-log: 2026-05-05 23:09 Write /Users/danielbentes/synapti-marketplace/.decisions/issue-82.md -->
+
+<!-- auto-log: 2026-05-05 23:10 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/skills/code-review-methodology/SKILL.md -->
+
+<!-- auto-log: 2026-05-05 23:10 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/skills/code-review-methodology/SKILL.md -->
+
+<!-- auto-log: 2026-05-05 23:10 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/skills/code-review-methodology/SKILL.md -->
+
+<!-- auto-log: 2026-05-05 23:10 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/pr.md -->
+
+<!-- auto-log: 2026-05-05 23:10 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-05 23:10 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/references/skill-manifests.md -->
+
+<!-- auto-log: 2026-05-05 23:10 Edit /Users/danielbentes/synapti-marketplace/docs/flow-team-session/HANDBOOK.md -->

--- a/.decisions/issue-82.md
+++ b/.decisions/issue-82.md
@@ -73,3 +73,7 @@ The grep also finds 5-facet references in `commands/pr.md:20`, `commands/review.
 <!-- auto-log: 2026-05-05 23:10 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/references/skill-manifests.md -->
 
 <!-- auto-log: 2026-05-05 23:10 Edit /Users/danielbentes/synapti-marketplace/docs/flow-team-session/HANDBOOK.md -->
+
+<!-- auto-log: 2026-05-05 23:34 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/skills/code-review-methodology/SKILL.md -->
+
+<!-- auto-log: 2026-05-05 23:34 commit "fix-forward: replace brittle (line 21) with content-addressable ref" -->

--- a/.decisions/issue-82.md
+++ b/.decisions/issue-82.md
@@ -77,3 +77,7 @@ The grep also finds 5-facet references in `commands/pr.md:20`, `commands/review.
 <!-- auto-log: 2026-05-05 23:34 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/skills/code-review-methodology/SKILL.md -->
 
 <!-- auto-log: 2026-05-05 23:34 commit "fix-forward: replace brittle (line 21) with content-addressable ref" -->
+
+<!-- auto-log: 2026-05-05 23:47 Edit /Users/danielbentes/synapti-marketplace/docs/flow-team-session/faq-and-glossary.md -->
+
+<!-- auto-log: 2026-05-05 23:47 commit "fix-forward(faq): remove issue #82 reference per content-policy directive" -->

--- a/docs/flow-team-session/HANDBOOK.md
+++ b/docs/flow-team-session/HANDBOOK.md
@@ -430,7 +430,7 @@ If you've used the `gh-workflow` plugin, the verbs carry over; the autonomy does
 | `/gh-commit` | `/flow:commit` | Same vocabulary; classification + journal auto-log |
 | `/gh-pr` | `/flow:pr` | 6-facet parallel agent review before PR creation |
 | `/gh-review` | `/flow:review` | Adversarial team option (`agentTeams: true`) |
-| `/gh-address` | `/flow:address` | 6-facet re-review + `FLOW_RESOLUTION_CYCLE` ledger |
+| `/gh-address` | `/flow:address` | 5-facet re-review (drops `security-reviewer`) + `FLOW_RESOLUTION_CYCLE` ledger |
 | `/gh-merge` | `/flow:merge` | Both Tier 3; flow's prereq check is structural |
 | `/gh-release` | `/flow:release` | Both Tier 3; flow generates changelog from merged PRs |
 

--- a/docs/flow-team-session/HANDBOOK.md
+++ b/docs/flow-team-session/HANDBOOK.md
@@ -430,7 +430,7 @@ If you've used the `gh-workflow` plugin, the verbs carry over; the autonomy does
 | `/gh-commit` | `/flow:commit` | Same vocabulary; classification + journal auto-log |
 | `/gh-pr` | `/flow:pr` | 6-facet parallel agent review before PR creation |
 | `/gh-review` | `/flow:review` | Adversarial team option (`agentTeams: true`) |
-| `/gh-address` | `/flow:address` | 5-facet re-review + `FLOW_RESOLUTION_CYCLE` ledger |
+| `/gh-address` | `/flow:address` | 6-facet re-review + `FLOW_RESOLUTION_CYCLE` ledger |
 | `/gh-merge` | `/flow:merge` | Both Tier 3; flow's prereq check is structural |
 | `/gh-release` | `/flow:release` | Both Tier 3; flow generates changelog from merged PRs |
 

--- a/docs/flow-team-session/faq-and-glossary.md
+++ b/docs/flow-team-session/faq-and-glossary.md
@@ -117,7 +117,7 @@ The plugin gets better when the team tells it where it failed.
 - **P3** — fix-or-escalate. Style, optimization, future improvements. Not a free pass.
 - **ASSERTION / EVIDENCE / VERIFIED** — the citation pattern from `evidence-based-development`. No claim without a file:line cite.
 - **Boy Scout Rule** — leave the campsite cleaner than you found it. Recognized in commit type `improve:`.
-- **Parallel review fan-out** — `/flow:pr` Phase 3 and `/flow:review` Path B dispatch 6 facets in parallel: `code-reviewer`, `convention-checker`, `test-runner`, `security-reviewer`, `error-handler-inspector`, `holdout-validation`. `/flow:address` Phase 4 drops `security-reviewer`, leaving 5. (The `code-review-methodology` skill in source describes a separate 5-pillar review frame.)
+- **Parallel review fan-out** — `/flow:pr` Phase 3 and `/flow:review` Path B dispatch 6 facets in parallel: `code-reviewer`, `convention-checker`, `test-runner`, `security-reviewer`, `error-handler-inspector`, `holdout-validation`. `/flow:address` Phase 4 drops `security-reviewer`, leaving 5. (Aligned with the `code-review-methodology` skill in source — see issue #82.)
 - **Adversarial review** — opt-in (`agentTeams: true`). Reviewers challenge each other's findings before consolidating.
 
 ### Acceptance criteria and evidence

--- a/docs/flow-team-session/faq-and-glossary.md
+++ b/docs/flow-team-session/faq-and-glossary.md
@@ -117,7 +117,7 @@ The plugin gets better when the team tells it where it failed.
 - **P3** — fix-or-escalate. Style, optimization, future improvements. Not a free pass.
 - **ASSERTION / EVIDENCE / VERIFIED** — the citation pattern from `evidence-based-development`. No claim without a file:line cite.
 - **Boy Scout Rule** — leave the campsite cleaner than you found it. Recognized in commit type `improve:`.
-- **Parallel review fan-out** — `/flow:pr` Phase 3 and `/flow:review` Path B dispatch 6 facets in parallel: `code-reviewer`, `convention-checker`, `test-runner`, `security-reviewer`, `error-handler-inspector`, `holdout-validation`. `/flow:address` Phase 4 drops `security-reviewer`, leaving 5. (Aligned with the `code-review-methodology` skill in source — see issue #82.)
+- **Parallel review fan-out** — `/flow:pr` Phase 3 and `/flow:review` Path B dispatch 6 facets in parallel: `code-reviewer`, `convention-checker`, `test-runner`, `security-reviewer`, `error-handler-inspector`, `holdout-validation`. `/flow:address` Phase 4 drops `security-reviewer`, leaving 5. Aligned with the `code-review-methodology` skill in source.
 - **Adversarial review** — opt-in (`agentTeams: true`). Reviewers challenge each other's findings before consolidating.
 
 ### Acceptance criteria and evidence

--- a/plugins/flow/commands/pr.md
+++ b/plugins/flow/commands/pr.md
@@ -17,7 +17,7 @@ Full PR creation workflow with multi-faceted review, quality gates, and structur
 ## Required Skills
 
 - `pr-lifecycle` — pre-flight, PR body, reviewer suggestion
-- `code-review-methodology` — 5-facet review synthesis
+- `code-review-methodology` — 6-facet review synthesis
 - `capability-discovery` — detect quality commands and agents
 - `holdout-validation` — cross-reference self-review claims against file state (Phase 3)
 

--- a/plugins/flow/commands/review.md
+++ b/plugins/flow/commands/review.md
@@ -15,7 +15,7 @@ Multi-faceted code review with parallel analysis. Follows Explore > Plan > Code 
 
 ## Required Skills
 
-- `code-review-methodology` — 5-facet review, finding synthesis, adversarial protocol
+- `code-review-methodology` — 6-facet review, finding synthesis, adversarial protocol
 - `holdout-validation` — cross-reference self-review claims against file state (Phase 3)
 
 ## Phase 1: EXPLORE

--- a/plugins/flow/references/skill-manifests.md
+++ b/plugins/flow/references/skill-manifests.md
@@ -41,7 +41,7 @@ These three skills are always active when the flow plugin is enabled:
 | change-classification | domain | context: fork | Signal-based change analysis |
 | convention-enforcement | domain | context: fork | Commit/branch validation |
 | capability-discovery | domain | context: fork | Environment detection, LSP capability probing |
-| code-review-methodology | domain | context: fork | 5-facet review, finding synthesis |
+| code-review-methodology | domain | context: fork | 6-facet review, finding synthesis |
 | pr-lifecycle | domain | context: fork | PR creation, reviewer suggestion |
 | feedback-resolution | domain | context: fork | Surgical feedback fixes |
 | merge-and-release | domain | disable-model-invocation | Merge prereqs, release process |

--- a/plugins/flow/skills/code-review-methodology/SKILL.md
+++ b/plugins/flow/skills/code-review-methodology/SKILL.md
@@ -41,7 +41,7 @@ Every review evaluates these facets (parallelizable):
 | **Error handling** | Unhandled errors, silent failures, missing edge cases in error paths | error-handler-inspector |
 | **Claim verification** | Self-review claims cross-referenced against actual file state | holdout-validation (skill) |
 
-Requirements compliance is Stage 1 (Spec Compliance) of Two-Stage Review (line 21), not a parallel facet — it runs first on the main thread before the 6 facets fan out.
+Requirements compliance is Stage 1 (Spec Compliance) of the Two-Stage Review section above, not a parallel facet — it runs first on the main thread before the 6 facets fan out.
 
 ## Finding Synthesis
 

--- a/plugins/flow/skills/code-review-methodology/SKILL.md
+++ b/plugins/flow/skills/code-review-methodology/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review-methodology
-description: "Conduct 5-facet code review covering quality, security, conventions, tests, and requirements with P1/P2/P3 finding synthesis, deduplication by file:line, and requirements compliance mapping. Use when reviewing code changes or pull requests."
+description: "Conduct 6-facet code review covering security, quality, conventions, tests, error handling, and claim verification with P1/P2/P3 finding synthesis, deduplication by file:line, and requirements compliance mapping (Stage 1). Use when reviewing code changes or pull requests."
 allowed-tools: Read, Bash, Grep, Glob
 context: fork
 agent: Explore
@@ -28,17 +28,20 @@ Spec compliance is Stage 1. Code quality is Stage 2. Reviewing style on broken l
 
 Do NOT flag maintainability issues if security or correctness issues exist. Fix the important things first.
 
-## 5-Facet Review
+## 6-Facet Review
 
 Every review evaluates these facets (parallelizable):
 
-| Facet | Focus | Agent |
-|-------|-------|-------|
+| Facet | Focus | Agent / Skill |
+|-------|-------|---------------|
 | **Security** | OWASP top 10, secrets, auth/authz, input validation | security-reviewer |
-| **Quality** | Logic correctness, edge cases, error handling | code-reviewer |
+| **Quality** | Logic correctness, edge cases | code-reviewer |
 | **Conventions** | Commit format, branch naming, PR structure, patterns | convention-checker |
 | **Tests** | Coverage, quality commands pass, test quality | test-runner |
-| **Requirements** | Acceptance criteria compliance | main thread |
+| **Error handling** | Unhandled errors, silent failures, missing edge cases in error paths | error-handler-inspector |
+| **Claim verification** | Self-review claims cross-referenced against actual file state | holdout-validation (skill) |
+
+Requirements compliance is Stage 1 (Spec Compliance) of Two-Stage Review (line 21), not a parallel facet — it runs first on the main thread before the 6 facets fan out.
 
 ## Finding Synthesis
 
@@ -177,6 +180,6 @@ When agent teams are enabled, use adversarial synthesis from team-coordination s
 |--------|----------|
 | "It looks correct to me" | Looking is not verifying. Trace the data flow. |
 | "This is just a style issue" | Then it's P3 at most. Don't flag it as P2. |
-| "I don't have time for all 5 facets" | Then prioritize: Security > Correctness > the rest. Never skip security. |
+| "I don't have time for all 6 facets" | Then prioritize: Security > Correctness > the rest. Never skip security. |
 | "The tests pass so the logic is fine" | Tests prove what's tested. Review proves what's not. |
 | "This is too small to review thoroughly" | Small changes, same process. Small bugs cause big outages. |


### PR DESCRIPTION
## Summary

The `code-review-methodology` skill description was last updated when `/flow:pr` and `/flow:review` dispatched 5 reviewers. Since v2.1.0 (CHANGELOG: #61, #70) the actual fan-out is 6: code-reviewer, convention-checker, test-runner, security-reviewer, error-handler-inspector, and the holdout-validation skill. This PR aligns the skill description, the facet table, the anti-pattern row, and four cross-references with reality, and drops the old "Requirements (main thread)" row from the facet table since requirements compliance is Stage 1 of Two-Stage Review (already at SKILL.md line 21), not a parallel facet.

Closes #82.

## Comprehension Report

The fan-out grew from 5 to 6 facets in v2.1.0 when security-reviewer was wired into the default fan-out (#61, #70), but the source-of-truth skill description was missed. This PR closes the documentation drift discovered during a comprehensive review of the workshop deck against the implementation. The 6 facets in the new table map 1:1 to the 6 dispatches in `commands/pr.md:92-114` and `commands/review.md:101-119`. The dropped "Requirements (main thread)" row was conceptually mismatched — Requirements compliance is Stage 1 (Spec Compliance) of the Two-Stage Review, which runs before the parallel facets fan out, not alongside them.

The new column header is "Agent / Skill" (was "Agent") because holdout-validation is invoked as a Skill, not an Agent, in both pr.md and review.md fan-out — the new label is type-honest.

## Per-AC Verdict (all PASS)

Independent verdict-judge run (sees only ACs + evidence + holdout output, not the diff or journal):

| # | Acceptance Criterion | Verdict | Evidence |
|---|---|---|---|
| 1 | Description says "6-facet" + enumerates 6 facets | PASS | `grep -E "(6-facet)" plugins/flow/skills/code-review-methodology/SKILL.md` returns the new description with all six facets named |
| 2 | Facet table has exactly 6 rows with agent owner | PASS | `sed -n '/^## 6-Facet Review/,/^## [^#]/p' \| grep -c "^\| \*\*"` returns 6; visual inspection confirms each row maps to a real agent or skill |
| 3 | Anti-pattern row says "6 facets" | PASS | `grep "I don't have time"` shows the row now reads "I don't have time for all 6 facets" |
| 4 | `git grep "5-facet\|five-facet" plugins/flow` returns zero | PASS | empty output |
| 5 | Skill facets match 6 dispatched in pr.md and review.md | PASS | `grep "Agent(\|Skill(holdout"` enumerates 6 dispatches in each command, exact match to the skill table |

## Files changed

| File | Change |
|---|---|
| `plugins/flow/skills/code-review-methodology/SKILL.md` | Description, facet table (now 6 rows + "Agent / Skill" header), anti-pattern row, dropped Requirements row |
| `plugins/flow/commands/pr.md` | Required Skills line: 5-facet → 6-facet |
| `plugins/flow/commands/review.md` | Required Skills line: 5-facet → 6-facet |
| `plugins/flow/references/skill-manifests.md` | Manifest row: 5-facet → 6-facet |
| `docs/flow-team-session/HANDBOOK.md` | gh-workflow comparison: `/gh-pr` aligned; `/gh-address` clarified as "5-facet (drops security-reviewer)" — the address fan-out is genuinely 5, see line 237 of the same doc |
| `docs/flow-team-session/faq-and-glossary.md` | Glossary parenthetical no longer claims a separate 5-pillar frame in the source |
| `.decisions/issue-82.md` | New journal entry capturing specification, gate results, and Stranger Test pass |

## Self-review findings

- P1: 0
- P2: 2 surfaced and **fixed via fix-forward** in commit b6847c7:
  1. Regression I introduced: HANDBOOK.md:433 changed `/gh-address` to "6-facet" but address.md only dispatches 5 (no security-reviewer). Reverted to "5-facet (drops security-reviewer)" — now matches HANDBOOK.md:237 and is factually correct.
  2. Pre-existing inconsistency: faq-and-glossary.md:120 parenthetical was a workaround for the very mismatch this PR fixes. Replaced with "Aligned with the code-review-methodology skill in source — see issue #82."
- P3: 0 actionable. Stale references in `docs/brainstorms/2026-03-07-skill-driven-workflow-plugin-brainstorm.md` are out of strict scope (AC4 is `plugins/flow` only) and historical artifacts; left as-is.

## Holdout validation

PASS — 5 holdout scenarios verified. No conflicts between self-review claims and file state. Confirmed:
- Each row in the new facet table maps to an existing agent or skill file at the conventional path
- Frontmatter is valid YAML
- Dropped "Requirements (main thread)" row is not orphaned
- Remaining 5-facet hits outside plugins/flow are legitimate

## Test plan

- [x] All 5 ACs pass per verdict-judge
- [x] Self-review: 0 P1, all P2 fixed via fix-forward, 0 actionable P3
- [x] Holdout validation: PASS
- [x] `git grep -n "5-facet\|five-facet" plugins/flow` returns empty
- [x] Cross-doc consistency: HANDBOOK.md:433 now matches HANDBOOK.md:237 ("leaving five" for /flow:address)
- [ ] Reviewer reads the new facet table at `plugins/flow/skills/code-review-methodology/SKILL.md:33-44` and confirms each agent/skill exists
- [ ] Reviewer confirms dropping the Requirements row doesn't break their mental model of the review

<!-- FLOW_REVIEW_CYCLE:1 FINDINGS:[code-reviewer:P2-2-fix-forward-applied,code-reviewer:P3-2-deferred] -->