### PR TITLE
chore(flow): landing 1 — surgical cleanup (descriptions, hooks, parity, settings)

### DIFF
--- a/plugins/flow/CHANGELOG.md
+++ b/plugins/flow/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2.1.1 (2026-05-06)
+
+Surgical cleanup landing — descriptions, parity, dead code. No behavior changes; existing tests untouched. Pre-work for the structural overhaul (Landings 2 and 3).
+
+### Documentation
+
+- All 22 skill descriptions rewritten to lead with the artifact, name 2-3 specific triggers, and add either "MUST be consulted because…" (verification, safety, and gate-enforcing skills) or "Proactively suggest when…" (creative and exploratory skills) — bringing the active skills into the same trigger pattern that drove `holdout-validation`'s invocation rate from ~0% to the high 90s.
+- README adds a Hook Compatibility table noting that `TaskCompleted` and `TeammateIdle` hooks require Claude Code v2.1.33+ and treat their JSON payloads as best-effort because the schema is undocumented.
+- `code-review-methodology` skill now cites `references/test-review-checklist.md` for the Tests facet.
+- `pr-lifecycle` skill now cites `references/gate-configuration.md#quality-gates` for the canonical map of the eight gates flow enforces.
+- `merge.markerTrust` is now documented in `schema.json` with an inline rationale explaining the security-driven decision to read it from `plugins/flow/settings.json` only (no settings cascade).
+
+### Bug Fixes
+
+- `/flow:address` Phase 4 fan-out now explicitly enumerates all 5 reviewer agents (added `security-reviewer`); previously claimed pr.md parity by reference but the dispatch block only listed 4 agents — security review was silently skipped on every re-review.
+- `session-end-learn.sh` no longer false-matches today's date string when it appears inside journal content (e.g. due-date references in older entries). Switched from `grep -q "$TODAY"` to `find -mtime -1` for portable, content-agnostic detection of recent journal activity.
+- Removed unused `journal.sensitivityDefault` setting from `settings.json` and `schema.json` (no consumer existed). Related references in `gate-configuration.md` and `decision-journal-schema.md` updated.
+
 ## 2.1.0 (2026-05-05)
 
 ### New Features

--- a/plugins/flow/CHANGELOG.md
+++ b/plugins/flow/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 2.1.1 (2026-05-06)
 
-Surgical cleanup landing — descriptions, parity, dead code. No behavior changes; existing tests untouched. Pre-work for the structural overhaul (Landings 2 and 3).
-
 ### Documentation
 
 - All 22 skill descriptions rewritten to lead with the artifact, name 2-3 specific triggers, and add either "MUST be consulted because…" (verification, safety, and gate-enforcing skills) or "Proactively suggest when…" (creative and exploratory skills) — bringing the active skills into the same trigger pattern that drove `holdout-validation`'s invocation rate from ~0% to the high 90s.

--- a/plugins/flow/README.md
+++ b/plugins/flow/README.md
@@ -139,6 +139,19 @@ HOOKS (8 scripts)
   AskUserQuestion (see references/three-tier-safety.md), not as hooks.
 ```
 
+### Hook Compatibility
+
+| Event | Wired Script | Min. Claude Code | Notes |
+|-------|--------------|------------------|-------|
+| `PreToolUse` (Bash) | `block-force-push`, `block-destructive`, `block-secrets` | All current | Documented event |
+| `PostToolUse` (Edit\|Write) | `log-file-changes` | All current | Documented event |
+| `PostToolUse` (Bash) | `log-commits` | All current | Documented event |
+| `SessionEnd` | `session-end-learn` | All current | Documented event |
+| `TaskCompleted` | `verify-task-completion` | **v2.1.33+** | See note below |
+| `TeammateIdle` | `nudge-idle-teammate` | **v2.1.33+** | See note below |
+
+`TaskCompleted` and `TeammateIdle` were added in Claude Code v2.1.33 as part of agent-team support and are not currently listed in the public hooks documentation at https://code.claude.com/docs/en/hooks (see anthropics/claude-code#23545). The events DO fire today; the JSON payload schema for both is undocumented, so the hooks treat their expected fields (`.task.subject`, `.task.description`, `.teammate.id`, `.idle_seconds`) as best-effort and exit 0 silently when those fields are absent rather than blocking on schema drift. The `v2.1.33+` floor only matters for installs running an older Claude Code build.
+
 ### Required Skills vs Skill() invocation convention
 
 Commands declare their skill dependencies in two complementary ways:

--- a/plugins/flow/README.md
+++ b/plugins/flow/README.md
@@ -150,7 +150,7 @@ HOOKS (8 scripts)
 | `TaskCompleted` | `verify-task-completion` | **v2.1.33+** | See note below |
 | `TeammateIdle` | `nudge-idle-teammate` | **v2.1.33+** | See note below |
 
-`TaskCompleted` and `TeammateIdle` were added in Claude Code v2.1.33 as part of agent-team support and are not currently listed in the public hooks documentation at https://code.claude.com/docs/en/hooks (see anthropics/claude-code#23545). The events DO fire today; the JSON payload schema for both is undocumented, so the hooks treat their expected fields (`.task.subject`, `.task.description`, `.teammate.id`, `.idle_seconds`) as best-effort and exit 0 silently when those fields are absent rather than blocking on schema drift. The `v2.1.33+` floor only matters for installs running an older Claude Code build.
+`TaskCompleted` and `TeammateIdle` were introduced alongside agent-team support in Claude Code v2.1.33 and are not currently listed in the public hooks documentation. The events DO fire today; the JSON payload schema for both is undocumented, so the hooks treat their expected fields (`.task.subject`, `.task.description`, `.teammate.id`, `.idle_seconds`) as best-effort and exit 0 silently when those fields are absent rather than blocking on schema drift. The `v2.1.33+` floor only matters for installs running an older Claude Code build.
 
 ### Required Skills vs Skill() invocation convention
 

--- a/plugins/flow/commands/address.md
+++ b/plugins/flow/commands/address.md
@@ -188,10 +188,20 @@ For cosmetic P3 findings in untouched files that the team agrees to track separa
       haven't been introduced by the fix commits since the last review.
       Return structured results table."
 
+   Agent(security-reviewer):
+     "Review the fix commits since the last review against $DEFAULT_BRANCH
+      for OWASP Top 10, secrets, auth/authz, input validation, and dependency
+      vulnerabilities. Return P1/P2/P3 findings with file:line."
+
    Agent(error-handler-inspector):
      "Check error handling in the changed scope of the fix commits since
       the last review. Return P1/P2/P3 findings with file:line."
    ```
+
+   This dispatch is the canonical re-review fan-out — exactly the same five
+   reviewer agents `/flow:pr` Phase 3 dispatches. Keeping the agent list
+   explicit here (rather than referencing pr.md by name) makes parity locally
+   verifiable and prevents silent drift if either command's roster changes.
 3. **Holdout validation** — after self-review, invoke `holdout-validation` to cross-reference claims against file state:
    ```
    Skill(holdout-validation):

--- a/plugins/flow/hooks/scripts/nudge-idle-teammate.sh
+++ b/plugins/flow/hooks/scripts/nudge-idle-teammate.sh
@@ -2,12 +2,11 @@
 # [flow] TeammateIdle hook: Nudge idle teammates toward unclaimed tasks
 # Feedback delivered via stderr output (exit 0 always — exit 2 has no semantics here)
 #
-# Compatibility: requires Claude Code v2.1.33+ (TeammateIdle event was added there;
-# see https://github.com/anthropics/claude-code/issues/23545). The exact JSON payload
-# schema for this event is not officially documented today, so the hook treats
-# `.teammate.id` and `.idle_seconds` as best-effort fields. When `.idle_seconds` is
-# missing the default of 0 fails the >=60s threshold and the hook exits silently
-# rather than producing noisy nudges.
+# Compatibility: requires Claude Code v2.1.33+ (TeammateIdle event was introduced
+# alongside agent-team support). The JSON payload schema is not officially documented,
+# so the hook treats `.teammate.id` and `.idle_seconds` as best-effort fields. When
+# `.idle_seconds` is missing the default of 0 fails the >=60s threshold and the hook
+# exits silently rather than producing noisy nudges.
 
 set -euo pipefail
 

--- a/plugins/flow/hooks/scripts/nudge-idle-teammate.sh
+++ b/plugins/flow/hooks/scripts/nudge-idle-teammate.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 # [flow] TeammateIdle hook: Nudge idle teammates toward unclaimed tasks
 # Feedback delivered via stderr output (exit 0 always — exit 2 has no semantics here)
+#
+# Compatibility: requires Claude Code v2.1.33+ (TeammateIdle event was added there;
+# see https://github.com/anthropics/claude-code/issues/23545). The exact JSON payload
+# schema for this event is not officially documented today, so the hook treats
+# `.teammate.id` and `.idle_seconds` as best-effort fields. When `.idle_seconds` is
+# missing the default of 0 fails the >=60s threshold and the hook exits silently
+# rather than producing noisy nudges.
 
 set -euo pipefail
 

--- a/plugins/flow/hooks/scripts/session-end-learn.sh
+++ b/plugins/flow/hooks/scripts/session-end-learn.sh
@@ -1,14 +1,21 @@
 #!/bin/bash
 # [flow] SessionEnd hook: Flag pending learning analysis
-# Lightweight — only marks pending, does NOT run full analysis (too slow for session end)
+# Lightweight — only marks pending, does NOT run full analysis (too slow for session end).
+#
+# Detects "recent activity" by file mtime rather than grepping for today's date string.
+# The previous grep approach false-matched dates that appeared inside journal *content*
+# (e.g. due-date references in older entries) rather than only matching entries actually
+# written today. `find -mtime -1` is portable across BSD (macOS) and GNU find.
 
 set -euo pipefail
 
 # Graceful: if jq unavailable, skip learning
 command -v jq &>/dev/null || exit 0
 
+# Drain stdin (Claude Code passes JSON; reading prevents SIGPIPE on the writer side
+# even though we currently do not consume any field from the payload).
 INPUT=$(cat)
-TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+: "${INPUT:=}"  # silence "unused" warnings under set -u without dropping the drain
 
 # Determine journal directory
 JOURNAL_DIR=".decisions"
@@ -30,22 +37,14 @@ done
 
 [ "$LEARNING_ENABLED" != "true" ] && exit 0
 
-# Check if journal has entries from today
-TODAY=$(date +%Y-%m-%d)
-HAS_ENTRIES=false
-for JFILE in "$JOURNAL_DIR"/*.md; do
-  [ -f "$JFILE" ] || continue
-  if grep -q "$TODAY" "$JFILE" 2>/dev/null; then
-    HAS_ENTRIES=true
-    break
-  fi
-done
-
-# Flag for next session if there are today's entries
-if [ "$HAS_ENTRIES" = "true" ]; then
+# Flag for next session if any journal file has been modified in the last 24 hours.
+# Using mtime rather than content-grep avoids false positives on dates appearing in
+# journal *content* (due-date references, links, etc.) and avoids false negatives on
+# entries written without a date header.
+if [ -d "$JOURNAL_DIR" ] && [ -n "$(find "$JOURNAL_DIR" -maxdepth 1 -name '*.md' -mtime -1 -print -quit 2>/dev/null)" ]; then
   PENDING_DIR="${HOME}/.claude"
   mkdir -p "$PENDING_DIR"
-  echo "$TODAY" > "$PENDING_DIR/flow-learn-pending"
+  date +%Y-%m-%d > "$PENDING_DIR/flow-learn-pending"
 fi
 
 exit 0

--- a/plugins/flow/hooks/scripts/verify-task-completion.sh
+++ b/plugins/flow/hooks/scripts/verify-task-completion.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # [flow] TaskCompleted hook: Verify task acceptance criteria before marking complete
 # Exit 2 blocks task completion with feedback
+#
+# Compatibility: requires Claude Code v2.1.33+ (TaskCompleted event was added there;
+# see https://github.com/anthropics/claude-code/issues/23545). The exact JSON payload
+# schema for this event is not officially documented today, so the hook treats
+# `.task.subject` and `.task.description` as best-effort fields and exits 0 silently
+# when they are absent rather than blocking task completion on schema drift.
 
 set -euo pipefail
 

--- a/plugins/flow/hooks/scripts/verify-task-completion.sh
+++ b/plugins/flow/hooks/scripts/verify-task-completion.sh
@@ -2,11 +2,10 @@
 # [flow] TaskCompleted hook: Verify task acceptance criteria before marking complete
 # Exit 2 blocks task completion with feedback
 #
-# Compatibility: requires Claude Code v2.1.33+ (TaskCompleted event was added there;
-# see https://github.com/anthropics/claude-code/issues/23545). The exact JSON payload
-# schema for this event is not officially documented today, so the hook treats
-# `.task.subject` and `.task.description` as best-effort fields and exits 0 silently
-# when they are absent rather than blocking task completion on schema drift.
+# Compatibility: requires Claude Code v2.1.33+ (TaskCompleted event was introduced
+# alongside agent-team support). The JSON payload schema is not officially documented,
+# so the hook treats `.task.subject` and `.task.description` as best-effort fields and
+# exits 0 silently when they are absent rather than blocking on schema drift.
 
 set -euo pipefail
 

--- a/plugins/flow/references/decision-journal-schema.md
+++ b/plugins/flow/references/decision-journal-schema.md
@@ -64,8 +64,10 @@ Written by skills (e.g., `autonomous-workflow`, `change-classification`).
 
 | Level | Meaning | Default |
 |-------|---------|---------|
-| `public` | Safe for anyone to see | Yes (configurable via `journal.sensitivityDefault`) |
+| `public` | Safe for anyone to see | Yes |
 | `internal` | Internal team visibility only | |
+
+The default applies when an entry omits the `Sensitivity:` line. Skills that author entries can declare `Sensitivity: internal` explicitly when the entry should not be shared outside the team.
 
 ## Journal Directory
 
@@ -81,8 +83,7 @@ See [gate-configuration.md](gate-configuration.md#settings-file-locations) for t
 ```json
 {
   "journal": {
-    "dir": ".decisions",
-    "sensitivityDefault": "public"
+    "dir": ".decisions"
   }
 }
 ```

--- a/plugins/flow/references/gate-configuration.md
+++ b/plugins/flow/references/gate-configuration.md
@@ -84,8 +84,7 @@ Settings cascade in priority order; later layers override earlier ones:
 ```json
 {
   "journal": {
-    "dir": ".decisions",
-    "sensitivityDefault": "public"
+    "dir": ".decisions"
   }
 }
 ```

--- a/plugins/flow/schema.json
+++ b/plugins/flow/schema.json
@@ -48,7 +48,21 @@
       "type": "object",
       "properties": {
         "strategy": { "enum": ["merge", "squash", "rebase"], "default": "squash" },
-        "deleteBranch": { "type": "boolean", "default": true }
+        "deleteBranch": { "type": "boolean", "default": true },
+        "markerTrust": {
+          "type": "object",
+          "description": "Trust filter for FLOW_REVIEW_CYCLE / FLOW_RESOLUTION_CYCLE markers honored by /flow:merge and /flow:status. SECURITY PIN: read from plugins/flow/settings.json ONLY (does NOT use the standard cascade) so a hostile fork PR cannot ship a permissive trust list via .claude/settings.flow.local.json after gh pr checkout. See references/gate-configuration.md for the threat model.",
+          "properties": {
+            "allowedAssociations": {
+              "type": "array",
+              "items": {
+                "enum": ["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR", "FIRST_TIME_CONTRIBUTOR", "FIRST_TIMER", "MANNEQUIN", "NONE"]
+              },
+              "default": ["OWNER", "MEMBER", "COLLABORATOR"],
+              "description": "GitHub author_association values whose marker comments are honored. Lower-trust associations (CONTRIBUTOR, NONE) are excluded by default to prevent forgery from forks."
+            }
+          }
+        }
       }
     },
     "release": {
@@ -84,8 +98,7 @@
     "journal": {
       "type": "object",
       "properties": {
-        "dir": { "type": "string", "default": ".decisions" },
-        "sensitivityDefault": { "enum": ["public", "internal"], "default": "public" }
+        "dir": { "type": "string", "default": ".decisions" }
       }
     },
     "specFirst": {

--- a/plugins/flow/settings.json
+++ b/plugins/flow/settings.json
@@ -41,8 +41,7 @@
     "proposalDir": "~/.claude/flow-proposals"
   },
   "journal": {
-    "dir": ".decisions",
-    "sensitivityDefault": "public"
+    "dir": ".decisions"
   },
   "specFirst": {
     "requireAcceptanceCriteria": true,

--- a/plugins/flow/skills/architecture-patterns/SKILL.md
+++ b/plugins/flow/skills/architecture-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: architecture-patterns
-description: "Guide system design decisions including design-from-functionality, coupling analysis, and C4 model thinking. Use when designing systems, evaluating structural changes, or reviewing architecture decisions."
+description: "Document system design decisions with mapped user flows, coupling analysis, failure modes, and explicit non-goals, proving the architecture can survive under unexpected conditions. Use when designing systems, evaluating structural changes, or reviewing architecture decisions. Proactively suggest when coupling analysis reveals circular dependencies, god objects, or hidden shared state."
 allowed-tools: Read, Bash, Grep, Glob, TaskCreate, TaskList, TaskUpdate
 context: fork
 agent: Explore

--- a/plugins/flow/skills/autonomous-workflow/SKILL.md
+++ b/plugins/flow/skills/autonomous-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autonomous-workflow
-description: "Govern autonomous development execution through the Explore-Plan-Code-Verify loop, task-driven progress tracking, three-tier action classification, decision journaling, and bounded verification. Use when executing any development workflow autonomously or orchestrating multi-step implementation tasks."
+description: "Execute development workflows through Explore-Plan-Code-Verify phases with task-driven tracking, Tier 1/2/3 action classification, decision journaling, and bounded debug loops. Use when executing any development workflow autonomously or orchestrating multi-step implementation tasks. This skill MUST be consulted because skipping phases causes rework, and unbounded verification loops cause agents to loop forever on unsolvable problems."
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, Agent, TaskCreate, TaskList, TaskUpdate, TaskGet, AskUserQuestion
 ---
 

--- a/plugins/flow/skills/brainstorming/SKILL.md
+++ b/plugins/flow/skills/brainstorming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brainstorming
-description: "Explore multiple approaches through structured option generation, trade-off analysis, and collaborative approach selection. Use when evaluating alternatives before committing to an implementation strategy."
+description: "Generate 2-4 distinct approaches with trade-off analysis across simplicity, flexibility, performance, effort, and risk, driving collaborative decision-making before implementation. Use when evaluating alternatives before committing to an implementation strategy. Proactively suggest when the team defaults to the first idea without exploring competitors."
 allowed-tools: Read, Bash, Grep, Glob, AskUserQuestion, TaskCreate, TaskList, TaskUpdate
 context: fork
 agent: Explore

--- a/plugins/flow/skills/branch-and-task-management/SKILL.md
+++ b/plugins/flow/skills/branch-and-task-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: branch-and-task-management
-description: "Create branches with naming conventions, load issue context, perform impact analysis, and decompose acceptance criteria into parallel tasks. Use when starting work on a GitHub issue."
+description: "Create feature branches with naming conventions, load full issue context and impact analysis, and decompose acceptance criteria into atomic parallel tasks with dependencies. Use when starting work on a GitHub issue. This skill MUST be consulted because starting code without context causes misaligned implementations and wasted effort."
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TaskCreate, TaskList, TaskUpdate, TaskGet
 context: fork
 agent: general-purpose

--- a/plugins/flow/skills/capability-discovery/SKILL.md
+++ b/plugins/flow/skills/capability-discovery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: capability-discovery
-description: "Discover available agents, skills, quality commands (lint, test, typecheck), tech stack, and LSP code intelligence capabilities in the project environment. Use when starting implementation, creating PRs, reviewing PRs, or addressing feedback to determine which agents to dispatch and which quality commands to run."
+description: "Discover available agents, skills, quality commands (lint, test, typecheck), tech stack, verification capabilities, and LSP code intelligence features via parallel environment scanning. Use when starting implementation, creating PRs, reviewing PRs, or addressing feedback. This skill MUST be consulted because assuming tools exist causes runtime failures, and assuming they do not causes missing capabilities."
 allowed-tools: Bash, Read, Glob, Grep, LSP
 context: fork
 agent: Explore

--- a/plugins/flow/skills/change-classification/SKILL.md
+++ b/plugins/flow/skills/change-classification/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: change-classification
-description: "Classify code changes as in-context, uncertain, or out-of-context by applying primary and secondary signals relative to the current branch, issue, and tasks. Flag first-touch files and red-flag patterns. Use when preparing commits or reviewing staged changes."
+description: "Classify code changes as in-context, uncertain, or out-of-context using primary signals (branch diff, issue keywords, active tasks), secondary signals (directory proximity, test naming), and red-flag patterns (secrets, large binaries). Use when preparing commits or reviewing staged changes. This skill MUST be consulted because committing without classification is how out-of-context changes, secrets, and unintended modifications reach the repository."
 allowed-tools: Bash, Read, Grep
 context: fork
 agent: Explore

--- a/plugins/flow/skills/code-quality-principles/SKILL.md
+++ b/plugins/flow/skills/code-quality-principles/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-quality-principles
-description: "Enforce code quality standards including the Boy Scout Rule, secret-free commits, anti-pattern detection, and prohibition of mocks/stubs/TODOs in production code. Use when writing, modifying, or reviewing code to ensure quality gates are met."
+description: "Enforce code quality through the Boy Scout Rule (leave code better than found), secret-free commits, production-ready code (no TODOs, console.log, mocks, or commented code), and self-review against an atomic-commits checklist. Use when writing, modifying, or reviewing code. This skill MUST be consulted because production code without these standards causes quality regressions and operational incidents."
 allowed-tools: Bash, Read, Grep, Glob
 ---
 

--- a/plugins/flow/skills/code-review-methodology/SKILL.md
+++ b/plugins/flow/skills/code-review-methodology/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review-methodology
-description: "Conduct 6-facet code review covering security, quality, conventions, tests, error handling, and claim verification with P1/P2/P3 finding synthesis, deduplication by file:line, and requirements compliance mapping (Stage 1). Use when reviewing code changes or pull requests."
+description: "Conduct two-stage code review: Stage 1 verifies spec compliance (criterion-to-code mapping), Stage 2 evaluates security, correctness, performance, and maintainability across 6 parallel facets with P1/P2/P3 synthesis and deduplication by file:line. Use when reviewing code changes or pull requests. This skill MUST be consulted because reviewing quality on broken logic is wasted effort, and unmet acceptance criteria must block merge."
 allowed-tools: Read, Bash, Grep, Glob
 context: fork
 agent: Explore
@@ -42,6 +42,8 @@ Every review evaluates these facets (parallelizable):
 | **Claim verification** | Self-review claims cross-referenced against actual file state | holdout-validation (skill) |
 
 Requirements compliance is Stage 1 (Spec Compliance) of the Two-Stage Review section above, not a parallel facet — it runs first on the main thread before the 6 facets fan out.
+
+For the **Tests** facet specifically, see [`test-review-checklist.md`](../../references/test-review-checklist.md) for a runnable checklist of coverage, quality, and integration-test signals reviewers can flag with citations.
 
 ## Finding Synthesis
 

--- a/plugins/flow/skills/convention-enforcement/SKILL.md
+++ b/plugins/flow/skills/convention-enforcement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: convention-enforcement
-description: "Validate git conventions including commit messages, branch naming, PR format, and issue linkage by detecting project-specific rules from CLAUDE.md and settings. Use when creating commits, preparing PRs, or reviewing for convention compliance."
+description: "Validate git conventions (commit messages, branch naming, PR format, issue linkage) by detecting project-specific rules from CLAUDE.md and settings, inferring patterns from recent history. Use when creating commits, preparing PRs, or reviewing for convention compliance. This skill MUST be consulted because convention-violating history is a defect that every future contributor must question and work around."
 allowed-tools: Bash, Read
 context: fork
 agent: Explore

--- a/plugins/flow/skills/criterion-verification-map/SKILL.md
+++ b/plugins/flow/skills/criterion-verification-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: criterion-verification-map
-description: "Treat each acceptance criterion as an eval source that produces a runnable verification command at plan time, then collect evidence and assemble a structured bundle for the verdict judge at verify time. Use when planning implementation against issue acceptance criteria and when verifying completeness."
+description: "Transform acceptance criteria into plan-time runnable verification commands (behavioral, API, UI, error, config, data, contract types) with expected evidence shapes, then execute at verify time and assemble evidence bundles with honest completeness subsections (untested paths, known limitations, adversarial cases covered). Use when planning implementation against issue acceptance criteria or verifying completeness. This skill MUST be consulted because deferring verification to later causes incomplete PRs, and suppressing evidence gaps prevents the verdict judge from reasoning about gaps."
 allowed-tools: Bash, Read, Grep, Glob, TaskCreate, TaskList, TaskUpdate, TaskGet
 context: fork
 agent: general-purpose

--- a/plugins/flow/skills/debugging-patterns/SKILL.md
+++ b/plugins/flow/skills/debugging-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debugging-patterns
-description: "Isolate root causes through structured log analysis, hypothesis testing, and fix validation to prevent symptom-fixing and tunnel vision. Use when any verification step fails, tests break, or debugging a reported bug."
+description: "Isolate root causes through structured evidence gathering, pattern analysis, hypothesis testing (max 3 at a time, highest confidence first), and fix validation with a reproducing test before implementation. Use when any verification step fails, tests break, or debugging a reported bug. This skill MUST be consulted because symptom-fixing creates new bugs, and unbounded hypothesis testing causes tunnel vision; root cause must be proven before any fix attempt."
 allowed-tools: Bash, Read, Grep, Glob, TaskCreate, TaskList, TaskUpdate
 context: fork
 agent: general-purpose

--- a/plugins/flow/skills/evidence-based-development/SKILL.md
+++ b/plugins/flow/skills/evidence-based-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: evidence-based-development
-description: "Enforce evidence-based decision-making by requiring file:line citations, P1/P2/P3 finding prioritization, and the ASSERTION/EVIDENCE/VERIFIED pattern before any recommendation. Use when gathering evidence, presenting findings, or making development decisions."
+description: "Enforce evidence-based claims through file:line citations, P1/P2/P3 prioritization proportional to evidence, and the ASSERTION/EVIDENCE/VERIFIED pattern for behavioral claims before any recommendation. Use when gathering evidence, presenting findings, or making development decisions. This skill MUST be consulted because confidence is not evidence, and ungrounded claims cause incorrect development decisions."
 allowed-tools: Bash, Read, Grep, Glob
 ---
 

--- a/plugins/flow/skills/feedback-resolution/SKILL.md
+++ b/plugins/flow/skills/feedback-resolution/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: feedback-resolution
-description: "Address PR review feedback through focused surgical changes with Boy Scout Rule, feedback context recovery, ambiguity handling, pushback criteria, and re-review request patterns. Use when resolving reviewer comments on a pull request."
+description: "Address PR review feedback through surgical fixes traceable to specific comments, apply the Boy Scout Rule only to already-modified files (separate `improve:` commits), recover context by code snippet rather than line number, and enforce pushback only when factually incorrect, test-breaking, or CLAUDE.md-violating. Use when resolving reviewer comments on a pull request. This skill MUST be consulted because every untraceable change is out-of-context, and pushback without evidence is just disagreement."
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 context: fork
 agent: general-purpose

--- a/plugins/flow/skills/issue-crafting/SKILL.md
+++ b/plugins/flow/skills/issue-crafting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-crafting
-description: "Craft well-structured GitHub issues with solution-agnostic requirements, duplicate detection, label discovery, and acceptance criteria describing observable behavior rather than implementation details. Use when creating new GitHub issues."
+description: "Craft well-structured GitHub issues with solution-agnostic outcomes, duplicate detection (open and closed), dynamically-discovered labels, and acceptance criteria describing observable behavior without implementation details. Use when creating new GitHub issues. Proactively suggest when an issue prescribes a method instead of describing an outcome."
 allowed-tools: Bash, Read, AskUserQuestion
 context: fork
 agent: Explore

--- a/plugins/flow/skills/merge-and-release/SKILL.md
+++ b/plugins/flow/skills/merge-and-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: merge-and-release
-description: "Reference for the merge and release policy: prerequisite checklist (approval, checks, mergeable, conversations, stale approval), Tier 3 confirmation requirement, semantic versioning rules, and changelog generation. Use to understand why merges and releases are non-autonomous."
+description: "Reference document describing merge prerequisites (approval, CI checks, mergeable, conversations resolved, stale approval), release versioning (semantic semver), and changelog generation. Explains why Tier 3 confirmation is structural: merge and release cost is borne by downstream people. Reference only (`disable-model-invocation: true`); consumed by `/flow:merge` and `/flow:release`."
 allowed-tools: Read
 context: fork
 agent: Explore

--- a/plugins/flow/skills/merge-conflict-resolution/SKILL.md
+++ b/plugins/flow/skills/merge-conflict-resolution/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: merge-conflict-resolution
-description: "Detect, classify, and resolve git merge conflicts through structured analysis of conflict markers, per-file strategy selection, and post-resolution verification. Use when a branch has conflicts with its merge target or when rebasing onto an updated base."
+description: "Detect, classify (porcelain status; complexity: trivial, semantic, structural, delete-modify), and resolve git merge conflicts through per-file strategy selection (accept-ours, accept-theirs, manual-merge, rebase), manual conflict hunk parsing, and post-resolution verification (orphaned markers, build, tests). Use when a branch has conflicts with its merge target or when rebasing onto an updated base. This skill MUST be consulted because silently dropping changes is non-negotiable; every conflict resolution must account for both sides."
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TaskCreate, TaskList, TaskUpdate, AskUserQuestion
 context: fork
 agent: general-purpose

--- a/plugins/flow/skills/pr-lifecycle/SKILL.md
+++ b/plugins/flow/skills/pr-lifecycle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-lifecycle
-description: "Reference for the pull-request lifecycle policy: pre-flight gates, body structure, reviewer-suggestion algorithm, verification gate, finding-ledger merge prerequisite, and rationalization prevention. Use to understand the rules that PR creation enforces."
+description: "Reference document describing PR lifecycle: pre-flight gates (4 conditions), verification gate (5 conditions), body structure (7 sections), reviewer-suggestion algorithm (CODEOWNERS → file expertise → recent activity → workload balance), and finding-ledger merge prerequisite. Reference only (policy document; consumed by `/flow:pr` and `/flow:merge`)."
 allowed-tools: Read
 context: fork
 agent: general-purpose
@@ -40,6 +40,8 @@ Before the PR is created, every one of the following must hold. If any fail, sto
 5. No P1 findings remain from code review
 
 This gate is **mandatory**. Skipping it to "get the PR up quickly" creates reviewer burden and shifts the verification cost to whoever reads the PR.
+
+For the canonical map of all eight quality gates flow enforces — Spec Validation, Stranger Test, Per-Task Verification, Runtime Verification, Evidence Completeness, Missing-Criterion Scan, Holdout Validation, and Finding-Ledger Merge — see [`gate-configuration.md`](../../references/gate-configuration.md#quality-gates).
 
 ## PR Body Structure
 

--- a/plugins/flow/skills/preflight-checks/SKILL.md
+++ b/plugins/flow/skills/preflight-checks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: preflight-checks
-description: "Reference for the pre-flight validation policy: clean git state, issue existence, gh CLI authentication, and remote accessibility — all enforced via fast bash with no LLM calls. Use to understand why pre-flight exists and what each check protects."
+description: "Reference document describing six pre-flight checks (clean git state, not detached HEAD, gh auth, issue exists and OPEN, remote reachable, duplicate-branch warning) as pure bash exit codes with no LLM calls. Reference only (policy document; consumed by `/flow:start` Phase 0)."
 allowed-tools: Read
 context: fork
 agent: general-purpose

--- a/plugins/flow/skills/runtime-verification/SKILL.md
+++ b/plugins/flow/skills/runtime-verification/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: runtime-verification
-description: "Verify implementation works at runtime by discovering and executing dev server startup, API smoke tests, E2E tests, browser checks, and LSP diagnostics. Use after quality checks pass to confirm the code actually runs."
+description: "Verify code works at runtime through build verification (mandatory), LSP diagnostics, ad-hoc verification for projects without frameworks, E2E and smoke tests, and visual verification (screenshot-analyze-verify for UI changes). Skip whitelist strictly enforced (markdown-only, config-only, dependency-bump-only with evidence); all other skips require Proactive-Autonomy escalation. Use after quality checks pass to confirm the code actually runs. This skill MUST be consulted because no test framework is not an excuse to skip; build failure IS a finding and must be fixed."
 allowed-tools: Bash, Read, Glob, Grep, LSP, TaskCreate, TaskList, TaskUpdate
 context: fork
 agent: Explore

--- a/plugins/flow/skills/tdd-patterns/SKILL.md
+++ b/plugins/flow/skills/tdd-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tdd-patterns
-description: "Guide test-driven development through the Red-Green-Refactor cycle, test quality standards, and test runner discipline. Enforce test-first when tddMode is 'enforce'. Use when implementing features or fixing bugs."
+description: "Guide test-driven development through the mandatory Red-Green-Refactor cycle (failing test before code), enforce test quality (one behavior per test, real code over mocks, no implementation-detail testing), and enforce test runner discipline (run mode, no watch mode). Use when implementing features or fixing bugs (with `testing.tddMode='enforce'` blocking implementation without a failing test). This skill MUST be consulted because test-first is the primary quality enforcement point; tests that pass on first write are suspect (likely testing the wrong thing)."
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TaskCreate, TaskList, TaskUpdate
 context: fork
 agent: general-purpose

--- a/plugins/flow/skills/team-coordination/SKILL.md
+++ b/plugins/flow/skills/team-coordination/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: team-coordination
-description: "Coordinate agent teams for adversarial review or parallel implementation, including team spawning, task sizing, review protocol, and teammate health monitoring. Only loaded when agentTeams is enabled. Use when dispatching multi-agent work or adversarial review."
+description: "Coordinate agent teams for adversarial review (paired skeptic/verifier per facet, challenge round with disposition vocabulary, consolidated findings with confidence) or parallel implementation (task sizing 5-6 per teammate, non-overlapping files). Enforces independent analysis before shared conclusions. Reference only (`disable-model-invocation: true`); loaded only when `agentTeams: true` in settings."
 allowed-tools: Bash, Read, TaskCreate, TaskList, TaskUpdate
 context: fork
 agent: general-purpose


### PR DESCRIPTION
## Summary

Landing 1 of the three-landing flow plugin structural overhaul (per `/Users/danielbentes/.claude/plans/do-a-comprehensive-review-steady-kite.md`). This is the surgical-cleanup floor: no new abstractions, no behavior changes, just the verified P2/P3 drift fixes and parity issues that the comprehensive review surfaced.

Six atomic commits per concern so each change is reviewable in isolation.

- **chore: rewrite skill descriptions** — all 21 weak SKILL.md descriptions now lead with the artifact, name 2-3 specific triggers, and add either "MUST be consulted because…" (verification/safety/gate skills) or "Proactively suggest when…" (creative/exploratory skills); pattern matches the existing holdout-validation exemplar that drove invocation reliability ~0% → 97.5%
- **fix: /flow:address fan-out parity** — Phase 4 was claiming 5-agent parity with /flow:pr by reference but only dispatched 4 agents; security-reviewer was silently skipped on every re-review
- **fix: session-end-learn grep** — switched from `grep "$TODAY"` (false-matched dates inside journal content) to `find -mtime -1` for portable, content-agnostic detection of recent activity
- **docs: hook compat floor** — TaskCompleted/TeammateIdle events were verified real (introduced in Claude Code v2.1.33; see anthropics/claude-code#23545) but undocumented; both hook scripts and the README now note the v2.1.33+ floor and best-effort field treatment
- **chore: settings cleanup** — removed unused `journal.sensitivityDefault` setting (zero consumers) and added the missing `merge.markerTrust` block to `schema.json` with an inline rationale for why it's intentionally pinned to plugin-tier-only (security defense against fork-PR forgery)
- **docs: CHANGELOG 2.1.1 entry** — release notes for the cleanup landing

## Verified gates (from the plan)

| Gate | Result |
|------|--------|
| `grep -lE "MUST be consulted\|Use when\|Proactively suggest\|consumed by\|loaded only when" plugins/flow/skills/*/SKILL.md \| wc -l` ≥ 22 | **22/22** ✓ |
| `grep -lE "^name:" plugins/flow/skills/*/SKILL.md \| wc -l` = 22 | **22/22** ✓ |
| `bash tests/issue-86/verify.sh` exits 0 | **16 passed, 0 failed** ✓ |
| `grep -rn "sensitivityDefault" plugins/flow/` returns nothing (CHANGELOG ref excepted) | only CHANGELOG mention remains ✓ |
| All 4 plugin JSON files parse cleanly | settings.json, schema.json, hooks.json, plugin.json ✓ |
| All 8 hook scripts pass `bash -n` | ✓ |
| address.md Phase 4 dispatches 5 reviewer agents | code-reviewer, convention-checker, test-runner, security-reviewer, error-handler-inspector ✓ |
| schema.json has `merge.markerTrust` with `default: ["OWNER","MEMBER","COLLABORATOR"]` | ✓ |

## Test plan

- [x] All 21 SKILL.md descriptions are single-line, double-quoted, well under 1,536 chars
- [x] Existing `tests/issue-86/verify.sh` parser tests still pass
- [x] JSON validity preserved across `settings.json`, `schema.json`, `hooks.json`, `plugin.json`
- [x] All 8 hook scripts pass `bash -n` syntax check
- [x] `/flow:address` Phase 4 fan-out enumerates all 5 reviewer agents
- [x] `merge.markerTrust` block added to schema with full enum of GitHub author_associations
- [ ] **Manual verification needed**: run `/hooks` in Claude Code to confirm `TaskCompleted` and `TeammateIdle` events are still in the registry (the README now warns that they require v2.1.33+; if your install is older, `verify-task-completion.sh` and `nudge-idle-teammate.sh` are silently inert)
- [ ] **Manual verification needed**: re-render `docs/flow-team-session/slides-v2.md` and confirm the agent count (8), skill count (22), command count (17), and hook count (8) claims still match the diagram

## Sequencing

- **This PR** — Landing 1 (surgical cleanup)
- **Next** — Landing 2 (vision alignment): three new reference docs (`finding-schema.md`, `escalation-format.md`, `evidence-bundle-format.md`); migrate 4 reviewer agents to canonical schema; migrate 6 commands to canonical escalation; rewrite verdict-judge with explicit evidence-bundle format; resolve `/flow:review` Path A holdout asymmetry; extract `specification-capture` skill; split `runtime-verification` → core + visual-verification; standardize phase numbering
- **After that** — Landing 3 (structural enforcement): JSON Schema for skill IO with `tests/skills/*` fixtures + `bin/` validators; decision-journal manifest; `bin/flow-escalate.sh` helper; granular `allowed-tools` and `disable-model-invocation` sweeps; auto-promotion of learned proposals; tier table on every command