### PR TITLE
refactor(flow): pre-execute read-only context via `!` prefix

### DIFF
--- a/plugins/flow/commands/address.md
+++ b/plugins/flow/commands/address.md
@@ -62,27 +62,44 @@ else
   echo ""
   echo "### Inline Review Comments"
   REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
-  INLINE_JSON=$(gh api "repos/$REPO/pulls/$PR_NUM/comments" 2>/dev/null)
-  INLINE_COUNT=$(echo "$INLINE_JSON" | jq 'length' 2>/dev/null || echo "0")
-  echo "INLINE_COUNT=$INLINE_COUNT"
-  if [ "$INLINE_COUNT" = "0" ]; then
-    echo "STATE=empty"
+  # Capture gh exit separately. gh failure ⇒ "" + non-zero exit; jq on empty
+  # stdin produces no output + exit 0, so `|| echo "0"` doesn't fire and the
+  # block silently emits a bare `INLINE_COUNT=` line. Distinguish unavailable
+  # (gh failed) from empty (gh ok, no records).
+  INLINE_JSON=$(gh api "repos/$REPO/pulls/$PR_NUM/comments" 2>/dev/null); GH_EXIT=$?
+  if [ $GH_EXIT -ne 0 ]; then
+    echo "INLINE_COUNT=0"
+    echo "STATE=unavailable"
+    INLINE_JSON="[]"  # neutral fallback so the Conversation Threads section below also degrades gracefully
   else
-    # One record per comment; full body lives in the JSON cache for the agent
-    # to fetch on demand. The summary line carries the routing fields.
-    echo "$INLINE_JSON" | jq -r '.[] | "INLINE_COMMENT=id=\(.id) author=@\(.user.login) path=\(.path) line=\(.line // "?") length=\(.body | length)"' 2>/dev/null
+    INLINE_COUNT=$(echo "$INLINE_JSON" | jq 'length' 2>/dev/null)
+    [ -z "$INLINE_COUNT" ] && INLINE_COUNT=0
+    echo "INLINE_COUNT=$INLINE_COUNT"
+    if [ "$INLINE_COUNT" = "0" ]; then
+      echo "STATE=empty"
+    else
+      # One record per comment; full body lives in the JSON cache for the agent
+      # to fetch on demand. The summary line carries the routing fields.
+      echo "$INLINE_JSON" | jq -r '.[] | "INLINE_COMMENT=id=\(.id) author=@\(.user.login) path=\(.path) line=\(.line // "?") length=\(.body | length)"' 2>/dev/null
+    fi
   fi
 
   # Section: Review Summaries
   echo ""
   echo "### Review Summaries"
-  REVIEWS_JSON=$(gh pr view "$PR_NUM" --json reviews --jq '.reviews' 2>/dev/null)
-  REVIEW_COUNT=$(echo "$REVIEWS_JSON" | jq 'length' 2>/dev/null || echo "0")
-  echo "REVIEW_COUNT=$REVIEW_COUNT"
-  if [ "$REVIEW_COUNT" = "0" ]; then
-    echo "STATE=empty"
+  REVIEWS_JSON=$(gh pr view "$PR_NUM" --json reviews --jq '.reviews' 2>/dev/null); GH_EXIT=$?
+  if [ $GH_EXIT -ne 0 ]; then
+    echo "REVIEW_COUNT=0"
+    echo "STATE=unavailable"
   else
-    echo "$REVIEWS_JSON" | jq -r '.[] | "REVIEW=state=\(.state) author=@\(.author.login) at=\(.submittedAt) length=\(.body | length)"' 2>/dev/null
+    REVIEW_COUNT=$(echo "$REVIEWS_JSON" | jq 'length' 2>/dev/null)
+    [ -z "$REVIEW_COUNT" ] && REVIEW_COUNT=0
+    echo "REVIEW_COUNT=$REVIEW_COUNT"
+    if [ "$REVIEW_COUNT" = "0" ]; then
+      echo "STATE=empty"
+    else
+      echo "$REVIEWS_JSON" | jq -r '.[] | "REVIEW=state=\(.state) author=@\(.author.login) at=\(.submittedAt) length=\(.body | length)"' 2>/dev/null
+    fi
   fi
 
   # Section: Conversation Threads (grouped by file path)

--- a/plugins/flow/commands/address.md
+++ b/plugins/flow/commands/address.md
@@ -31,35 +31,40 @@ Systematic feedback resolution. Follows Explore > Plan > Code > Verify loop.
 Pre-executed at command load (`!` prefix) — PR details, review comments, review summaries, and conversation threads all reach the agent as prompt context. `gh pr checkout` stays inline (mutating).
 
 ```!
-# Take the first whitespace-separated token as the PR number;
-# the rest of $ARGUMENTS is free-form context for the agent.
-PR_NUM="${ARGUMENTS%% *}"
+# Take the first whitespace-separated token; accept only if it is all digits.
+# A non-numeric token (e.g., "foo42" or "evil;rm") is rejected with empty
+# PR_NUM so it never reaches the prompt context or any downstream shell.
+ARG1="${ARGUMENTS%% *}"
+case "$ARG1" in
+  ''|*[!0-9]*) PR_NUM="" ;;
+  *) PR_NUM="$ARG1" ;;
+esac
 
 if [ -z "$PR_NUM" ]; then
-  echo "ERROR: PR number required. Usage: /flow:address <pr-number>"
+  echo "ERROR: PR number required (all-digit). Usage: /flow:address <pr-number>"
 else
   # 1. PR details
-  gh pr view "$PR_NUM" --json headRefName,baseRefName,title,body
+  gh pr view "$PR_NUM" --json headRefName,baseRefName,title,body 2>/dev/null
 
   # 2. Review comments (inline)
-  REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+  REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
   gh api "repos/$REPO/pulls/$PR_NUM/comments" --jq '.[] | {
     id: .id,
     path: .path,
     line: .line,
     body: .body,
     author: .user.login
-  }'
+  }' 2>/dev/null
 
   # 3. Review summaries
   gh pr view "$PR_NUM" --json reviews --jq '.reviews[] | {
     state: .state,
     body: .body,
     author: .author.login
-  }'
+  }' 2>/dev/null
 
   # 4. Conversation threads
-  gh api "repos/$REPO/pulls/$PR_NUM/comments" --jq 'group_by(.path) | .[] | {file: .[0].path, comments: [.[] | {body: .body, author: .user.login}]}'
+  gh api "repos/$REPO/pulls/$PR_NUM/comments" --jq 'group_by(.path) | .[] | {file: .[0].path, comments: [.[] | {body: .body, author: .user.login}]}' 2>/dev/null
 
   # 5. Echo for downstream phases (inline blocks consume $PR_NUM, not $ARGUMENTS).
   echo "PR_NUM=$PR_NUM"
@@ -83,12 +88,17 @@ gh pr checkout "$PR_NUM"
 Pre-executed at command load (`!` prefix) — cycle count reaches the agent as prompt context for choosing the right strategy below.
 
 ```!
-PR_NUM="${ARGUMENTS%% *}"
+# Digit-validate PR_NUM (matches Phase 1 block).
+ARG1="${ARGUMENTS%% *}"
+case "$ARG1" in
+  ''|*[!0-9]*) PR_NUM="" ;;
+  *) PR_NUM="$ARG1" ;;
+esac
 
 if [ -z "$PR_NUM" ]; then
-  echo "ERROR: PR number required"
+  echo "ERROR: PR number required (all-digit)"
 else
-  CYCLE_COUNT=$(gh pr view "$PR_NUM" --json reviews --jq '[.reviews[] | select(.state == "CHANGES_REQUESTED")] | length')
+  CYCLE_COUNT=$(gh pr view "$PR_NUM" --json reviews --jq '[.reviews[] | select(.state == "CHANGES_REQUESTED")] | length' 2>/dev/null)
   echo "PR_NUM=$PR_NUM"
   echo "REVIEW_CYCLE=$CYCLE_COUNT"
 fi

--- a/plugins/flow/commands/address.md
+++ b/plugins/flow/commands/address.md
@@ -28,7 +28,7 @@ Systematic feedback resolution. Follows Explore > Plan > Code > Verify loop.
 
 ## Phase 1: EXPLORE
 
-Pre-executed at command load (`!` prefix) — PR details, review comments, review summaries, and conversation threads all reach the agent as prompt context. `gh pr checkout` stays inline (mutating).
+`gh pr checkout` stays inline (mutating); read-only context-gathering is in the `!` block below.
 
 ```!
 # Take the first whitespace-separated token; accept only if it is all digits.
@@ -84,8 +84,6 @@ gh pr checkout "$PR_NUM"
 **Skill(capability-discovery)**: Discover quality commands for verification.
 
 ## Review Cycle Tracking
-
-Pre-executed at command load (`!` prefix) — cycle count reaches the agent as prompt context for choosing the right strategy below.
 
 ```!
 # Digit-validate PR_NUM (matches Phase 1 block).

--- a/plugins/flow/commands/address.md
+++ b/plugins/flow/commands/address.md
@@ -34,33 +34,36 @@ Pre-executed at command load (`!` prefix) — PR details, review comments, revie
 # Take the first whitespace-separated token as the PR number;
 # the rest of $ARGUMENTS is free-form context for the agent.
 PR_NUM="${ARGUMENTS%% *}"
-[ -z "$PR_NUM" ] && { echo "ERROR: PR number required. Usage: /flow:address <pr-number>"; exit 1; }
 
-# 1. PR details
-gh pr view "$PR_NUM" --json headRefName,baseRefName,title,body
+if [ -z "$PR_NUM" ]; then
+  echo "ERROR: PR number required. Usage: /flow:address <pr-number>"
+else
+  # 1. PR details
+  gh pr view "$PR_NUM" --json headRefName,baseRefName,title,body
 
-# 2. Review comments (inline)
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-gh api "repos/$REPO/pulls/$PR_NUM/comments" --jq '.[] | {
-  id: .id,
-  path: .path,
-  line: .line,
-  body: .body,
-  author: .user.login
-}'
+  # 2. Review comments (inline)
+  REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+  gh api "repos/$REPO/pulls/$PR_NUM/comments" --jq '.[] | {
+    id: .id,
+    path: .path,
+    line: .line,
+    body: .body,
+    author: .user.login
+  }'
 
-# 3. Review summaries
-gh pr view "$PR_NUM" --json reviews --jq '.reviews[] | {
-  state: .state,
-  body: .body,
-  author: .author.login
-}'
+  # 3. Review summaries
+  gh pr view "$PR_NUM" --json reviews --jq '.reviews[] | {
+    state: .state,
+    body: .body,
+    author: .author.login
+  }'
 
-# 4. Conversation threads
-gh api "repos/$REPO/pulls/$PR_NUM/comments" --jq 'group_by(.path) | .[] | {file: .[0].path, comments: [.[] | {body: .body, author: .user.login}]}'
+  # 4. Conversation threads
+  gh api "repos/$REPO/pulls/$PR_NUM/comments" --jq 'group_by(.path) | .[] | {file: .[0].path, comments: [.[] | {body: .body, author: .user.login}]}'
 
-# 5. Echo for downstream phases (inline blocks consume $PR_NUM, not $ARGUMENTS).
-echo "PR_NUM=$PR_NUM"
+  # 5. Echo for downstream phases (inline blocks consume $PR_NUM, not $ARGUMENTS).
+  echo "PR_NUM=$PR_NUM"
+fi
 
 true
 ```
@@ -81,10 +84,14 @@ Pre-executed at command load (`!` prefix) — cycle count reaches the agent as p
 
 ```!
 PR_NUM="${ARGUMENTS%% *}"
-[ -z "$PR_NUM" ] && { echo "ERROR: PR number required"; exit 1; }
-CYCLE_COUNT=$(gh pr view "$PR_NUM" --json reviews --jq '[.reviews[] | select(.state == "CHANGES_REQUESTED")] | length')
-echo "PR_NUM=$PR_NUM"
-echo "REVIEW_CYCLE=$CYCLE_COUNT"
+
+if [ -z "$PR_NUM" ]; then
+  echo "ERROR: PR number required"
+else
+  CYCLE_COUNT=$(gh pr view "$PR_NUM" --json reviews --jq '[.reviews[] | select(.state == "CHANGES_REQUESTED")] | length')
+  echo "PR_NUM=$PR_NUM"
+  echo "REVIEW_CYCLE=$CYCLE_COUNT"
+fi
 
 true
 ```

--- a/plugins/flow/commands/address.md
+++ b/plugins/flow/commands/address.md
@@ -59,6 +59,9 @@ gh pr view "$PR_NUM" --json reviews --jq '.reviews[] | {
 # 4. Conversation threads
 gh api "repos/$REPO/pulls/$PR_NUM/comments" --jq 'group_by(.path) | .[] | {file: .[0].path, comments: [.[] | {body: .body, author: .user.login}]}'
 
+# 5. Echo for downstream phases (inline blocks consume $PR_NUM, not $ARGUMENTS).
+echo "PR_NUM=$PR_NUM"
+
 true
 ```
 
@@ -80,6 +83,7 @@ Pre-executed at command load (`!` prefix) — cycle count reaches the agent as p
 PR_NUM="${ARGUMENTS%% *}"
 [ -z "$PR_NUM" ] && { echo "ERROR: PR number required"; exit 1; }
 CYCLE_COUNT=$(gh pr view "$PR_NUM" --json reviews --jq '[.reviews[] | select(.state == "CHANGES_REQUESTED")] | length')
+echo "PR_NUM=$PR_NUM"
 echo "REVIEW_CYCLE=$CYCLE_COUNT"
 
 true
@@ -251,23 +255,23 @@ For cosmetic P3 findings in untouched files that the team agrees to track separa
    ```bash
    REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
    # For each fixed item, reply to the original review comment:
-   gh api repos/$REPO/pulls/$ARGUMENTS/comments/{comment_id}/replies \
+   gh api "repos/$REPO/pulls/$PR_NUM/comments/{comment_id}/replies" \
      -f body="Addressed in \`{SHA}\`. {brief description of fix}"
 
    # For Question/Pushback items, reply with the response:
-   gh api repos/$REPO/pulls/$ARGUMENTS/comments/{comment_id}/replies \
+   gh api "repos/$REPO/pulls/$PR_NUM/comments/{comment_id}/replies" \
      -f body="{response text}"
    ```
 9. **Post resolution comment** (MANDATORY) using the template structure from `templates/resolution-comment.md`:
    ```bash
-   gh pr comment $ARGUMENTS --body "$BODY"
+   gh pr comment "$PR_NUM" --body "$BODY"
    ```
    - TaskUpdate(postCommentTaskId, status: "completed", result: "PASS — resolution comment posted to PR")
 10. **Update PR body review cycle state** (if `### Review Cycle History` exists in the PR body):
-   - Fetch current body: `gh pr view $ARGUMENTS --json body --jq '.body'`
+   - Fetch current body: `gh pr view "$PR_NUM" --json body --jq '.body'`
    - If the body contains `### Review Cycle History`, replace content between that heading and the next `##` heading with the cycle metrics table (received/fixed/discussed/escalated)
    - If the heading does not exist, append a `### Review Cycle History` section under `## Review Findings`
-   - Update: `gh pr edit $ARGUMENTS --body "$UPDATED_BODY"`
+   - Update: `gh pr edit "$PR_NUM" --body "$UPDATED_BODY"`
 11. **TaskList**: Confirm ALL tasks complete including "Post resolution comment". Do NOT proceed until verified.
 12. **Conditional re-request review**:
 
@@ -275,7 +279,7 @@ For cosmetic P3 findings in untouched files that the team agrees to track separa
     - If self-review found 0 findings → do NOT re-request (nothing changed that needs re-review beyond the feedback fixes)
     - If cycle < `reviewCycleLimit` (default 3) → re-request normally:
       ```bash
-      gh pr edit $ARGUMENTS --add-reviewer @{reviewer}
+      gh pr edit "$PR_NUM" --add-reviewer @{reviewer}
       ```
     - If cycle >= `reviewCycleLimit` → use the AskUserQuestion tool with the following Proactive-Autonomy escalation:
 

--- a/plugins/flow/commands/address.md
+++ b/plugins/flow/commands/address.md
@@ -1,6 +1,6 @@
 ---
 description: "Address PR review feedback systematically. Categorizes feedback, implements surgical fixes, verifies changes, and re-requests review."
-argument-hint: <pr-number>
+argument-hint: <pr-number> [free-form context]
 allowed-tools: Bash, Read, Write, Edit, Agent, AskUserQuestion, TaskCreate, TaskList, TaskUpdate, TaskGet, Skill, Grep, Glob
 ---
 

--- a/plugins/flow/commands/address.md
+++ b/plugins/flow/commands/address.md
@@ -28,16 +28,20 @@ Systematic feedback resolution. Follows Explore > Plan > Code > Verify loop.
 
 ## Phase 1: EXPLORE
 
-**Parallel operations:**
+Pre-executed at command load (`!` prefix) — PR details, review comments, review summaries, and conversation threads all reach the agent as prompt context. `gh pr checkout` stays inline (mutating).
 
-```bash
-# 1. PR details and branch
-gh pr view $ARGUMENTS --json headRefName,baseRefName,title,body
-gh pr checkout $ARGUMENTS
+```!
+# Take the first whitespace-separated token as the PR number;
+# the rest of $ARGUMENTS is free-form context for the agent.
+PR_NUM="${ARGUMENTS%% *}"
+[ -z "$PR_NUM" ] && { echo "ERROR: PR number required. Usage: /flow:address <pr-number>"; exit 1; }
+
+# 1. PR details
+gh pr view "$PR_NUM" --json headRefName,baseRefName,title,body
 
 # 2. Review comments (inline)
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-gh api repos/$REPO/pulls/$ARGUMENTS/comments --jq '.[] | {
+gh api "repos/$REPO/pulls/$PR_NUM/comments" --jq '.[] | {
   id: .id,
   path: .path,
   line: .line,
@@ -46,14 +50,22 @@ gh api repos/$REPO/pulls/$ARGUMENTS/comments --jq '.[] | {
 }'
 
 # 3. Review summaries
-gh pr view $ARGUMENTS --json reviews --jq '.reviews[] | {
+gh pr view "$PR_NUM" --json reviews --jq '.reviews[] | {
   state: .state,
   body: .body,
   author: .author.login
 }'
 
 # 4. Conversation threads
-gh api repos/$REPO/pulls/$ARGUMENTS/comments --jq 'group_by(.path) | .[] | {file: .[0].path, comments: [.[] | {body: .body, author: .user.login}]}'
+gh api "repos/$REPO/pulls/$PR_NUM/comments" --jq 'group_by(.path) | .[] | {file: .[0].path, comments: [.[] | {body: .body, author: .user.login}]}'
+
+true
+```
+
+Then check out the PR branch (mutating, runs inline):
+
+```bash
+gh pr checkout "$PR_NUM"
 ```
 
 **Agent(Explore)**: "Pre-resolve check — for each review comment, verify the feedback still applies to the current code. Some comments may already be addressed by later commits."
@@ -62,12 +74,15 @@ gh api repos/$REPO/pulls/$ARGUMENTS/comments --jq 'group_by(.path) | .[] | {file
 
 ## Review Cycle Tracking
 
-Before planning, determine the current review cycle:
+Pre-executed at command load (`!` prefix) — cycle count reaches the agent as prompt context for choosing the right strategy below.
 
-```bash
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-CYCLE_COUNT=$(gh pr view $ARGUMENTS --json reviews --jq '[.reviews[] | select(.state == "CHANGES_REQUESTED")] | length')
+```!
+PR_NUM="${ARGUMENTS%% *}"
+[ -z "$PR_NUM" ] && { echo "ERROR: PR number required"; exit 1; }
+CYCLE_COUNT=$(gh pr view "$PR_NUM" --json reviews --jq '[.reviews[] | select(.state == "CHANGES_REQUESTED")] | length')
 echo "REVIEW_CYCLE=$CYCLE_COUNT"
+
+true
 ```
 
 **Escalating strategy by cycle:**

--- a/plugins/flow/commands/address.md
+++ b/plugins/flow/commands/address.md
@@ -34,40 +34,66 @@ Systematic feedback resolution. Follows Explore > Plan > Code > Verify loop.
 # Take the first whitespace-separated token; accept only if it is all digits.
 # A non-numeric token (e.g., "foo42" or "evil;rm") is rejected with empty
 # PR_NUM so it never reaches the prompt context or any downstream shell.
+#
+# Output: `###`-headed sections + KEY=value per
+# `references/command-output-format.md`. STATE=blocked on bad input.
 ARG1="${ARGUMENTS%% *}"
 case "$ARG1" in
   ''|*[!0-9]*) PR_NUM="" ;;
   *) PR_NUM="$ARG1" ;;
 esac
 
+echo "### PR Reference"
 if [ -z "$PR_NUM" ]; then
-  echo "ERROR: PR number required (all-digit). Usage: /flow:address <pr-number>"
+  echo "STATE=blocked"
+  echo "ERROR=PR number required (all-digit). Usage: /flow:address <pr-number>"
 else
-  # 1. PR details
-  gh pr view "$PR_NUM" --json headRefName,baseRefName,title,body 2>/dev/null
-
-  # 2. Review comments (inline)
-  REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
-  gh api "repos/$REPO/pulls/$PR_NUM/comments" --jq '.[] | {
-    id: .id,
-    path: .path,
-    line: .line,
-    body: .body,
-    author: .user.login
-  }' 2>/dev/null
-
-  # 3. Review summaries
-  gh pr view "$PR_NUM" --json reviews --jq '.reviews[] | {
-    state: .state,
-    body: .body,
-    author: .author.login
-  }' 2>/dev/null
-
-  # 4. Conversation threads
-  gh api "repos/$REPO/pulls/$PR_NUM/comments" --jq 'group_by(.path) | .[] | {file: .[0].path, comments: [.[] | {body: .body, author: .user.login}]}' 2>/dev/null
-
-  # 5. Echo for downstream phases (inline blocks consume $PR_NUM, not $ARGUMENTS).
+  echo "STATE=ok"
   echo "PR_NUM=$PR_NUM"
+
+  # Section: PR Details
+  echo ""
+  echo "### PR Details"
+  gh pr view "$PR_NUM" --json headRefName,baseRefName,title,body --jq '
+    "TITLE=\"\(.title)\"\nHEAD_BRANCH=\(.headRefName)\nBASE_BRANCH=\(.baseRefName)\nBODY_LENGTH=\(.body | length)"
+  ' 2>/dev/null
+
+  # Section: Inline Review Comments
+  echo ""
+  echo "### Inline Review Comments"
+  REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
+  INLINE_JSON=$(gh api "repos/$REPO/pulls/$PR_NUM/comments" 2>/dev/null)
+  INLINE_COUNT=$(echo "$INLINE_JSON" | jq 'length' 2>/dev/null || echo "0")
+  echo "INLINE_COUNT=$INLINE_COUNT"
+  if [ "$INLINE_COUNT" = "0" ]; then
+    echo "STATE=empty"
+  else
+    # One record per comment; full body lives in the JSON cache for the agent
+    # to fetch on demand. The summary line carries the routing fields.
+    echo "$INLINE_JSON" | jq -r '.[] | "INLINE_COMMENT=id=\(.id) author=@\(.user.login) path=\(.path) line=\(.line // "?") length=\(.body | length)"' 2>/dev/null
+  fi
+
+  # Section: Review Summaries
+  echo ""
+  echo "### Review Summaries"
+  REVIEWS_JSON=$(gh pr view "$PR_NUM" --json reviews --jq '.reviews' 2>/dev/null)
+  REVIEW_COUNT=$(echo "$REVIEWS_JSON" | jq 'length' 2>/dev/null || echo "0")
+  echo "REVIEW_COUNT=$REVIEW_COUNT"
+  if [ "$REVIEW_COUNT" = "0" ]; then
+    echo "STATE=empty"
+  else
+    echo "$REVIEWS_JSON" | jq -r '.[] | "REVIEW=state=\(.state) author=@\(.author.login) at=\(.submittedAt) length=\(.body | length)"' 2>/dev/null
+  fi
+
+  # Section: Conversation Threads (grouped by file path)
+  echo ""
+  echo "### Conversation Threads"
+  THREADS=$(echo "$INLINE_JSON" | jq -r 'group_by(.path) | .[] | "THREAD=file=\(.[0].path) count=\(length)"' 2>/dev/null)
+  if [ -z "$THREADS" ]; then
+    echo "STATE=empty"
+  else
+    echo "$THREADS"
+  fi
 fi
 
 true
@@ -93,9 +119,12 @@ case "$ARG1" in
   *) PR_NUM="$ARG1" ;;
 esac
 
+echo "### Review Cycle"
 if [ -z "$PR_NUM" ]; then
-  echo "ERROR: PR number required (all-digit)"
+  echo "STATE=blocked"
+  echo "ERROR=PR number required (all-digit)"
 else
+  echo "STATE=ok"
   CYCLE_COUNT=$(gh pr view "$PR_NUM" --json reviews --jq '[.reviews[] | select(.state == "CHANGES_REQUESTED")] | length' 2>/dev/null)
   echo "PR_NUM=$PR_NUM"
   echo "REVIEW_CYCLE=$CYCLE_COUNT"

--- a/plugins/flow/commands/brainstorm.md
+++ b/plugins/flow/commands/brainstorm.md
@@ -29,16 +29,22 @@ This command operates with these domain skills loaded:
 
 Understand the goal before generating options. Execute in parallel:
 
-**Parallel Bash calls:**
+Pre-executed at command load (`!` prefix) — extracted ISSUE_NUM, issue context, and project state all reach the agent as prompt context.
 
-```bash
-# 1. If issue number given, load context
-ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oE '[0-9]+')
-[ -n "$ISSUE_NUM" ] && gh issue view $ISSUE_NUM --json title,body,labels
+```!
+# 1. If issue number given, load context. Take the first whitespace-separated
+# token as the candidate issue ref; extract digits. Supports usage like
+# /flow:brainstorm 42 (alternative auth strategies).
+ARG1="${ARGUMENTS%% *}"
+ISSUE_NUM=$(echo "$ARG1" | grep -oE '[0-9]+')
+echo "ISSUE_NUM=$ISSUE_NUM"
+[ -n "$ISSUE_NUM" ] && gh issue view "$ISSUE_NUM" --json title,body,labels 2>/dev/null
 
 # 2. Current project state
 git branch --show-current
 git log --oneline -5
+
+true
 ```
 
 **Parallel searches:**

--- a/plugins/flow/commands/brainstorm.md
+++ b/plugins/flow/commands/brainstorm.md
@@ -33,10 +33,15 @@ Pre-executed at command load (`!` prefix) — extracted ISSUE_NUM, issue context
 
 ```!
 # 1. If issue number given, load context. Take the first whitespace-separated
-# token as the candidate issue ref; extract digits. Supports usage like
-# /flow:brainstorm 42 (alternative auth strategies).
+# token; accept only if it is *all* digits. Inputs like "foo42 strategy"
+# (where greedy digit-extraction would otherwise pluck `42` from `foo42` and
+# fire `gh issue view 42` on an unrelated issue) are rejected to empty
+# ISSUE_NUM. Supports usage like /flow:brainstorm 42 (alternative auth strategies).
 ARG1="${ARGUMENTS%% *}"
-ISSUE_NUM=$(echo "$ARG1" | grep -oE '[0-9]+')
+case "$ARG1" in
+  ''|*[!0-9]*) ISSUE_NUM="" ;;
+  *) ISSUE_NUM="$ARG1" ;;
+esac
 echo "ISSUE_NUM=$ISSUE_NUM"
 [ -n "$ISSUE_NUM" ] && gh issue view "$ISSUE_NUM" --json title,body,labels 2>/dev/null
 

--- a/plugins/flow/commands/brainstorm.md
+++ b/plugins/flow/commands/brainstorm.md
@@ -29,8 +29,6 @@ This command operates with these domain skills loaded:
 
 Understand the goal before generating options. Execute in parallel:
 
-Pre-executed at command load (`!` prefix) — extracted ISSUE_NUM, issue context, and project state all reach the agent as prompt context.
-
 ```!
 # 1. If issue number given, load context. Take the first whitespace-separated
 # token; accept only if it is *all* digits. Inputs like "foo42 strategy"

--- a/plugins/flow/commands/brainstorm.md
+++ b/plugins/flow/commands/brainstorm.md
@@ -44,7 +44,9 @@ case "$ARG1" in
 esac
 
 echo "### Issue Reference"
-echo "ISSUE_NUM=${ISSUE_NUM:-(none — exploratory brainstorm)}"
+# Quote parenthesized fallback per command-output-format.md rule 2 (values
+# with whitespace/parens must be double-quoted scalars).
+echo "ISSUE_NUM=${ISSUE_NUM:-\"(none — exploratory brainstorm)\"}"
 
 echo ""
 echo "### Issue Context"

--- a/plugins/flow/commands/brainstorm.md
+++ b/plugins/flow/commands/brainstorm.md
@@ -64,7 +64,12 @@ echo "### Project State"
 echo "BRANCH=$(git branch --show-current 2>/dev/null)"
 echo ""
 echo "#### Recent commits"
-git log --oneline -5 2>/dev/null | sed 's/^/COMMIT=/'
+RECENT_COMMITS=$(git log --oneline -5 2>/dev/null)
+if [ -z "$RECENT_COMMITS" ]; then
+  echo "STATE=empty"
+else
+  printf '%s\n' "$RECENT_COMMITS" | sed 's/^/COMMIT=/'
+fi
 
 true
 ```

--- a/plugins/flow/commands/brainstorm.md
+++ b/plugins/flow/commands/brainstorm.md
@@ -30,22 +30,39 @@ This command operates with these domain skills loaded:
 Understand the goal before generating options. Execute in parallel:
 
 ```!
-# 1. If issue number given, load context. Take the first whitespace-separated
-# token; accept only if it is *all* digits. Inputs like "foo42 strategy"
-# (where greedy digit-extraction would otherwise pluck `42` from `foo42` and
-# fire `gh issue view 42` on an unrelated issue) are rejected to empty
-# ISSUE_NUM. Supports usage like /flow:brainstorm 42 (alternative auth strategies).
+# Take the first whitespace-separated token; accept only if it is *all*
+# digits. Inputs like "foo42 strategy" (greedy digit-extraction would pluck
+# `42` from `foo42` and fire `gh issue view 42` on an unrelated issue) are
+# rejected. Supports usage like /flow:brainstorm 42 (alternative auth strategies).
+#
+# Output: `###`-headed sections + KEY=value per
+# `references/command-output-format.md`.
 ARG1="${ARGUMENTS%% *}"
 case "$ARG1" in
   ''|*[!0-9]*) ISSUE_NUM="" ;;
   *) ISSUE_NUM="$ARG1" ;;
 esac
-echo "ISSUE_NUM=$ISSUE_NUM"
-[ -n "$ISSUE_NUM" ] && gh issue view "$ISSUE_NUM" --json title,body,labels 2>/dev/null
 
-# 2. Current project state
-git branch --show-current
-git log --oneline -5
+echo "### Issue Reference"
+echo "ISSUE_NUM=${ISSUE_NUM:-(none — exploratory brainstorm)}"
+
+echo ""
+echo "### Issue Context"
+if [ -n "$ISSUE_NUM" ]; then
+  gh issue view "$ISSUE_NUM" --json title,body,labels --jq '"TITLE=\"\(.title)\"\nLABELS=\([.labels[].name] | join(","))\nBODY_LENGTH=\(.body | length)"' 2>/dev/null
+  echo ""
+  echo "#### Issue body"
+  gh issue view "$ISSUE_NUM" --json body --jq '.body' 2>/dev/null
+else
+  echo "STATE=empty"
+fi
+
+echo ""
+echo "### Project State"
+echo "BRANCH=$(git branch --show-current 2>/dev/null)"
+echo ""
+echo "#### Recent commits"
+git log --oneline -5 2>/dev/null | sed 's/^/COMMIT=/'
 
 true
 ```

--- a/plugins/flow/commands/commit.md
+++ b/plugins/flow/commands/commit.md
@@ -72,7 +72,14 @@ fi
 
 echo ""
 echo "### Recent Commits (for style)"
-git log --oneline -10 2>/dev/null | sed 's/^/COMMIT=/'
+# Capture so an empty log (new repo) emits STATE=empty rather than silent
+# heading.
+RECENT_COMMITS=$(git log --oneline -10 2>/dev/null)
+if [ -z "$RECENT_COMMITS" ]; then
+  echo "STATE=empty"
+else
+  printf '%s\n' "$RECENT_COMMITS" | sed 's/^/COMMIT=/'
+fi
 
 true
 ```

--- a/plugins/flow/commands/commit.md
+++ b/plugins/flow/commands/commit.md
@@ -64,7 +64,8 @@ fi
 echo ""
 echo "### Issue Context"
 ISSUE_NUM=$(echo "$BRANCH" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
-echo "ISSUE_NUM=${ISSUE_NUM:-(none)}"
+# Quote parenthesized fallback per command-output-format.md rule 2.
+echo "ISSUE_NUM=${ISSUE_NUM:-\"(none)\"}"
 if [ -n "$ISSUE_NUM" ]; then
   gh issue view "$ISSUE_NUM" --json title,body --jq '"ISSUE_TITLE=\"\(.title)\"\nISSUE_BODY_LENGTH=\(.body | length)"' 2>/dev/null
 fi

--- a/plugins/flow/commands/commit.md
+++ b/plugins/flow/commands/commit.md
@@ -24,8 +24,6 @@ Classify changes, flag anomalies, and create atomic conventional commits. Follow
 
 ## Phase 1: EXPLORE
 
-Pre-executed at command load (`!` prefix) — the agent receives branch, status, diff, and issue context as part of the prompt, no Bash tool round-trip.
-
 ```!
 # 1. All changes
 git status --porcelain

--- a/plugins/flow/commands/commit.md
+++ b/plugins/flow/commands/commit.md
@@ -25,23 +25,47 @@ Classify changes, flag anomalies, and create atomic conventional commits. Follow
 ## Phase 1: EXPLORE
 
 ```!
-# 1. All changes
-git status --porcelain
+# Output: `###`-headed sections + KEY=value per
+# `references/command-output-format.md`.
 
-# 2. Branch context
-BRANCH=$(git branch --show-current)
+echo "### Branch Context"
+BRANCH=$(git branch --show-current 2>/dev/null)
 DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
-echo "BRANCH=$BRANCH DEFAULT=$DEFAULT_BRANCH"
+echo "BRANCH=$BRANCH"
+echo "DEFAULT_BRANCH=$DEFAULT_BRANCH"
 
-# 3. Files already on branch
-git diff --name-only "$DEFAULT_BRANCH"...HEAD
+echo ""
+echo "### Uncommitted Changes"
+UNCOMMITTED_COUNT=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+echo "UNCOMMITTED_COUNT=$UNCOMMITTED_COUNT"
+if [ "$UNCOMMITTED_COUNT" = "0" ]; then
+  echo "STATE=empty"
+else
+  git status --porcelain 2>/dev/null | sed 's/^/UNCOMMITTED_LINE=/'
+fi
 
-# 4. Issue context
+echo ""
+echo "### Branch Files (vs default)"
+BRANCH_FILES=$(git diff --name-only "$DEFAULT_BRANCH"...HEAD 2>/dev/null)
+BRANCH_FILE_COUNT=$(printf '%s\n' "$BRANCH_FILES" | grep -c '.' || echo "0")
+echo "BRANCH_FILE_COUNT=$BRANCH_FILE_COUNT"
+if [ "$BRANCH_FILE_COUNT" = "0" ]; then
+  echo "STATE=empty"
+else
+  printf '%s\n' "$BRANCH_FILES" | sed 's/^/BRANCH_FILE=/'
+fi
+
+echo ""
+echo "### Issue Context"
 ISSUE_NUM=$(echo "$BRANCH" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
-[ -n "$ISSUE_NUM" ] && gh issue view "$ISSUE_NUM" --json title,body 2>/dev/null
+echo "ISSUE_NUM=${ISSUE_NUM:-(none)}"
+if [ -n "$ISSUE_NUM" ]; then
+  gh issue view "$ISSUE_NUM" --json title,body --jq '"ISSUE_TITLE=\"\(.title)\"\nISSUE_BODY_LENGTH=\(.body | length)"' 2>/dev/null
+fi
 
-# 5. Recent commits (for style)
-git log --oneline -10
+echo ""
+echo "### Recent Commits (for style)"
+git log --oneline -10 2>/dev/null | sed 's/^/COMMIT=/'
 
 true
 ```

--- a/plugins/flow/commands/commit.md
+++ b/plugins/flow/commands/commit.md
@@ -24,11 +24,9 @@ Classify changes, flag anomalies, and create atomic conventional commits. Follow
 
 ## Phase 1: EXPLORE
 
-Execute these in parallel:
+Pre-executed at command load (`!` prefix) — the agent receives branch, status, diff, and issue context as part of the prompt, no Bash tool round-trip.
 
-**Parallel Bash calls:**
-
-```bash
+```!
 # 1. All changes
 git status --porcelain
 
@@ -38,16 +36,16 @@ DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.na
 echo "BRANCH=$BRANCH DEFAULT=$DEFAULT_BRANCH"
 
 # 3. Files already on branch
-git diff --name-only $DEFAULT_BRANCH...HEAD
+git diff --name-only "$DEFAULT_BRANCH"...HEAD
 
 # 4. Issue context
-ISSUE_NUM=$(echo $BRANCH | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
-[ -n "$ISSUE_NUM" ] && gh issue view $ISSUE_NUM --json title,body 2>/dev/null
+ISSUE_NUM=$(echo "$BRANCH" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
+[ -n "$ISSUE_NUM" ] && gh issue view "$ISSUE_NUM" --json title,body 2>/dev/null
 
 # 5. Recent commits (for style)
 git log --oneline -10
 
-# 6. Task-related context from branch or issue
+true
 ```
 
 **Grep** — search branch diff and issue body for task-related context.

--- a/plugins/flow/commands/commit.md
+++ b/plugins/flow/commands/commit.md
@@ -47,7 +47,13 @@ fi
 echo ""
 echo "### Branch Files (vs default)"
 BRANCH_FILES=$(git diff --name-only "$DEFAULT_BRANCH"...HEAD 2>/dev/null)
-BRANCH_FILE_COUNT=$(printf '%s\n' "$BRANCH_FILES" | grep -c '.' || echo "0")
+# `grep -c '.' || echo 0` produces multi-line `0\n0` on empty input (grep
+# exits 1, the `||` ALSO fires). Use explicit empty-check.
+if [ -z "$BRANCH_FILES" ]; then
+  BRANCH_FILE_COUNT=0
+else
+  BRANCH_FILE_COUNT=$(printf '%s\n' "$BRANCH_FILES" | wc -l | tr -d ' ')
+fi
 echo "BRANCH_FILE_COUNT=$BRANCH_FILE_COUNT"
 if [ "$BRANCH_FILE_COUNT" = "0" ]; then
   echo "STATE=empty"

--- a/plugins/flow/commands/debug.md
+++ b/plugins/flow/commands/debug.md
@@ -24,9 +24,9 @@ This command operates with these domain skills loaded:
 
 Gather all evidence before theorizing. Execute in parallel:
 
-**Parallel Bash calls:**
+Pre-executed at command load (`!` prefix) — recent git history, diff stat, and current state all reach the agent as prompt context.
 
-```bash
+```!
 # 1. Recent changes that might have introduced the bug
 git log --oneline -10
 
@@ -36,6 +36,8 @@ git diff HEAD~3..HEAD --stat
 # 3. Current state
 git status --short
 git branch --show-current
+
+true
 ```
 
 **Parallel searches:**

--- a/plugins/flow/commands/debug.md
+++ b/plugins/flow/commands/debug.md
@@ -25,15 +25,22 @@ This command operates with these domain skills loaded:
 Gather all evidence before theorizing. Execute in parallel:
 
 ```!
-# 1. Recent changes that might have introduced the bug
-git log --oneline -10
+# Output: `###`-headed sections + KEY=value per
+# `references/command-output-format.md`.
 
-# 2. Recent diff
-git diff HEAD~3..HEAD --stat
+echo "### Recent History"
+git log --oneline -10 2>/dev/null | sed 's/^/COMMIT=/'
 
-# 3. Current state
-git status --short
-git branch --show-current
+echo ""
+echo "### Recent Diff (last 3 commits)"
+git diff HEAD~3..HEAD --stat 2>/dev/null
+
+echo ""
+echo "### Current State"
+echo "BRANCH=$(git branch --show-current 2>/dev/null)"
+UNCOMMITTED_COUNT=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+echo "UNCOMMITTED_COUNT=$UNCOMMITTED_COUNT"
+[ "$UNCOMMITTED_COUNT" != "0" ] && git status --short 2>/dev/null | head -20 | sed 's/^/UNCOMMITTED_LINE=/'
 
 true
 ```

--- a/plugins/flow/commands/debug.md
+++ b/plugins/flow/commands/debug.md
@@ -24,8 +24,6 @@ This command operates with these domain skills loaded:
 
 Gather all evidence before theorizing. Execute in parallel:
 
-Pre-executed at command load (`!` prefix) — recent git history, diff stat, and current state all reach the agent as prompt context.
-
 ```!
 # 1. Recent changes that might have introduced the bug
 git log --oneline -10

--- a/plugins/flow/commands/debug.md
+++ b/plugins/flow/commands/debug.md
@@ -29,11 +29,24 @@ Gather all evidence before theorizing. Execute in parallel:
 # `references/command-output-format.md`.
 
 echo "### Recent History"
-git log --oneline -10 2>/dev/null | sed 's/^/COMMIT=/'
+# Capture into a var so an empty result emits an explicit STATE=empty
+# sentinel rather than a silent heading.
+RECENT_LOG=$(git log --oneline -10 2>/dev/null)
+if [ -z "$RECENT_LOG" ]; then
+  echo "STATE=empty"
+else
+  printf '%s\n' "$RECENT_LOG" | sed 's/^/COMMIT=/'
+fi
 
 echo ""
 echo "### Recent Diff (last 3 commits)"
-git diff HEAD~3..HEAD --stat 2>/dev/null
+RECENT_DIFF=$(git diff HEAD~3..HEAD --stat 2>/dev/null)
+if [ -z "$RECENT_DIFF" ]; then
+  echo "STATE=empty"
+else
+  # Prefix raw stat lines with DIFF_STAT= per command-output-format.md.
+  printf '%s\n' "$RECENT_DIFF" | sed 's/^/DIFF_STAT=/'
+fi
 
 echo ""
 echo "### Current State"

--- a/plugins/flow/commands/design.md
+++ b/plugins/flow/commands/design.md
@@ -30,26 +30,43 @@ This command operates with these domain skills loaded:
 Map existing architecture before proposing anything. Execute in parallel:
 
 ```!
-# 1. Project structure
-ls -la src/ app/ lib/ packages/ 2>/dev/null || ls -la
-
-# 2. If issue number given, load issue context. Take the first whitespace-
-# separated token; accept only if it is *all* digits. Inputs like
-# "foo42 strategy" (where greedy digit-extraction would otherwise pluck
-# `42` and fire `gh issue view 42` on an unrelated issue) are rejected to
-# empty ISSUE_NUM. Supports usage like /flow:design 42 (decoupled auth
-# service architecture).
+# Take the first whitespace-separated token; accept only if it is *all*
+# digits. Inputs like "foo42 strategy" (greedy digit-extraction would pluck
+# `42` and fire `gh issue view 42` on an unrelated issue) are rejected.
+# Supports usage like /flow:design 42 (decoupled auth service architecture).
+#
+# Output: `###`-headed sections + KEY=value per
+# `references/command-output-format.md`.
 ARG1="${ARGUMENTS%% *}"
 case "$ARG1" in
   ''|*[!0-9]*) ISSUE_NUM="" ;;
   *) ISSUE_NUM="$ARG1" ;;
 esac
-echo "ISSUE_NUM=$ISSUE_NUM"
-[ -n "$ISSUE_NUM" ] && gh issue view "$ISSUE_NUM" --json title,body,labels 2>/dev/null
 
-# 3. Current branch context
-git branch --show-current
-git log --oneline -5
+echo "### Project Structure"
+ls -la src/ app/ lib/ packages/ 2>/dev/null || ls -la
+
+echo ""
+echo "### Issue Reference"
+echo "ISSUE_NUM=${ISSUE_NUM:-(none — exploratory design)}"
+
+echo ""
+echo "### Issue Context"
+if [ -n "$ISSUE_NUM" ]; then
+  gh issue view "$ISSUE_NUM" --json title,body,labels --jq '"TITLE=\"\(.title)\"\nLABELS=\([.labels[].name] | join(","))\nBODY_LENGTH=\(.body | length)"' 2>/dev/null
+  echo ""
+  echo "#### Issue body"
+  gh issue view "$ISSUE_NUM" --json body --jq '.body' 2>/dev/null
+else
+  echo "STATE=empty"
+fi
+
+echo ""
+echo "### Branch Context"
+echo "BRANCH=$(git branch --show-current 2>/dev/null)"
+echo ""
+echo "#### Recent commits"
+git log --oneline -5 2>/dev/null | sed 's/^/COMMIT=/'
 
 true
 ```

--- a/plugins/flow/commands/design.md
+++ b/plugins/flow/commands/design.md
@@ -48,7 +48,8 @@ ls -la src/ app/ lib/ packages/ 2>/dev/null || ls -la
 
 echo ""
 echo "### Issue Reference"
-echo "ISSUE_NUM=${ISSUE_NUM:-(none — exploratory design)}"
+# Quote parenthesized fallback per command-output-format.md rule 2.
+echo "ISSUE_NUM=${ISSUE_NUM:-\"(none — exploratory design)\"}"
 
 echo ""
 echo "### Issue Context"

--- a/plugins/flow/commands/design.md
+++ b/plugins/flow/commands/design.md
@@ -45,14 +45,19 @@ esac
 
 echo "### Project Structure"
 # Prefix each entry with ENTRY= per command-output-format.md (raw `ls -la`
-# rows have no KEY= label). Try the conventional source roots first; fall
-# back to repo root if none exist. Use `printf` so an empty ls produces a
-# detectable empty var rather than a silent heading.
+# rows have no KEY= label). Each row contains whitespace (permission bits,
+# owner, size, date, name), so values are double-quoted per rule 2.
+# Try the conventional source roots first; fall back to repo root if none
+# exist. Use `printf` so an empty ls produces a detectable empty var
+# rather than a silent heading.
 STRUCTURE=$(ls -la src/ app/ lib/ packages/ 2>/dev/null || ls -la 2>/dev/null)
 if [ -z "$STRUCTURE" ]; then
   echo "STATE=empty"
 else
-  printf '%s\n' "$STRUCTURE" | sed 's/^/ENTRY=/'
+  # Quote each row so values containing whitespace remain a single scalar
+  # under one KEY=. Embedded double-quotes (rare in ls output) are escaped
+  # with sed before wrapping.
+  printf '%s\n' "$STRUCTURE" | sed 's/"/\\"/g; s/^/ENTRY="/; s/$/"/'
 fi
 
 echo ""

--- a/plugins/flow/commands/design.md
+++ b/plugins/flow/commands/design.md
@@ -29,19 +29,25 @@ This command operates with these domain skills loaded:
 
 Map existing architecture before proposing anything. Execute in parallel:
 
-**Parallel Bash calls:**
+Pre-executed at command load (`!` prefix) — project structure, extracted ISSUE_NUM, issue context, and branch state all reach the agent as prompt context.
 
-```bash
+```!
 # 1. Project structure
 ls -la src/ app/ lib/ packages/ 2>/dev/null || ls -la
 
-# 2. If issue number given, load issue context
-ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oE '[0-9]+')
-[ -n "$ISSUE_NUM" ] && gh issue view $ISSUE_NUM --json title,body,labels
+# 2. If issue number given, load issue context. Take the first whitespace-
+# separated token as the candidate issue ref; extract digits. Supports usage
+# like /flow:design 42 (decoupled auth service architecture).
+ARG1="${ARGUMENTS%% *}"
+ISSUE_NUM=$(echo "$ARG1" | grep -oE '[0-9]+')
+echo "ISSUE_NUM=$ISSUE_NUM"
+[ -n "$ISSUE_NUM" ] && gh issue view "$ISSUE_NUM" --json title,body,labels 2>/dev/null
 
 # 3. Current branch context
 git branch --show-current
 git log --oneline -5
+
+true
 ```
 
 **Parallel Agent + Skill calls:**

--- a/plugins/flow/commands/design.md
+++ b/plugins/flow/commands/design.md
@@ -44,7 +44,16 @@ case "$ARG1" in
 esac
 
 echo "### Project Structure"
-ls -la src/ app/ lib/ packages/ 2>/dev/null || ls -la
+# Prefix each entry with ENTRY= per command-output-format.md (raw `ls -la`
+# rows have no KEY= label). Try the conventional source roots first; fall
+# back to repo root if none exist. Use `printf` so an empty ls produces a
+# detectable empty var rather than a silent heading.
+STRUCTURE=$(ls -la src/ app/ lib/ packages/ 2>/dev/null || ls -la 2>/dev/null)
+if [ -z "$STRUCTURE" ]; then
+  echo "STATE=empty"
+else
+  printf '%s\n' "$STRUCTURE" | sed 's/^/ENTRY=/'
+fi
 
 echo ""
 echo "### Issue Reference"
@@ -67,7 +76,12 @@ echo "### Branch Context"
 echo "BRANCH=$(git branch --show-current 2>/dev/null)"
 echo ""
 echo "#### Recent commits"
-git log --oneline -5 2>/dev/null | sed 's/^/COMMIT=/'
+RECENT_COMMITS=$(git log --oneline -5 2>/dev/null)
+if [ -z "$RECENT_COMMITS" ]; then
+  echo "STATE=empty"
+else
+  printf '%s\n' "$RECENT_COMMITS" | sed 's/^/COMMIT=/'
+fi
 
 true
 ```

--- a/plugins/flow/commands/design.md
+++ b/plugins/flow/commands/design.md
@@ -29,8 +29,6 @@ This command operates with these domain skills loaded:
 
 Map existing architecture before proposing anything. Execute in parallel:
 
-Pre-executed at command load (`!` prefix) — project structure, extracted ISSUE_NUM, issue context, and branch state all reach the agent as prompt context.
-
 ```!
 # 1. Project structure
 ls -la src/ app/ lib/ packages/ 2>/dev/null || ls -la

--- a/plugins/flow/commands/design.md
+++ b/plugins/flow/commands/design.md
@@ -36,10 +36,16 @@ Pre-executed at command load (`!` prefix) — project structure, extracted ISSUE
 ls -la src/ app/ lib/ packages/ 2>/dev/null || ls -la
 
 # 2. If issue number given, load issue context. Take the first whitespace-
-# separated token as the candidate issue ref; extract digits. Supports usage
-# like /flow:design 42 (decoupled auth service architecture).
+# separated token; accept only if it is *all* digits. Inputs like
+# "foo42 strategy" (where greedy digit-extraction would otherwise pluck
+# `42` and fire `gh issue view 42` on an unrelated issue) are rejected to
+# empty ISSUE_NUM. Supports usage like /flow:design 42 (decoupled auth
+# service architecture).
 ARG1="${ARGUMENTS%% *}"
-ISSUE_NUM=$(echo "$ARG1" | grep -oE '[0-9]+')
+case "$ARG1" in
+  ''|*[!0-9]*) ISSUE_NUM="" ;;
+  *) ISSUE_NUM="$ARG1" ;;
+esac
 echo "ISSUE_NUM=$ISSUE_NUM"
 [ -n "$ISSUE_NUM" ] && gh issue view "$ISSUE_NUM" --json title,body,labels 2>/dev/null
 

--- a/plugins/flow/commands/explain.md
+++ b/plugins/flow/commands/explain.md
@@ -13,12 +13,13 @@ _None — explanatory Q&A over journal and diff context. No skill invocations._
 
 ## Phase 1: Load Context
 
-**Parallel operations:**
+Pre-executed at command load (`!` prefix) — branch, journal contents, issue details, and branch diff all reach the agent as prompt context.
 
-```bash
+```!
 # 1. Current branch and issue
 BRANCH=$(git branch --show-current)
 ISSUE_NUM=$(echo "$BRANCH" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
+echo "BRANCH=$BRANCH ISSUE_NUM=$ISSUE_NUM"
 
 # 2. Decision journal. Resolved via bin/cascade-resolve.sh.
 HELPER="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
@@ -32,6 +33,8 @@ JOURNAL_DIR=".decisions"
 # 4. Branch diff summary
 DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
 git diff --stat "$DEFAULT_BRANCH"...HEAD
+
+true
 ```
 
 ## Phase 2: Present Context

--- a/plugins/flow/commands/explain.md
+++ b/plugins/flow/commands/explain.md
@@ -14,23 +14,47 @@ _None — explanatory Q&A over journal and diff context. No skill invocations._
 ## Phase 1: Load Context
 
 ```!
-# 1. Current branch and issue
-BRANCH=$(git branch --show-current)
-ISSUE_NUM=$(echo "$BRANCH" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
-echo "BRANCH=$BRANCH ISSUE_NUM=$ISSUE_NUM"
+# Output: `###`-headed sections + KEY=value per
+# `references/command-output-format.md`.
 
-# 2. Decision journal. Resolved via bin/cascade-resolve.sh.
+echo "### Branch & Issue"
+BRANCH=$(git branch --show-current 2>/dev/null)
+ISSUE_NUM=$(echo "$BRANCH" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
+echo "BRANCH=$BRANCH"
+echo "ISSUE_NUM=${ISSUE_NUM:-(none)}"
+
+echo ""
+echo "### Decision Journal"
 HELPER="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
 JOURNAL_DIR=".decisions"
 [ -x "$HELPER" ] && JOURNAL_DIR=$("$HELPER" --default ".decisions" '.journal.dir // empty')
-[ -n "$ISSUE_NUM" ] && cat "$JOURNAL_DIR/issue-$ISSUE_NUM.md" 2>/dev/null
+echo "JOURNAL_DIR=$JOURNAL_DIR"
+if [ -n "$ISSUE_NUM" ] && [ -f "$JOURNAL_DIR/issue-$ISSUE_NUM.md" ]; then
+  echo "JOURNAL_FILE=$JOURNAL_DIR/issue-$ISSUE_NUM.md"
+  echo "JOURNAL_BYTES=$(wc -c < "$JOURNAL_DIR/issue-$ISSUE_NUM.md" | tr -d ' ')"
+  echo ""
+  echo "#### Journal contents"
+  cat "$JOURNAL_DIR/issue-$ISSUE_NUM.md"
+else
+  echo "STATE=empty"
+fi
 
-# 3. Issue details
-[ -n "$ISSUE_NUM" ] && gh issue view "$ISSUE_NUM" --json title,body 2>/dev/null
+echo ""
+echo "### Issue Details"
+if [ -n "$ISSUE_NUM" ]; then
+  gh issue view "$ISSUE_NUM" --json title,body --jq '"TITLE=\"\(.title)\"\nBODY_LENGTH=\(.body | length)"' 2>/dev/null
+  echo ""
+  echo "#### Issue body"
+  gh issue view "$ISSUE_NUM" --json body --jq '.body' 2>/dev/null
+else
+  echo "STATE=empty"
+fi
 
-# 4. Branch diff summary
+echo ""
+echo "### Branch Diff Summary"
 DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
-git diff --stat "$DEFAULT_BRANCH"...HEAD
+echo "DEFAULT_BRANCH=$DEFAULT_BRANCH"
+git diff --stat "$DEFAULT_BRANCH"...HEAD 2>/dev/null
 
 true
 ```

--- a/plugins/flow/commands/explain.md
+++ b/plugins/flow/commands/explain.md
@@ -55,7 +55,14 @@ echo ""
 echo "### Branch Diff Summary"
 DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
 echo "DEFAULT_BRANCH=$DEFAULT_BRANCH"
-git diff --stat "$DEFAULT_BRANCH"...HEAD 2>/dev/null
+# Capture so an empty stat (e.g., on the default branch) emits STATE=empty
+# rather than a silent heading; prefix raw stat lines with DIFF_STAT=.
+DIFF_STAT=$(git diff --stat "$DEFAULT_BRANCH"...HEAD 2>/dev/null)
+if [ -z "$DIFF_STAT" ]; then
+  echo "STATE=empty"
+else
+  printf '%s\n' "$DIFF_STAT" | sed 's/^/DIFF_STAT=/'
+fi
 
 true
 ```

--- a/plugins/flow/commands/explain.md
+++ b/plugins/flow/commands/explain.md
@@ -21,7 +21,8 @@ echo "### Branch & Issue"
 BRANCH=$(git branch --show-current 2>/dev/null)
 ISSUE_NUM=$(echo "$BRANCH" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
 echo "BRANCH=$BRANCH"
-echo "ISSUE_NUM=${ISSUE_NUM:-(none)}"
+# Quote parenthesized fallback per command-output-format.md rule 2.
+echo "ISSUE_NUM=${ISSUE_NUM:-\"(none)\"}"
 
 echo ""
 echo "### Decision Journal"

--- a/plugins/flow/commands/explain.md
+++ b/plugins/flow/commands/explain.md
@@ -13,8 +13,6 @@ _None — explanatory Q&A over journal and diff context. No skill invocations._
 
 ## Phase 1: Load Context
 
-Pre-executed at command load (`!` prefix) — branch, journal contents, issue details, and branch diff all reach the agent as prompt context.
-
 ```!
 # 1. Current branch and issue
 BRANCH=$(git branch --show-current)

--- a/plugins/flow/commands/flow.md
+++ b/plugins/flow/commands/flow.md
@@ -68,7 +68,7 @@ Parse `$ARGUMENTS` to extract verb and target:
 When invoked without arguments, show help and current status:
 
 1. Display available verbs with one-line descriptions
-2. Pre-executed at command load (`!` prefix) — quick state queries reach the agent as prompt context:
+2. Quick state queries (read-only):
 
 ```!
 # Parallel: current state queries. Bare `/flow` runs in any CWD, including

--- a/plugins/flow/commands/flow.md
+++ b/plugins/flow/commands/flow.md
@@ -71,12 +71,34 @@ When invoked without arguments, show help and current status:
 2. Quick state queries (read-only):
 
 ```!
-# Parallel: current state queries. Bare `/flow` runs in any CWD, including
-# non-repos and offline shells, so stderr from gh is suppressed (otherwise
-# "could not determine repository" leaks into the prompt as data).
-git branch --show-current
-gh issue list --assignee @me --state open --limit 5 2>/dev/null
-gh pr list --author @me --state open --limit 5 2>/dev/null
+# Output: `###`-headed sections + KEY=value per
+# `references/command-output-format.md`. Bare `/flow` runs in any CWD,
+# including non-repos / offline shells, so gh stderr is suppressed.
+
+echo "### Branch"
+echo "BRANCH=$(git branch --show-current 2>/dev/null)"
+
+echo ""
+echo "### Assigned Issues"
+ASSIGNED_JSON=$(gh issue list --assignee @me --state open --limit 5 --json number,title 2>/dev/null)
+ASSIGNED_COUNT=$(echo "$ASSIGNED_JSON" | jq 'length' 2>/dev/null || echo "0")
+echo "ASSIGNED_COUNT=$ASSIGNED_COUNT"
+if [ "$ASSIGNED_COUNT" = "0" ]; then
+  echo "STATE=empty"
+else
+  echo "$ASSIGNED_JSON" | jq -r '.[] | "ISSUE=\(.number) title=\"\(.title)\""' 2>/dev/null
+fi
+
+echo ""
+echo "### My PRs"
+AUTHORED_JSON=$(gh pr list --author @me --state open --limit 5 --json number,title 2>/dev/null)
+AUTHORED_COUNT=$(echo "$AUTHORED_JSON" | jq 'length' 2>/dev/null || echo "0")
+echo "AUTHORED_COUNT=$AUTHORED_COUNT"
+if [ "$AUTHORED_COUNT" = "0" ]; then
+  echo "STATE=empty"
+else
+  echo "$AUTHORED_JSON" | jq -r '.[] | "PR=\(.number) title=\"\(.title)\""' 2>/dev/null
+fi
 
 true
 ```

--- a/plugins/flow/commands/flow.md
+++ b/plugins/flow/commands/flow.md
@@ -68,13 +68,15 @@ Parse `$ARGUMENTS` to extract verb and target:
 When invoked without arguments, show help and current status:
 
 1. Display available verbs with one-line descriptions
-2. Run a quick status check:
+2. Pre-executed at command load (`!` prefix) — quick state queries reach the agent as prompt context:
 
-```bash
+```!
 # Parallel: current state queries
 git branch --show-current
 gh issue list --assignee @me --state open --limit 5
 gh pr list --author @me --state open --limit 5
+
+true
 ```
 
 3. Suggest next action based on state:

--- a/plugins/flow/commands/flow.md
+++ b/plugins/flow/commands/flow.md
@@ -71,10 +71,12 @@ When invoked without arguments, show help and current status:
 2. Pre-executed at command load (`!` prefix) — quick state queries reach the agent as prompt context:
 
 ```!
-# Parallel: current state queries
+# Parallel: current state queries. Bare `/flow` runs in any CWD, including
+# non-repos and offline shells, so stderr from gh is suppressed (otherwise
+# "could not determine repository" leaks into the prompt as data).
 git branch --show-current
-gh issue list --assignee @me --state open --limit 5
-gh pr list --author @me --state open --limit 5
+gh issue list --assignee @me --state open --limit 5 2>/dev/null
+gh pr list --author @me --state open --limit 5 2>/dev/null
 
 true
 ```

--- a/plugins/flow/commands/flow.md
+++ b/plugins/flow/commands/flow.md
@@ -80,24 +80,40 @@ echo "BRANCH=$(git branch --show-current 2>/dev/null)"
 
 echo ""
 echo "### Assigned Issues"
-ASSIGNED_JSON=$(gh issue list --assignee @me --state open --limit 5 --json number,title 2>/dev/null)
-ASSIGNED_COUNT=$(echo "$ASSIGNED_JSON" | jq 'length' 2>/dev/null || echo "0")
-echo "ASSIGNED_COUNT=$ASSIGNED_COUNT"
-if [ "$ASSIGNED_COUNT" = "0" ]; then
-  echo "STATE=empty"
+# Capture gh exit code separately: gh success with no records returns `[]` exit 0;
+# gh failure (auth, network, non-repo CWD) returns "" with non-zero exit and jq
+# 1.8 on empty input produces NO output and exits 0 — so `|| echo 0` doesn't
+# fire and COUNT stays empty, leaking a bare `ASSIGNED_COUNT=` line.
+ASSIGNED_JSON=$(gh issue list --assignee @me --state open --limit 5 --json number,title 2>/dev/null); GH_EXIT=$?
+if [ $GH_EXIT -ne 0 ]; then
+  echo "ASSIGNED_COUNT=0"
+  echo "STATE=unavailable"
 else
-  echo "$ASSIGNED_JSON" | jq -r '.[] | "ISSUE=\(.number) title=\"\(.title)\""' 2>/dev/null
+  ASSIGNED_COUNT=$(echo "$ASSIGNED_JSON" | jq 'length' 2>/dev/null)
+  [ -z "$ASSIGNED_COUNT" ] && ASSIGNED_COUNT=0
+  echo "ASSIGNED_COUNT=$ASSIGNED_COUNT"
+  if [ "$ASSIGNED_COUNT" = "0" ]; then
+    echo "STATE=empty"
+  else
+    echo "$ASSIGNED_JSON" | jq -r '.[] | "ISSUE=\(.number) title=\"\(.title)\""' 2>/dev/null
+  fi
 fi
 
 echo ""
 echo "### My PRs"
-AUTHORED_JSON=$(gh pr list --author @me --state open --limit 5 --json number,title 2>/dev/null)
-AUTHORED_COUNT=$(echo "$AUTHORED_JSON" | jq 'length' 2>/dev/null || echo "0")
-echo "AUTHORED_COUNT=$AUTHORED_COUNT"
-if [ "$AUTHORED_COUNT" = "0" ]; then
-  echo "STATE=empty"
+AUTHORED_JSON=$(gh pr list --author @me --state open --limit 5 --json number,title 2>/dev/null); GH_EXIT=$?
+if [ $GH_EXIT -ne 0 ]; then
+  echo "AUTHORED_COUNT=0"
+  echo "STATE=unavailable"
 else
-  echo "$AUTHORED_JSON" | jq -r '.[] | "PR=\(.number) title=\"\(.title)\""' 2>/dev/null
+  AUTHORED_COUNT=$(echo "$AUTHORED_JSON" | jq 'length' 2>/dev/null)
+  [ -z "$AUTHORED_COUNT" ] && AUTHORED_COUNT=0
+  echo "AUTHORED_COUNT=$AUTHORED_COUNT"
+  if [ "$AUTHORED_COUNT" = "0" ]; then
+    echo "STATE=empty"
+  else
+    echo "$AUTHORED_JSON" | jq -r '.[] | "PR=\(.number) title=\"\(.title)\""' 2>/dev/null
+  fi
 fi
 
 true

--- a/plugins/flow/commands/issue.md
+++ b/plugins/flow/commands/issue.md
@@ -23,14 +23,25 @@ Skill-driven issue creation. Follows the Explore > Plan > Code > Verify loop wit
 Gather context before formulating the issue.
 
 ```!
-# 1. Repo info
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
-echo "REPO=$REPO"
-[ -z "$REPO" ] && echo "WARN: cannot resolve repo (gh auth or non-repo CWD?)" >&2
+# Output: `###`-headed sections + KEY=value per
+# `references/command-output-format.md`.
 
-# 2. Current git state (branch context for cross-references)
-git branch --show-current
-git status --short
+echo "### Repo Context"
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
+if [ -z "$REPO" ]; then
+  echo "STATE=unavailable"
+  echo "ERROR=cannot resolve repo (gh auth or non-repo CWD?)"
+else
+  echo "STATE=ok"
+  echo "REPO=$REPO"
+fi
+
+echo ""
+echo "### Git State"
+echo "BRANCH=$(git branch --show-current 2>/dev/null)"
+UNCOMMITTED_COUNT=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+echo "UNCOMMITTED_COUNT=$UNCOMMITTED_COUNT"
+[ "$UNCOMMITTED_COUNT" != "0" ] && git status --short 2>/dev/null | head -20 | sed 's/^/UNCOMMITTED_LINE=/'
 
 true
 ```

--- a/plugins/flow/commands/issue.md
+++ b/plugins/flow/commands/issue.md
@@ -22,9 +22,9 @@ Skill-driven issue creation. Follows the Explore > Plan > Code > Verify loop wit
 
 Gather context before formulating the issue.
 
-**Parallel Bash calls:**
+Pre-executed at command load (`!` prefix) — repo and branch context reach the agent as prompt context.
 
-```bash
+```!
 # 1. Repo info
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 echo "REPO=$REPO"
@@ -32,6 +32,8 @@ echo "REPO=$REPO"
 # 2. Current git state (branch context for cross-references)
 git branch --show-current
 git status --short
+
+true
 ```
 
 **Branch context extraction**: If on a feature branch matching `feature/issue-{N}-*` or `fix/issue-{N}-*`, extract the issue number — the new issue may be related.

--- a/plugins/flow/commands/issue.md
+++ b/plugins/flow/commands/issue.md
@@ -26,8 +26,9 @@ Pre-executed at command load (`!` prefix) — repo and branch context reach the 
 
 ```!
 # 1. Repo info
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
 echo "REPO=$REPO"
+[ -z "$REPO" ] && echo "WARN: cannot resolve repo (gh auth or non-repo CWD?)" >&2
 
 # 2. Current git state (branch context for cross-references)
 git branch --show-current

--- a/plugins/flow/commands/issue.md
+++ b/plugins/flow/commands/issue.md
@@ -22,8 +22,6 @@ Skill-driven issue creation. Follows the Explore > Plan > Code > Verify loop wit
 
 Gather context before formulating the issue.
 
-Pre-executed at command load (`!` prefix) — repo and branch context reach the agent as prompt context.
-
 ```!
 # 1. Repo info
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)

--- a/plugins/flow/commands/learn.md
+++ b/plugins/flow/commands/learn.md
@@ -19,13 +19,28 @@ _None — retrospective pattern analysis over the decision journal. No skill inv
 
 echo "### Resolved Paths"
 # JOURNAL_DIR and PROPOSAL_DIR resolve via the standard settings cascade.
+# settings.json may store paths with a leading `~` (literal — JSON has no
+# tilde-expansion semantics). The cascade helper returns the value verbatim
+# without expansion, so downstream tools that don't auto-expand tildes
+# (Read/Write/Edit, Python os.path) would fail. Manually expand `~` to
+# $HOME so the agent always receives an absolute path.
 HELPER="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
 JOURNAL_DIR=".decisions"
 PROPOSAL_DIR="$HOME/.claude/flow-proposals"
 if [ -x "$HELPER" ]; then
   JOURNAL_DIR=$("$HELPER" --default ".decisions" '.journal.dir // empty')
   PROPOSAL_DIR=$("$HELPER" --default "$HOME/.claude/flow-proposals" '.learning.proposalDir // empty')
+  echo "STATE=ok"
+else
+  # Helper missing or non-executable — using compile-time defaults. Surface
+  # so the agent knows resolution was best-effort and config might be ignored.
+  echo "STATE=unavailable"
+  echo "ERROR=cascade-resolve.sh missing or non-executable; using built-in defaults"
 fi
+# Expand leading `~` to $HOME so downstream Read/Write/Edit tools (which
+# don't tilde-expand) receive absolute paths.
+JOURNAL_DIR="${JOURNAL_DIR/#\~/$HOME}"
+PROPOSAL_DIR="${PROPOSAL_DIR/#\~/$HOME}"
 echo "JOURNAL_DIR=$JOURNAL_DIR"
 echo "PROPOSAL_DIR=$PROPOSAL_DIR"
 

--- a/plugins/flow/commands/learn.md
+++ b/plugins/flow/commands/learn.md
@@ -13,8 +13,6 @@ _None — retrospective pattern analysis over the decision journal. No skill inv
 
 ## Phase 1: Gather Journal Entries
 
-Pre-executed at command load (`!` prefix) — the agent receives directory paths and counts as part of the prompt, no Bash tool round-trip.
-
 ```!
 # Read journal directory and proposal directory via bin/cascade-resolve.sh.
 HELPER="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"

--- a/plugins/flow/commands/learn.md
+++ b/plugins/flow/commands/learn.md
@@ -14,7 +14,11 @@ _None — retrospective pattern analysis over the decision journal. No skill inv
 ## Phase 1: Gather Journal Entries
 
 ```!
-# Read journal directory and proposal directory via bin/cascade-resolve.sh.
+# Output: `###`-headed sections + KEY=value per
+# `references/command-output-format.md`.
+
+echo "### Resolved Paths"
+# JOURNAL_DIR and PROPOSAL_DIR resolve via the standard settings cascade.
 HELPER="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
 JOURNAL_DIR=".decisions"
 PROPOSAL_DIR="$HOME/.claude/flow-proposals"
@@ -25,11 +29,27 @@ fi
 echo "JOURNAL_DIR=$JOURNAL_DIR"
 echo "PROPOSAL_DIR=$PROPOSAL_DIR"
 
-# List journal files
-ls -la "$JOURNAL_DIR"/*.md 2>/dev/null
+echo ""
+echo "### Journal Files"
+JOURNAL_FILES=0
+[ -d "$JOURNAL_DIR" ] && JOURNAL_FILES=$(ls "$JOURNAL_DIR"/*.md 2>/dev/null | wc -l | tr -d ' ')
+echo "JOURNAL_FILE_COUNT=$JOURNAL_FILES"
+if [ "$JOURNAL_FILES" = "0" ]; then
+  echo "STATE=empty"
+else
+  ls "$JOURNAL_DIR"/*.md 2>/dev/null | sed 's/^/JOURNAL_FILE=/'
+fi
 
-# Count existing proposals
-ls -la "$PROPOSAL_DIR"/*.md 2>/dev/null | wc -l
+echo ""
+echo "### Proposal Files"
+PROPOSAL_FILES=0
+[ -d "$PROPOSAL_DIR" ] && PROPOSAL_FILES=$(ls "$PROPOSAL_DIR"/*.md 2>/dev/null | wc -l | tr -d ' ')
+echo "PROPOSAL_FILE_COUNT=$PROPOSAL_FILES"
+if [ "$PROPOSAL_FILES" = "0" ]; then
+  echo "STATE=empty"
+else
+  ls "$PROPOSAL_DIR"/*.md 2>/dev/null | sed 's/^/PROPOSAL_FILE=/'
+fi
 
 true
 ```

--- a/plugins/flow/commands/learn.md
+++ b/plugins/flow/commands/learn.md
@@ -13,11 +13,10 @@ _None — retrospective pattern analysis over the decision journal. No skill inv
 
 ## Phase 1: Gather Journal Entries
 
-```bash
+Pre-executed at command load (`!` prefix) — the agent receives directory paths and counts as part of the prompt, no Bash tool round-trip.
+
+```!
 # Read journal directory and proposal directory via bin/cascade-resolve.sh.
-# The helper iterates project-local → project-shared → user-global → plugin
-# default and surfaces parse errors on stderr. Gracefully fall back to defaults
-# when the helper is unreachable (hardens against unusual cwd / env states).
 HELPER="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
 JOURNAL_DIR=".decisions"
 PROPOSAL_DIR="$HOME/.claude/flow-proposals"
@@ -25,12 +24,16 @@ if [ -x "$HELPER" ]; then
   JOURNAL_DIR=$("$HELPER" --default ".decisions" '.journal.dir // empty')
   PROPOSAL_DIR=$("$HELPER" --default "$HOME/.claude/flow-proposals" '.learning.proposalDir // empty')
 fi
+echo "JOURNAL_DIR=$JOURNAL_DIR"
+echo "PROPOSAL_DIR=$PROPOSAL_DIR"
 
 # List journal files
 ls -la "$JOURNAL_DIR"/*.md 2>/dev/null
 
 # Count existing proposals
 ls -la "$PROPOSAL_DIR"/*.md 2>/dev/null | wc -l
+
+true
 ```
 
 Read all journal files from the current session (today's entries).

--- a/plugins/flow/commands/merge.md
+++ b/plugins/flow/commands/merge.md
@@ -18,8 +18,6 @@ Tier 3 operation — **always requires human confirmation**. This is non-negotia
 
 ## Phase 1: Verify Prerequisites
 
-Pre-executed at command load (`!` prefix) — PR status, reviews, unresolved conversations, stale approval check, and finding-ledger seed all reach the agent as prompt context.
-
 ```!
 # Take the first whitespace-separated token; accept only if it is all digits.
 # Trailing context (e.g., "104 (verify ledger gate)") is fine — first-token
@@ -64,7 +62,7 @@ true
 
 ### Finding-Ledger Check
 
-Parse the latest `FLOW_RESOLUTION_CYCLE` and `FLOW_REVIEW_CYCLE` comments to verify all findings are resolved before merge. Marker schemas and the canonical extraction queries are documented in [`references/finding-ledger-parser.md`](../references/finding-ledger-parser.md); this command applies the merge-blocking subset (ESCALATED non-empty, FINDINGS without matching RESOLVED). Pre-executed at command load (`!` prefix).
+Parse the latest `FLOW_RESOLUTION_CYCLE` and `FLOW_REVIEW_CYCLE` comments to verify all findings are resolved before merge. Marker schemas and the canonical extraction queries are documented in [`references/finding-ledger-parser.md`](../references/finding-ledger-parser.md); this command applies the merge-blocking subset (ESCALATED non-empty, FINDINGS without matching RESOLVED).
 
 ```!
 # Extract the latest FLOW_RESOLUTION_CYCLE comment (issue/PR conversation).

--- a/plugins/flow/commands/merge.md
+++ b/plugins/flow/commands/merge.md
@@ -18,40 +18,57 @@ Tier 3 operation — **always requires human confirmation**. This is non-negotia
 
 ## Phase 1: Verify Prerequisites
 
-**Parallel checks:**
+Pre-executed at command load (`!` prefix) — PR status, reviews, unresolved conversations, stale approval check, and finding-ledger seed all reach the agent as prompt context.
 
-```bash
-# 1. PR status
-gh pr view $ARGUMENTS --json reviewDecision,statusCheckRollup,mergeable,mergeStateStatus,title,headRefName
+```!
+# Take the first whitespace-separated token as the PR number; the rest of
+# $ARGUMENTS is free-form context for the agent.
+PR_NUM="${ARGUMENTS%% *}"
 
-# 2. Reviews
-gh pr view $ARGUMENTS --json reviews --jq '.reviews[] | "\(.state) by \(.author.login) at \(.submittedAt)"'
+if [ -z "$PR_NUM" ]; then
+  echo "ERROR: PR number required. Usage: /flow:merge <pr-number>"
+else
+  echo "PR_NUM=$PR_NUM"
 
-# 3. Unresolved conversations (reviewThreads requires GraphQL API)
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-OWNER=$(echo $REPO | cut -d/ -f1)
-NAME=$(echo $REPO | cut -d/ -f2)
-gh api graphql -f query="query { repository(owner: \"$OWNER\", name: \"$NAME\") { pullRequest(number: $ARGUMENTS) { reviewThreads(first: 100) { nodes { isResolved } } } } }" --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length'
+  # 1. PR status
+  gh pr view "$PR_NUM" --json reviewDecision,statusCheckRollup,mergeable,mergeStateStatus,title,headRefName
 
-# 4. Stale approval check
-gh pr view $ARGUMENTS --json reviews,commits --jq '{
-  last_approval: [.reviews[] | select(.state == "APPROVED")] | sort_by(.submittedAt) | last | .submittedAt,
-  last_commit: .commits | last | .committedDate
-}'
+  # 2. Reviews
+  gh pr view "$PR_NUM" --json reviews --jq '.reviews[] | "\(.state) by \(.author.login) at \(.submittedAt)"'
 
-# 5. Finding-ledger check
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-COMMENTS=$(gh api "repos/$REPO/issues/$ARGUMENTS/comments" --jq '.[] | select(.body | test("FLOW_RESOLUTION_CYCLE|FLOW_REVIEW_CYCLE")) | {id: .id, body: .body}')
+  # 3. Unresolved conversations (reviewThreads requires GraphQL API)
+  REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+  OWNER=$(echo "$REPO" | cut -d/ -f1)
+  NAME=$(echo "$REPO" | cut -d/ -f2)
+  gh api graphql -f query="query { repository(owner: \"$OWNER\", name: \"$NAME\") { pullRequest(number: $PR_NUM) { reviewThreads(first: 100) { nodes { isResolved } } } } }" --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length'
+
+  # 4. Stale approval check
+  gh pr view "$PR_NUM" --json reviews,commits --jq '{
+    last_approval: [.reviews[] | select(.state == "APPROVED")] | sort_by(.submittedAt) | last | .submittedAt,
+    last_commit: .commits | last | .committedDate
+  }'
+
+  # 5. Finding-ledger seed (full ledger gate runs in next ! block)
+  gh api "repos/$REPO/issues/$PR_NUM/comments" --jq '.[] | select(.body | test("FLOW_RESOLUTION_CYCLE|FLOW_REVIEW_CYCLE")) | {id: .id, body: .body}'
+fi
+
+true
 ```
 
 ### Finding-Ledger Check
 
-Parse the latest `FLOW_RESOLUTION_CYCLE` and `FLOW_REVIEW_CYCLE` comments to verify all findings are resolved before merge. Marker schemas and the canonical extraction queries are documented in [`references/finding-ledger-parser.md`](../references/finding-ledger-parser.md); this command applies the merge-blocking subset (ESCALATED non-empty, FINDINGS without matching RESOLVED).
+Parse the latest `FLOW_RESOLUTION_CYCLE` and `FLOW_REVIEW_CYCLE` comments to verify all findings are resolved before merge. Marker schemas and the canonical extraction queries are documented in [`references/finding-ledger-parser.md`](../references/finding-ledger-parser.md); this command applies the merge-blocking subset (ESCALATED non-empty, FINDINGS without matching RESOLVED). Pre-executed at command load (`!` prefix).
 
-```bash
+```!
 # Extract the latest FLOW_RESOLUTION_CYCLE comment (issue/PR conversation).
 # Capture gh exit code: a silent gh failure (auth, network) must fail the gate
 # CLOSED, not pass it open.
+PR_NUM="${ARGUMENTS%% *}"
+
+if [ -z "$PR_NUM" ]; then
+  echo "FINDING_LEDGER_BLOCK: PR number required"
+else
+
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 
 # MARKERTRUST_GATE_BEGIN
@@ -113,11 +130,11 @@ fi
 
 # Trust filter applied via jq's `index()` exact-match (no regex surface).
 # `--paginate` keeps fetching pages so a noisy thread can't hide forgeries.
-RESOLUTION_BODY=$(gh api --paginate "repos/$REPO/issues/$ARGUMENTS/comments" 2>/dev/null \
+RESOLUTION_BODY=$(gh api --paginate "repos/$REPO/issues/$PR_NUM/comments" 2>/dev/null \
   | jq -s -r --argjson trust "$TRUST_LIST" \
       'add | [.[] | select((.author_association as $a | $trust | index($a)) and (.body | test("FLOW_RESOLUTION_CYCLE:")))] | last | .body // ""')
 GH_EXIT_RES=${PIPESTATUS[0]}
-RES_UNTRUSTED=$(gh api --paginate "repos/$REPO/issues/$ARGUMENTS/comments" 2>/dev/null \
+RES_UNTRUSTED=$(gh api --paginate "repos/$REPO/issues/$PR_NUM/comments" 2>/dev/null \
   | jq -s -r --argjson trust "$TRUST_LIST" \
       'add | [.[] | select((.author_association as $a | $trust | index($a) | not) and (.body | test("FLOW_RESOLUTION_CYCLE:")))] | length')
 GH_EXIT_RES_U=${PIPESTATUS[0]}
@@ -127,11 +144,11 @@ GH_EXIT_RES_U=${PIPESTATUS[0]}
 ESCALATED=$(echo "$RESOLUTION_BODY" | grep -o 'ESCALATED:\[[^]]*\]' | sed 's/^ESCALATED:\[//;s/\]$//' | tr -d ' ')
 
 # Extract the latest FLOW_REVIEW_CYCLE — emitted in PR review bodies, not issue comments
-REVIEW_BODY=$(gh api --paginate "repos/$REPO/pulls/$ARGUMENTS/reviews" 2>/dev/null \
+REVIEW_BODY=$(gh api --paginate "repos/$REPO/pulls/$PR_NUM/reviews" 2>/dev/null \
   | jq -s -r --argjson trust "$TRUST_LIST" \
       'add | [.[] | select((.author_association as $a | $trust | index($a)) and (.body | test("FLOW_REVIEW_CYCLE:")))] | last | .body // ""')
 GH_EXIT_REV=${PIPESTATUS[0]}
-REV_UNTRUSTED=$(gh api --paginate "repos/$REPO/pulls/$ARGUMENTS/reviews" 2>/dev/null \
+REV_UNTRUSTED=$(gh api --paginate "repos/$REPO/pulls/$PR_NUM/reviews" 2>/dev/null \
   | jq -s -r --argjson trust "$TRUST_LIST" \
       'add | [.[] | select((.author_association as $a | $trust | index($a) | not) and (.body | test("FLOW_REVIEW_CYCLE:")))] | length')
 GH_EXIT_REV_U=${PIPESTATUS[0]}
@@ -175,6 +192,10 @@ UNRESOLVED=$(comm -23 <(echo "$REVIEW_FINDINGS") <(echo "$RESOLVED_FINDINGS") | 
 if [ -n "$UNRESOLVED" ]; then
   echo "FINDING_LEDGER_BLOCK: Unresolved findings: $UNRESOLVED"
 fi
+
+fi  # /if [ -z "$PR_NUM" ]
+
+true
 ```
 
 **If the finding-ledger check fails**, stop immediately and display:
@@ -182,7 +203,7 @@ fi
 ```markdown
 ## BLOCKED: Unresolved Findings
 
-PR #$ARGUMENTS cannot be merged — the finding ledger has unresolved items.
+PR #$PR_NUM cannot be merged — the finding ledger has unresolved items.
 
 | Issue | Details |
 |-------|---------|
@@ -193,10 +214,10 @@ PR #$ARGUMENTS cannot be merged — the finding ledger has unresolved items.
 
 ### Remediation
 
-1. Run `/flow:address $ARGUMENTS` to resolve remaining findings
+1. Run `/flow:address $PR_NUM` to resolve remaining findings
 2. Ensure every finding in `FLOW_REVIEW_CYCLE:FINDINGS` has a matching `RESOLVED` entry in `FLOW_RESOLUTION_CYCLE`
 3. Ensure `ESCALATED:[]` is empty (all escalated items must be resolved or have explicit human override)
-4. Re-run `/flow:merge $ARGUMENTS`
+4. Re-run `/flow:merge $PR_NUM`
 
 This gate enforces the "no incomplete shipments" hard boundary.
 ```
@@ -206,7 +227,7 @@ Do NOT proceed to Phase 2. Exit here.
 ## Phase 2: Display Assessment
 
 ```markdown
-## Merge Assessment for PR #$ARGUMENTS
+## Merge Assessment for PR #$PR_NUM
 
 | Check | Status | Details |
 |-------|--------|---------|
@@ -229,12 +250,12 @@ If the Mergeable check fails (has conflicts):
 
 Use the AskUserQuestion tool with a Proactive-Autonomy escalation:
 
-> **Situation** — PR #$ARGUMENTS has merge conflicts that prevent merging.
+> **Situation** — PR #$PR_NUM has merge conflicts that prevent merging.
 >
 > **What I tried** — Checked mergeable status via `gh pr view`. Conflicts exist between the PR branch and the base branch.
 >
 > **Options**:
-> 1. Resolve conflicts now — invokes `Skill(flow:resolve)` with $ARGUMENTS (Recommended)
+> 1. Resolve conflicts now — invokes `Skill(flow:resolve)` with $PR_NUM (Recommended)
 > 2. Cancel merge — address conflicts manually or rebase first
 >
 > **Recommendation** — Option 1. Automated conflict resolution handles most cases and re-verifies after resolution.
@@ -247,7 +268,7 @@ If Option 1: after resolution completes, re-run Phase 1 to verify PR is now merg
 
 ## Phase 3: Confirm and Execute
 
-Use the AskUserQuestion tool with contextual options to confirm: "PR #$ARGUMENTS is ready to merge. Proceed with squash merge and branch deletion?"
+Use the AskUserQuestion tool with contextual options to confirm: "PR #$PR_NUM is ready to merge. Proceed with squash merge and branch deletion?"
 
 Only after the user confirms via the tool:
 
@@ -256,14 +277,14 @@ Only after the user confirms via the tool:
 STRATEGY="squash"  # or from settings
 DELETE_FLAG="--delete-branch"  # or from settings
 
-gh pr merge $ARGUMENTS --$STRATEGY $DELETE_FLAG
+gh pr merge "$PR_NUM" --$STRATEGY $DELETE_FLAG
 ```
 
 ## Phase 4: Post-Merge
 
 ```bash
 # Verify merge
-gh pr view $ARGUMENTS --json state --jq '.state'
+gh pr view "$PR_NUM" --json state --jq '.state'
 
 # Switch to default branch
 DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
@@ -274,7 +295,7 @@ git pull origin $DEFAULT_BRANCH
 **Manifest emit** — if this merge resolved any escalations (a Proactive-Autonomy escalation surfaced via `AskUserQuestion` during Phase 1's finding-ledger check, Phase 2's stale-approval warning, or the conflict-resolution path closed because the user provided one of the six canonical fields), record an `escalation-resolved` artifact for each:
 
 ```bash
-ISSUE=$(gh pr view $ARGUMENTS --json body --jq '.body' | grep -oE '#[0-9]+' | head -1 | tr -d '#')
+ISSUE=$(gh pr view "$PR_NUM" --json body --jq '.body' | grep -oE '#[0-9]+' | head -1 | tr -d '#')
 if [ -n "$ISSUE" ]; then
   # Repeat once per escalation that closed during this merge run.
   "${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/journal-record.sh" \

--- a/plugins/flow/commands/merge.md
+++ b/plugins/flow/commands/merge.md
@@ -78,8 +78,15 @@ else
   REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
   OWNER=$(echo "$REPO" | cut -d/ -f1)
   NAME=$(echo "$REPO" | cut -d/ -f2)
-  UNRESOLVED_COUNT=$(gh api graphql -f query="query { repository(owner: \"$OWNER\", name: \"$NAME\") { pullRequest(number: $PR_NUM) { reviewThreads(first: 100) { nodes { isResolved } } } } }" --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length' 2>/dev/null)
-  echo "UNRESOLVED_COUNT=${UNRESOLVED_COUNT:-unavailable}"
+  UNRESOLVED_COUNT=$(gh api graphql -f query="query { repository(owner: \"$OWNER\", name: \"$NAME\") { pullRequest(number: $PR_NUM) { reviewThreads(first: 100) { nodes { isResolved } } } } }" --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length' 2>/dev/null); GH_EXIT=$?
+  # Closed-vocab contract: emit STATE=unavailable as a separate sentinel rather
+  # than encoding unavailability as the value of UNRESOLVED_COUNT.
+  if [ $GH_EXIT -ne 0 ] || [ -z "$UNRESOLVED_COUNT" ]; then
+    echo "UNRESOLVED_COUNT=0"
+    echo "STATE=unavailable"
+  else
+    echo "UNRESOLVED_COUNT=$UNRESOLVED_COUNT"
+  fi
 
   # Section: Stale Approval Check
   echo ""

--- a/plugins/flow/commands/merge.md
+++ b/plugins/flow/commands/merge.md
@@ -24,37 +24,82 @@ Tier 3 operation — **always requires human confirmation**. This is non-negotia
 # extraction handles it. A non-numeric token (e.g., "foo42" or "evil;rm") is
 # rejected with empty PR_NUM so it never reaches the prompt context or any
 # downstream shell. Matches the pattern in brainstorm.md / design.md.
+#
+# Output: `###`-headed sections + KEY=value per
+# `references/command-output-format.md`. STATE=blocked on bad input;
+# downstream Phase 2 reads each named field directly.
 ARG1="${ARGUMENTS%% *}"
 case "$ARG1" in
   ''|*[!0-9]*) PR_NUM="" ;;
   *) PR_NUM="$ARG1" ;;
 esac
 
+echo "### PR Reference"
 if [ -z "$PR_NUM" ]; then
-  echo "ERROR: PR number required (all-digit). Usage: /flow:merge <pr-number>"
+  echo "STATE=blocked"
+  echo "ERROR=PR number required (all-digit). Usage: /flow:merge <pr-number>"
 else
+  echo "STATE=ok"
   echo "PR_NUM=$PR_NUM"
 
-  # 1. PR status
-  gh pr view "$PR_NUM" --json reviewDecision,statusCheckRollup,mergeable,mergeStateStatus,title,headRefName 2>/dev/null
+  # Section: PR Status
+  echo ""
+  echo "### PR Status"
+  gh pr view "$PR_NUM" --json reviewDecision,statusCheckRollup,mergeable,mergeStateStatus,title,headRefName --jq '
+    [.statusCheckRollup[]? | select(.__typename == "CheckRun")] as $checks |
+    (if (.reviewDecision // "") == "" then "(none)" else .reviewDecision end) as $review |
+    "TITLE=\"\(.title)\"\nHEAD_BRANCH=\(.headRefName)\nMERGEABLE=\(.mergeable)\nMERGE_STATE_STATUS=\(.mergeStateStatus)\nREVIEW_DECISION=\($review)\nCHECKS_PASSED=\($checks | map(select(.conclusion == "SUCCESS")) | length)\nCHECKS_FAILED=\($checks | map(select(.conclusion == "FAILURE")) | length)\nCHECKS_TOTAL=\($checks | length)"
+  ' 2>/dev/null
 
-  # 2. Reviews
-  gh pr view "$PR_NUM" --json reviews --jq '.reviews[] | "\(.state) by \(.author.login) at \(.submittedAt)"' 2>/dev/null
+  # Section: Reviews — one labeled line per review
+  echo ""
+  echo "### Reviews"
+  REVIEWS_JSON=$(gh pr view "$PR_NUM" --json reviews --jq '.reviews' 2>/dev/null)
+  REVIEW_COUNT=$(echo "$REVIEWS_JSON" | jq 'length' 2>/dev/null || echo "0")
+  echo "REVIEW_COUNT=$REVIEW_COUNT"
+  if [ "$REVIEW_COUNT" = "0" ]; then
+    echo "STATE=empty"
+  else
+    echo "$REVIEWS_JSON" | jq -r '.[] | "REVIEW=state=\(.state) author=@\(.author.login) at=\(.submittedAt)"' 2>/dev/null
+  fi
 
-  # 3. Unresolved conversations (reviewThreads requires GraphQL API)
+  # Section: Unresolved Conversations (GraphQL — reviewThreads not in REST)
+  echo ""
+  echo "### Unresolved Conversations"
   REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
   OWNER=$(echo "$REPO" | cut -d/ -f1)
   NAME=$(echo "$REPO" | cut -d/ -f2)
-  gh api graphql -f query="query { repository(owner: \"$OWNER\", name: \"$NAME\") { pullRequest(number: $PR_NUM) { reviewThreads(first: 100) { nodes { isResolved } } } } }" --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length' 2>/dev/null
+  UNRESOLVED_COUNT=$(gh api graphql -f query="query { repository(owner: \"$OWNER\", name: \"$NAME\") { pullRequest(number: $PR_NUM) { reviewThreads(first: 100) { nodes { isResolved } } } } }" --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length' 2>/dev/null)
+  echo "UNRESOLVED_COUNT=${UNRESOLVED_COUNT:-unavailable}"
 
-  # 4. Stale approval check
-  gh pr view "$PR_NUM" --json reviews,commits --jq '{
-    last_approval: [.reviews[] | select(.state == "APPROVED")] | sort_by(.submittedAt) | last | .submittedAt,
-    last_commit: .commits | last | .committedDate
-  }' 2>/dev/null
+  # Section: Stale Approval Check
+  echo ""
+  echo "### Stale Approval Check"
+  gh pr view "$PR_NUM" --json reviews,commits --jq '
+    ([.reviews[] | select(.state == "APPROVED")] | sort_by(.submittedAt) | last | .submittedAt // "none") as $la |
+    (.commits | last | .committedDate) as $lc |
+    "LAST_APPROVAL=\($la)\nLAST_COMMIT=\($lc)\nSTALE=\(if $la == "none" then "n/a" elif $la < $lc then "true" else "false" end)"
+  ' 2>/dev/null
 
-  # 5. Finding-ledger seed (full ledger gate runs in next ! block)
-  gh api "repos/$REPO/issues/$PR_NUM/comments" --jq '.[] | select(.body | test("FLOW_RESOLUTION_CYCLE|FLOW_REVIEW_CYCLE")) | {id: .id, body: .body}' 2>/dev/null
+  # Section: Finding-ledger seed (full gate runs in next ! block)
+  echo ""
+  echo "### Finding-Ledger Seed"
+  SEED_JSON=$(gh api "repos/$REPO/issues/$PR_NUM/comments" --jq '[.[] | select(.body | test("FLOW_RESOLUTION_CYCLE|FLOW_REVIEW_CYCLE")) | {id, body}]' 2>/dev/null)
+  SEED_COUNT=$(echo "$SEED_JSON" | jq 'length' 2>/dev/null || echo "0")
+  echo "SEED_MARKER_COUNT=$SEED_COUNT"
+  if [ "$SEED_COUNT" = "0" ]; then
+    echo "STATE=empty"
+  else
+    # `scan` is a generator that yields each match; wrap in `[...]` to collect
+    # all matches into an array, then take `last` (the actual marker —
+    # typically in an HTML comment at end-of-body — earlier occurrences are
+    # usually prose references). Two capture groups (kind, cycle) so each
+    # element is `[kind, cycle]`.
+    echo "$SEED_JSON" | jq -r '.[] | (
+      ([.body | scan("FLOW_(RESOLUTION|REVIEW)_CYCLE:([0-9]+)")] | last // ["?","?"]) as $last |
+      "SEED=id=\(.id) kind=\($last[0]) cycle=\($last[1])"
+    )' 2>/dev/null
+  fi
 fi
 
 true
@@ -75,9 +120,16 @@ case "$ARG1" in
   *) PR_NUM="$ARG1" ;;
 esac
 
+echo "### Finding-Ledger Gate"
 if [ -z "$PR_NUM" ]; then
+  echo "LEDGER_GATE_STATE=blocked"
   echo "FINDING_LEDGER_BLOCK: PR number required (all-digit)"
 else
+
+# Tracks whether any FINDING_LEDGER_BLOCK has been emitted. Final
+# LEDGER_GATE_STATE is decided after all gate checks have run.
+LEDGER_GATE_BLOCKED=0
+emit_block() { LEDGER_GATE_BLOCKED=1; echo "FINDING_LEDGER_BLOCK: $1"; }
 
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
 
@@ -185,7 +237,7 @@ REV_UNTRUSTED=$(printf '%s' "$GH_REV_RAW" | jq -s -r --argjson trust "$TRUST_LIS
 # (they re-filter the cached JSON), so a single per-endpoint exit check covers
 # all four filter passes.
 if [ $GH_EXIT_RES -ne 0 ] || [ $GH_EXIT_REV -ne 0 ]; then
-  echo "FINDING_LEDGER_BLOCK: gh API unavailable — cannot verify finding ledger (resolution exit=$GH_EXIT_RES, review exit=$GH_EXIT_REV)"
+  emit_block "gh API unavailable — cannot verify finding ledger (resolution exit=$GH_EXIT_RES, review exit=$GH_EXIT_REV)"
 fi
 
 # Surface "untrusted-only" markers as a block reason rather than silently
@@ -203,10 +255,10 @@ if [ -z "$TRUST_LIST_DISPLAY" ]; then
   TRUST_LIST_DISPLAY=$(echo "$TRUST_DEFAULT" | jq -r 'join(",")' 2>/dev/null)
 fi
 if [ -z "$RESOLUTION_BODY" ] && [ "${RES_UNTRUSTED:-0}" != "0" ]; then
-  echo "FINDING_LEDGER_BLOCK: $RES_UNTRUSTED FLOW_RESOLUTION_CYCLE marker(s) found but none from trusted authors ($TRUST_LIST_DISPLAY)"
+  emit_block "$RES_UNTRUSTED FLOW_RESOLUTION_CYCLE marker(s) found but none from trusted authors ($TRUST_LIST_DISPLAY)"
 fi
 if [ -z "$REVIEW_BODY" ] && [ "${REV_UNTRUSTED:-0}" != "0" ]; then
-  echo "FINDING_LEDGER_BLOCK: $REV_UNTRUSTED FLOW_REVIEW_CYCLE marker(s) found but none from trusted authors ($TRUST_LIST_DISPLAY)"
+  emit_block "$REV_UNTRUSTED FLOW_REVIEW_CYCLE marker(s) found but none from trusted authors ($TRUST_LIST_DISPLAY)"
 fi
 
 # Extract all finding IDs from FINDINGS array (comma-separated, pipe-delimited fields, first field is the ID)
@@ -217,13 +269,23 @@ RESOLVED_FINDINGS=$(echo "$RESOLUTION_BODY" | grep -o 'RESOLVED:\[[^]]*\]' | sed
 
 # Check 1: ESCALATED must be empty
 if [ -n "$ESCALATED" ]; then
-  echo "FINDING_LEDGER_BLOCK: ESCALATED array is non-empty: [$ESCALATED]"
+  emit_block "ESCALATED array is non-empty: [$ESCALATED]"
 fi
 
 # Check 2: Every finding in REVIEW_FINDINGS must have a matching RESOLVED entry
 UNRESOLVED=$(comm -23 <(echo "$REVIEW_FINDINGS") <(echo "$RESOLVED_FINDINGS") | grep -v '^$' || true)
 if [ -n "$UNRESOLVED" ]; then
-  echo "FINDING_LEDGER_BLOCK: Unresolved findings: $UNRESOLVED"
+  emit_block "Unresolved findings: $UNRESOLVED"
+fi
+
+# Emit the final gate state sentinel. The agent dispatches off this:
+#   ok      → proceed to Phase 2 Display Assessment
+#   blocked → halt, render the "BLOCKED: Unresolved Findings" template
+#             (one FINDING_LEDGER_BLOCK line per reason was emitted above)
+if [ $LEDGER_GATE_BLOCKED -eq 1 ]; then
+  echo "LEDGER_GATE_STATE=blocked"
+else
+  echo "LEDGER_GATE_STATE=ok"
 fi
 
 fi  # /if [ -z "$PR_NUM" ]

--- a/plugins/flow/commands/merge.md
+++ b/plugins/flow/commands/merge.md
@@ -54,13 +54,22 @@ else
   # Section: Reviews — one labeled line per review
   echo ""
   echo "### Reviews"
-  REVIEWS_JSON=$(gh pr view "$PR_NUM" --json reviews --jq '.reviews' 2>/dev/null)
-  REVIEW_COUNT=$(echo "$REVIEWS_JSON" | jq 'length' 2>/dev/null || echo "0")
-  echo "REVIEW_COUNT=$REVIEW_COUNT"
-  if [ "$REVIEW_COUNT" = "0" ]; then
-    echo "STATE=empty"
+  # Capture gh exit separately; gh failure must surface as STATE=unavailable
+  # rather than collapse to STATE=empty (the merge gate must close, not open,
+  # when reviews can't be read).
+  REVIEWS_JSON=$(gh pr view "$PR_NUM" --json reviews --jq '.reviews' 2>/dev/null); GH_EXIT=$?
+  if [ $GH_EXIT -ne 0 ]; then
+    echo "REVIEW_COUNT=0"
+    echo "STATE=unavailable"
   else
-    echo "$REVIEWS_JSON" | jq -r '.[] | "REVIEW=state=\(.state) author=@\(.author.login) at=\(.submittedAt)"' 2>/dev/null
+    REVIEW_COUNT=$(echo "$REVIEWS_JSON" | jq 'length' 2>/dev/null)
+    [ -z "$REVIEW_COUNT" ] && REVIEW_COUNT=0
+    echo "REVIEW_COUNT=$REVIEW_COUNT"
+    if [ "$REVIEW_COUNT" = "0" ]; then
+      echo "STATE=empty"
+    else
+      echo "$REVIEWS_JSON" | jq -r '.[] | "REVIEW=state=\(.state) author=@\(.author.login) at=\(.submittedAt)"' 2>/dev/null
+    fi
   fi
 
   # Section: Unresolved Conversations (GraphQL — reviewThreads not in REST)
@@ -84,21 +93,30 @@ else
   # Section: Finding-ledger seed (full gate runs in next ! block)
   echo ""
   echo "### Finding-Ledger Seed"
-  SEED_JSON=$(gh api "repos/$REPO/issues/$PR_NUM/comments" --jq '[.[] | select(.body | test("FLOW_RESOLUTION_CYCLE|FLOW_REVIEW_CYCLE")) | {id, body}]' 2>/dev/null)
-  SEED_COUNT=$(echo "$SEED_JSON" | jq 'length' 2>/dev/null || echo "0")
-  echo "SEED_MARKER_COUNT=$SEED_COUNT"
-  if [ "$SEED_COUNT" = "0" ]; then
-    echo "STATE=empty"
+  # Capture gh exit separately. Same reason as the Reviews section: the merge
+  # gate must close (STATE=unavailable) rather than open (STATE=empty) when
+  # markers can't be read.
+  SEED_JSON=$(gh api "repos/$REPO/issues/$PR_NUM/comments" --jq '[.[] | select(.body | test("FLOW_RESOLUTION_CYCLE|FLOW_REVIEW_CYCLE")) | {id, body}]' 2>/dev/null); GH_EXIT=$?
+  if [ $GH_EXIT -ne 0 ]; then
+    echo "SEED_MARKER_COUNT=0"
+    echo "STATE=unavailable"
   else
-    # `scan` is a generator that yields each match; wrap in `[...]` to collect
-    # all matches into an array, then take `last` (the actual marker —
-    # typically in an HTML comment at end-of-body — earlier occurrences are
-    # usually prose references). Two capture groups (kind, cycle) so each
-    # element is `[kind, cycle]`.
-    echo "$SEED_JSON" | jq -r '.[] | (
-      ([.body | scan("FLOW_(RESOLUTION|REVIEW)_CYCLE:([0-9]+)")] | last // ["?","?"]) as $last |
-      "SEED=id=\(.id) kind=\($last[0]) cycle=\($last[1])"
-    )' 2>/dev/null
+    SEED_COUNT=$(echo "$SEED_JSON" | jq 'length' 2>/dev/null)
+    [ -z "$SEED_COUNT" ] && SEED_COUNT=0
+    echo "SEED_MARKER_COUNT=$SEED_COUNT"
+    if [ "$SEED_COUNT" = "0" ]; then
+      echo "STATE=empty"
+    else
+      # `scan` is a generator that yields each match; wrap in `[...]` to collect
+      # all matches into an array, then take `last` (the actual marker —
+      # typically in an HTML comment at end-of-body — earlier occurrences are
+      # usually prose references). Two capture groups (kind, cycle) so each
+      # element is `[kind, cycle]`.
+      echo "$SEED_JSON" | jq -r '.[] | (
+        ([.body | scan("FLOW_(RESOLUTION|REVIEW)_CYCLE:([0-9]+)")] | last // ["?","?"]) as $last |
+        "SEED=id=\(.id) kind=\($last[0]) cycle=\($last[1])"
+      )' 2>/dev/null
+    fi
   fi
 fi
 

--- a/plugins/flow/commands/merge.md
+++ b/plugins/flow/commands/merge.md
@@ -1,6 +1,6 @@
 ---
 description: "Merge an approved pull request. Verifies prerequisites (approval, checks, conversations), displays assessment, and requires explicit human confirmation. Tier 3 — never autonomous."
-argument-hint: <pr-number>
+argument-hint: <pr-number> [free-form context]
 allowed-tools: Bash, Read, AskUserQuestion, Skill
 ---
 
@@ -21,35 +21,42 @@ Tier 3 operation — **always requires human confirmation**. This is non-negotia
 Pre-executed at command load (`!` prefix) — PR status, reviews, unresolved conversations, stale approval check, and finding-ledger seed all reach the agent as prompt context.
 
 ```!
-# Take the first whitespace-separated token as the PR number; the rest of
-# $ARGUMENTS is free-form context for the agent.
-PR_NUM="${ARGUMENTS%% *}"
+# Take the first whitespace-separated token; accept only if it is all digits.
+# Trailing context (e.g., "104 (verify ledger gate)") is fine — first-token
+# extraction handles it. A non-numeric token (e.g., "foo42" or "evil;rm") is
+# rejected with empty PR_NUM so it never reaches the prompt context or any
+# downstream shell. Matches the pattern in brainstorm.md / design.md.
+ARG1="${ARGUMENTS%% *}"
+case "$ARG1" in
+  ''|*[!0-9]*) PR_NUM="" ;;
+  *) PR_NUM="$ARG1" ;;
+esac
 
 if [ -z "$PR_NUM" ]; then
-  echo "ERROR: PR number required. Usage: /flow:merge <pr-number>"
+  echo "ERROR: PR number required (all-digit). Usage: /flow:merge <pr-number>"
 else
   echo "PR_NUM=$PR_NUM"
 
   # 1. PR status
-  gh pr view "$PR_NUM" --json reviewDecision,statusCheckRollup,mergeable,mergeStateStatus,title,headRefName
+  gh pr view "$PR_NUM" --json reviewDecision,statusCheckRollup,mergeable,mergeStateStatus,title,headRefName 2>/dev/null
 
   # 2. Reviews
-  gh pr view "$PR_NUM" --json reviews --jq '.reviews[] | "\(.state) by \(.author.login) at \(.submittedAt)"'
+  gh pr view "$PR_NUM" --json reviews --jq '.reviews[] | "\(.state) by \(.author.login) at \(.submittedAt)"' 2>/dev/null
 
   # 3. Unresolved conversations (reviewThreads requires GraphQL API)
-  REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+  REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
   OWNER=$(echo "$REPO" | cut -d/ -f1)
   NAME=$(echo "$REPO" | cut -d/ -f2)
-  gh api graphql -f query="query { repository(owner: \"$OWNER\", name: \"$NAME\") { pullRequest(number: $PR_NUM) { reviewThreads(first: 100) { nodes { isResolved } } } } }" --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length'
+  gh api graphql -f query="query { repository(owner: \"$OWNER\", name: \"$NAME\") { pullRequest(number: $PR_NUM) { reviewThreads(first: 100) { nodes { isResolved } } } } }" --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length' 2>/dev/null
 
   # 4. Stale approval check
   gh pr view "$PR_NUM" --json reviews,commits --jq '{
     last_approval: [.reviews[] | select(.state == "APPROVED")] | sort_by(.submittedAt) | last | .submittedAt,
     last_commit: .commits | last | .committedDate
-  }'
+  }' 2>/dev/null
 
   # 5. Finding-ledger seed (full ledger gate runs in next ! block)
-  gh api "repos/$REPO/issues/$PR_NUM/comments" --jq '.[] | select(.body | test("FLOW_RESOLUTION_CYCLE|FLOW_REVIEW_CYCLE")) | {id: .id, body: .body}'
+  gh api "repos/$REPO/issues/$PR_NUM/comments" --jq '.[] | select(.body | test("FLOW_RESOLUTION_CYCLE|FLOW_REVIEW_CYCLE")) | {id: .id, body: .body}' 2>/dev/null
 fi
 
 true
@@ -62,14 +69,19 @@ Parse the latest `FLOW_RESOLUTION_CYCLE` and `FLOW_REVIEW_CYCLE` comments to ver
 ```!
 # Extract the latest FLOW_RESOLUTION_CYCLE comment (issue/PR conversation).
 # Capture gh exit code: a silent gh failure (auth, network) must fail the gate
-# CLOSED, not pass it open.
-PR_NUM="${ARGUMENTS%% *}"
+# CLOSED, not pass it open. PR_NUM is digit-validated (matches Phase 1 block);
+# a non-digit token rejects rather than reaching downstream shell or echo.
+ARG1="${ARGUMENTS%% *}"
+case "$ARG1" in
+  ''|*[!0-9]*) PR_NUM="" ;;
+  *) PR_NUM="$ARG1" ;;
+esac
 
 if [ -z "$PR_NUM" ]; then
-  echo "FINDING_LEDGER_BLOCK: PR number required"
+  echo "FINDING_LEDGER_BLOCK: PR number required (all-digit)"
 else
 
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
 
 # MARKERTRUST_GATE_BEGIN
 # Resolve trust list from the standard Claude Code settings cascade.
@@ -101,6 +113,17 @@ for SETTINGS_PATH in "$LOCAL_SETTINGS" "$PROJECT_SETTINGS" "$USER_SETTINGS" "$PL
   fi
   [ -z "$CONFIGURED" ] && continue
   if echo "$CONFIGURED" | jq -e '. | type == "array" and length > 0 and all(.[]; type == "string")' >/dev/null 2>&1; then
+    # Warn (don't block) when an element falls outside the known GitHub
+    # `author_association` vocabulary. A typo such as `"owner"` (lowercase)
+    # or `"MAINTAINER"` (not a real value) passes the type check above but
+    # would match no real author, silently disabling trust for the typo'd
+    # entry. Use the same WARN-and-continue pattern as the HIGH_RISK check
+    # below — the gate already fails closed via the "untrusted-only"
+    # branch when nothing matches.
+    UNKNOWN_VALUES=$(echo "$CONFIGURED" | jq -r '.[] | select(. != "OWNER" and . != "MEMBER" and . != "COLLABORATOR" and . != "CONTRIBUTOR" and . != "FIRST_TIME_CONTRIBUTOR" and . != "FIRST_TIMER" and . != "MANNEQUIN" and . != "NONE")' 2>/dev/null | tr '\n' ',' | sed 's/,$//')
+    if [ -n "$UNKNOWN_VALUES" ]; then
+      echo "LEDGER_WARN: markerTrust in $SETTINGS_PATH contains values [$UNKNOWN_VALUES] not in the GitHub author_association vocabulary (OWNER, MEMBER, COLLABORATOR, CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, MANNEQUIN, NONE). These elements will match no authors — check for typos." >&2
+    fi
     TRUST_LIST="$CONFIGURED"
     TRUST_SOURCE="$SETTINGS_PATH"
     break
@@ -130,36 +153,41 @@ fi
 
 # Trust filter applied via jq's `index()` exact-match (no regex surface).
 # `--paginate` keeps fetching pages so a noisy thread can't hide forgeries.
-RESOLUTION_BODY=$(gh api --paginate "repos/$REPO/issues/$PR_NUM/comments" 2>/dev/null \
-  | jq -s -r --argjson trust "$TRUST_LIST" \
-      'add | [.[] | select((.author_association as $a | $trust | index($a)) and (.body | test("FLOW_RESOLUTION_CYCLE:")))] | last | .body // ""')
-GH_EXIT_RES=${PIPESTATUS[0]}
-RES_UNTRUSTED=$(gh api --paginate "repos/$REPO/issues/$PR_NUM/comments" 2>/dev/null \
-  | jq -s -r --argjson trust "$TRUST_LIST" \
-      'add | [.[] | select((.author_association as $a | $trust | index($a) | not) and (.body | test("FLOW_RESOLUTION_CYCLE:")))] | length')
-GH_EXIT_RES_U=${PIPESTATUS[0]}
+#
+# Fetch each endpoint once; reuse the cached JSON for both filter passes
+# (trusted + untrusted-counting). Capturing `gh`'s exit code via `$?` directly
+# after the command substitution is the only reliable way to detect a silent
+# gh failure: `VAR=$(gh ... | jq ...)` then `${PIPESTATUS[0]}` does NOT capture
+# gh's inner exit — bash resets PIPESTATUS to reflect only the outer assignment
+# (verified: `X=$(false | true); echo ${PIPESTATUS[0]}` → 0). Without the cache
+# split, a gh stderr-only failure with empty stdout would let `jq -s 'add //
+# empty'` succeed on null input and the gate would pass open.
+GH_RES_RAW=$(gh api --paginate "repos/$REPO/issues/$PR_NUM/comments" 2>/dev/null)
+GH_EXIT_RES=$?
+RESOLUTION_BODY=$(printf '%s' "$GH_RES_RAW" | jq -s -r --argjson trust "$TRUST_LIST" \
+    'add | [.[] | select((.author_association as $a | $trust | index($a)) and (.body | test("FLOW_RESOLUTION_CYCLE:")))] | last | .body // ""')
+RES_UNTRUSTED=$(printf '%s' "$GH_RES_RAW" | jq -s -r --argjson trust "$TRUST_LIST" \
+    'add | [.[] | select((.author_association as $a | $trust | index($a) | not) and (.body | test("FLOW_RESOLUTION_CYCLE:")))] | length')
 
 # Extract ESCALATED array contents (portable POSIX grep+sed; BSD grep has no -P).
 # Strip whitespace so reviewer-edited arrays like `[F1, F2]` still match.
 ESCALATED=$(echo "$RESOLUTION_BODY" | grep -o 'ESCALATED:\[[^]]*\]' | sed 's/^ESCALATED:\[//;s/\]$//' | tr -d ' ')
 
 # Extract the latest FLOW_REVIEW_CYCLE — emitted in PR review bodies, not issue comments
-REVIEW_BODY=$(gh api --paginate "repos/$REPO/pulls/$PR_NUM/reviews" 2>/dev/null \
-  | jq -s -r --argjson trust "$TRUST_LIST" \
-      'add | [.[] | select((.author_association as $a | $trust | index($a)) and (.body | test("FLOW_REVIEW_CYCLE:")))] | last | .body // ""')
-GH_EXIT_REV=${PIPESTATUS[0]}
-REV_UNTRUSTED=$(gh api --paginate "repos/$REPO/pulls/$PR_NUM/reviews" 2>/dev/null \
-  | jq -s -r --argjson trust "$TRUST_LIST" \
-      'add | [.[] | select((.author_association as $a | $trust | index($a) | not) and (.body | test("FLOW_REVIEW_CYCLE:")))] | length')
-GH_EXIT_REV_U=${PIPESTATUS[0]}
+GH_REV_RAW=$(gh api --paginate "repos/$REPO/pulls/$PR_NUM/reviews" 2>/dev/null)
+GH_EXIT_REV=$?
+REVIEW_BODY=$(printf '%s' "$GH_REV_RAW" | jq -s -r --argjson trust "$TRUST_LIST" \
+    'add | [.[] | select((.author_association as $a | $trust | index($a)) and (.body | test("FLOW_REVIEW_CYCLE:")))] | last | .body // ""')
+REV_UNTRUSTED=$(printf '%s' "$GH_REV_RAW" | jq -s -r --argjson trust "$TRUST_LIST" \
+    'add | [.[] | select((.author_association as $a | $trust | index($a) | not) and (.body | test("FLOW_REVIEW_CYCLE:")))] | length')
 
-# Fail closed if any of the four gh calls failed — better to block a legitimate
-# merge than silently let a regression through when the gate state is unknowable.
-# Includes the untrusted-counting calls (RES_UNTRUSTED, REV_UNTRUSTED) — without
-# their exit codes a network blip during the secondary call would silently
-# treat as "no untrusted markers" rather than failing closed.
-if [ $GH_EXIT_RES -ne 0 ] || [ $GH_EXIT_REV -ne 0 ] || [ $GH_EXIT_RES_U -ne 0 ] || [ $GH_EXIT_REV_U -ne 0 ]; then
-  echo "FINDING_LEDGER_BLOCK: gh API unavailable — cannot verify finding ledger (resolution exit=$GH_EXIT_RES, review exit=$GH_EXIT_REV, res-untrusted exit=$GH_EXIT_RES_U, rev-untrusted exit=$GH_EXIT_REV_U)"
+# Fail closed if either gh call failed — better to block a legitimate merge
+# than silently let a regression through when the gate state is unknowable.
+# Both `_UNTRUSTED` counting calls share the same gh exit code as their primary
+# (they re-filter the cached JSON), so a single per-endpoint exit check covers
+# all four filter passes.
+if [ $GH_EXIT_RES -ne 0 ] || [ $GH_EXIT_REV -ne 0 ]; then
+  echo "FINDING_LEDGER_BLOCK: gh API unavailable — cannot verify finding ledger (resolution exit=$GH_EXIT_RES, review exit=$GH_EXIT_REV)"
 fi
 
 # Surface "untrusted-only" markers as a block reason rather than silently
@@ -168,7 +196,14 @@ fi
 # message — the `$TRUST_REGEX` variable used to appear here was a leftover
 # from PR #93 and never assigned, producing the empty-parens string
 # "trusted authors ()" in messages or aborting under `set -u`.
-TRUST_LIST_DISPLAY=$(echo "$TRUST_LIST" | jq -r 'join(",")' 2>/dev/null || echo "OWNER,MEMBER,COLLABORATOR")
+#
+# Derive the fallback from $TRUST_DEFAULT rather than hard-coding the value:
+# if $TRUST_DEFAULT changes (e.g., adding CONTRIBUTOR), the display string
+# stays in lockstep instead of silently lying.
+TRUST_LIST_DISPLAY=$(echo "$TRUST_LIST" | jq -r 'join(",")' 2>/dev/null)
+if [ -z "$TRUST_LIST_DISPLAY" ]; then
+  TRUST_LIST_DISPLAY=$(echo "$TRUST_DEFAULT" | jq -r 'join(",")' 2>/dev/null)
+fi
 if [ -z "$RESOLUTION_BODY" ] && [ "${RES_UNTRUSTED:-0}" != "0" ]; then
   echo "FINDING_LEDGER_BLOCK: $RES_UNTRUSTED FLOW_RESOLUTION_CYCLE marker(s) found but none from trusted authors ($TRUST_LIST_DISPLAY)"
 fi

--- a/plugins/flow/commands/pr.md
+++ b/plugins/flow/commands/pr.md
@@ -29,29 +29,68 @@ Full PR creation workflow with multi-faceted review, quality gates, and structur
 ## Phase 1: EXPLORE
 
 ```!
-# 1. Pre-flight checks
-BRANCH=$(git branch --show-current)
+# Output: `###`-headed sections + KEY=value per
+# `references/command-output-format.md`. STATE=blocked when on default branch
+# (can't create a PR from main); STATE=ok otherwise.
+
+echo "### Branch Context"
+BRANCH=$(git branch --show-current 2>/dev/null)
 DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
-echo "BRANCH=$BRANCH DEFAULT=$DEFAULT_BRANCH"
+echo "BRANCH=$BRANCH"
+echo "DEFAULT_BRANCH=$DEFAULT_BRANCH"
 
 if [ "$BRANCH" = "$DEFAULT_BRANCH" ]; then
-  echo "ERROR: Cannot create PR from default branch"
+  echo "STATE=blocked"
+  echo "ERROR=Cannot create PR from default branch"
 else
-  # 2. Commits and changes
-  git rev-list --count "$DEFAULT_BRANCH"..HEAD
-  git status --porcelain
-  git diff --stat "$DEFAULT_BRANCH"...HEAD
+  echo "STATE=ok"
 
-  # 3. Issue context
+  # Section: Branch Delta vs Default
+  echo ""
+  echo "### Branch Delta"
+  echo "COMMITS_AHEAD=$(git rev-list --count "$DEFAULT_BRANCH"..HEAD 2>/dev/null || echo "0")"
+  echo "UNCOMMITTED_COUNT=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')"
+  [ "$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')" != "0" ] && git status --short 2>/dev/null | head -20 | sed 's/^/UNCOMMITTED_LINE=/'
+  echo ""
+  echo "#### Diff stat"
+  git diff --stat "$DEFAULT_BRANCH"...HEAD 2>/dev/null
+
+  # Section: Issue Context (extracted from branch name `feature/issue-N-...`)
+  echo ""
+  echo "### Issue Context"
   ISSUE_NUM=$(echo "$BRANCH" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
-  [ -n "$ISSUE_NUM" ] && gh issue view "$ISSUE_NUM" --json title,body,labels 2>/dev/null
+  echo "ISSUE_NUM=${ISSUE_NUM:-(none)}"
+  if [ -n "$ISSUE_NUM" ]; then
+    gh issue view "$ISSUE_NUM" --json title,body,labels --jq '
+      "ISSUE_TITLE=\"\(.title)\"\nISSUE_LABELS=\([.labels[].name] | join(","))\nISSUE_BODY_LENGTH=\(.body | length)"
+    ' 2>/dev/null
+  fi
 
-  # 4. Existing PR check
-  gh pr list --head "$BRANCH" --state open --json number,url 2>/dev/null
+  # Section: Existing PR Check
+  echo ""
+  echo "### Existing PR Check"
+  EXISTING=$(gh pr list --head "$BRANCH" --state open --json number,url 2>/dev/null)
+  EXISTING_COUNT=$(echo "$EXISTING" | jq 'length' 2>/dev/null || echo "0")
+  echo "EXISTING_PR_COUNT=$EXISTING_COUNT"
+  if [ "$EXISTING_COUNT" = "0" ]; then
+    echo "STATE=empty"
+  else
+    echo "$EXISTING" | jq -r '.[] | "EXISTING_PR=number=\(.number) url=\(.url)"' 2>/dev/null
+  fi
 
-  # 5. Decision journal
+  # Section: Decision Journal
+  echo ""
+  echo "### Decision Journal"
   JOURNAL_DIR=".decisions"
-  [ -n "$ISSUE_NUM" ] && [ -f "$JOURNAL_DIR/issue-$ISSUE_NUM.md" ] && cat "$JOURNAL_DIR/issue-$ISSUE_NUM.md"
+  if [ -n "$ISSUE_NUM" ] && [ -f "$JOURNAL_DIR/issue-$ISSUE_NUM.md" ]; then
+    echo "JOURNAL_FILE=$JOURNAL_DIR/issue-$ISSUE_NUM.md"
+    echo "JOURNAL_BYTES=$(wc -c < "$JOURNAL_DIR/issue-$ISSUE_NUM.md" | tr -d ' ')"
+    echo ""
+    echo "#### Journal contents"
+    cat "$JOURNAL_DIR/issue-$ISSUE_NUM.md"
+  else
+    echo "STATE=empty"
+  fi
 fi
 
 true

--- a/plugins/flow/commands/pr.md
+++ b/plugins/flow/commands/pr.md
@@ -28,9 +28,9 @@ Full PR creation workflow with multi-faceted review, quality gates, and structur
 
 ## Phase 1: EXPLORE
 
-**Parallel operations:**
+Pre-executed at command load (`!` prefix) — pre-flight, branch context, commits/diff, issue context, existing-PR check, and journal entry all reach the agent as prompt context.
 
-```bash
+```!
 # 1. Pre-flight checks
 BRANCH=$(git branch --show-current)
 DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
@@ -43,8 +43,8 @@ git status --porcelain
 git diff --stat "$DEFAULT_BRANCH"...HEAD
 
 # 3. Issue context
-ISSUE_NUM=$(echo $BRANCH | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
-[ -n "$ISSUE_NUM" ] && gh issue view $ISSUE_NUM --json title,body,labels
+ISSUE_NUM=$(echo "$BRANCH" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
+[ -n "$ISSUE_NUM" ] && gh issue view "$ISSUE_NUM" --json title,body,labels
 
 # 4. Existing PR check
 gh pr list --head "$BRANCH" --state open --json number,url
@@ -52,6 +52,8 @@ gh pr list --head "$BRANCH" --state open --json number,url
 # 5. Decision journal
 JOURNAL_DIR=".decisions"
 [ -n "$ISSUE_NUM" ] && [ -f "$JOURNAL_DIR/issue-$ISSUE_NUM.md" ] && cat "$JOURNAL_DIR/issue-$ISSUE_NUM.md"
+
+true
 ```
 
 **Skill invocation:** `Skill(capability-discovery)` — detect quality commands.

--- a/plugins/flow/commands/pr.md
+++ b/plugins/flow/commands/pr.md
@@ -49,17 +49,27 @@ else
   echo ""
   echo "### Branch Delta"
   echo "COMMITS_AHEAD=$(git rev-list --count "$DEFAULT_BRANCH"..HEAD 2>/dev/null || echo "0")"
-  echo "UNCOMMITTED_COUNT=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')"
-  [ "$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')" != "0" ] && git status --short 2>/dev/null | head -20 | sed 's/^/UNCOMMITTED_LINE=/'
+  # Cache the porcelain count once — previously invoked twice in adjacent
+  # lines (count + gate on the UNCOMMITTED_LINE listing).
+  UNCOMMITTED_COUNT=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+  echo "UNCOMMITTED_COUNT=$UNCOMMITTED_COUNT"
+  [ "$UNCOMMITTED_COUNT" != "0" ] && git status --short 2>/dev/null | head -20 | sed 's/^/UNCOMMITTED_LINE=/'
   echo ""
   echo "#### Diff stat"
-  git diff --stat "$DEFAULT_BRANCH"...HEAD 2>/dev/null
+  DIFF_STAT=$(git diff --stat "$DEFAULT_BRANCH"...HEAD 2>/dev/null)
+  if [ -z "$DIFF_STAT" ]; then
+    echo "STATE=empty"
+  else
+    printf '%s\n' "$DIFF_STAT" | sed 's/^/DIFF_STAT=/'
+  fi
 
   # Section: Issue Context (extracted from branch name `feature/issue-N-...`)
   echo ""
   echo "### Issue Context"
   ISSUE_NUM=$(echo "$BRANCH" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
-  echo "ISSUE_NUM=${ISSUE_NUM:-(none)}"
+  # Quote parenthesized fallback per command-output-format.md rule 2 (values
+  # with whitespace/parens must be double-quoted scalars).
+  echo "ISSUE_NUM=${ISSUE_NUM:-\"(none)\"}"
   if [ -n "$ISSUE_NUM" ]; then
     gh issue view "$ISSUE_NUM" --json title,body,labels --jq '
       "ISSUE_TITLE=\"\(.title)\"\nISSUE_LABELS=\([.labels[].name] | join(","))\nISSUE_BODY_LENGTH=\(.body | length)"

--- a/plugins/flow/commands/pr.md
+++ b/plugins/flow/commands/pr.md
@@ -49,7 +49,7 @@ else
   [ -n "$ISSUE_NUM" ] && gh issue view "$ISSUE_NUM" --json title,body,labels 2>/dev/null
 
   # 4. Existing PR check
-  gh pr list --head "$BRANCH" --state open --json number,url
+  gh pr list --head "$BRANCH" --state open --json number,url 2>/dev/null
 
   # 5. Decision journal
   JOURNAL_DIR=".decisions"

--- a/plugins/flow/commands/pr.md
+++ b/plugins/flow/commands/pr.md
@@ -34,24 +34,27 @@ Pre-executed at command load (`!` prefix) — pre-flight, branch context, commit
 # 1. Pre-flight checks
 BRANCH=$(git branch --show-current)
 DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
-[ "$BRANCH" = "$DEFAULT_BRANCH" ] && echo "ERROR: Cannot create PR from default branch" && exit 1
 echo "BRANCH=$BRANCH DEFAULT=$DEFAULT_BRANCH"
 
-# 2. Commits and changes
-git rev-list --count "$DEFAULT_BRANCH"..HEAD
-git status --porcelain
-git diff --stat "$DEFAULT_BRANCH"...HEAD
+if [ "$BRANCH" = "$DEFAULT_BRANCH" ]; then
+  echo "ERROR: Cannot create PR from default branch"
+else
+  # 2. Commits and changes
+  git rev-list --count "$DEFAULT_BRANCH"..HEAD
+  git status --porcelain
+  git diff --stat "$DEFAULT_BRANCH"...HEAD
 
-# 3. Issue context
-ISSUE_NUM=$(echo "$BRANCH" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
-[ -n "$ISSUE_NUM" ] && gh issue view "$ISSUE_NUM" --json title,body,labels
+  # 3. Issue context
+  ISSUE_NUM=$(echo "$BRANCH" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
+  [ -n "$ISSUE_NUM" ] && gh issue view "$ISSUE_NUM" --json title,body,labels 2>/dev/null
 
-# 4. Existing PR check
-gh pr list --head "$BRANCH" --state open --json number,url
+  # 4. Existing PR check
+  gh pr list --head "$BRANCH" --state open --json number,url
 
-# 5. Decision journal
-JOURNAL_DIR=".decisions"
-[ -n "$ISSUE_NUM" ] && [ -f "$JOURNAL_DIR/issue-$ISSUE_NUM.md" ] && cat "$JOURNAL_DIR/issue-$ISSUE_NUM.md"
+  # 5. Decision journal
+  JOURNAL_DIR=".decisions"
+  [ -n "$ISSUE_NUM" ] && [ -f "$JOURNAL_DIR/issue-$ISSUE_NUM.md" ] && cat "$JOURNAL_DIR/issue-$ISSUE_NUM.md"
+fi
 
 true
 ```

--- a/plugins/flow/commands/pr.md
+++ b/plugins/flow/commands/pr.md
@@ -69,13 +69,24 @@ else
   # Section: Existing PR Check
   echo ""
   echo "### Existing PR Check"
-  EXISTING=$(gh pr list --head "$BRANCH" --state open --json number,url 2>/dev/null)
-  EXISTING_COUNT=$(echo "$EXISTING" | jq 'length' 2>/dev/null || echo "0")
-  echo "EXISTING_PR_COUNT=$EXISTING_COUNT"
-  if [ "$EXISTING_COUNT" = "0" ]; then
-    echo "STATE=empty"
+  # Capture gh exit separately. The `|| echo "0"` fallback fails to fire when
+  # gh succeeds but returns "" (impossible here — gh returns [] for empty
+  # success) OR when jq receives empty input from a failed gh call (jq 1.8
+  # produces no output + exit 0, so `||` doesn't trigger and the section
+  # silently leaks `EXISTING_PR_COUNT=`).
+  EXISTING=$(gh pr list --head "$BRANCH" --state open --json number,url 2>/dev/null); GH_EXIT=$?
+  if [ $GH_EXIT -ne 0 ]; then
+    echo "EXISTING_PR_COUNT=0"
+    echo "STATE=unavailable"
   else
-    echo "$EXISTING" | jq -r '.[] | "EXISTING_PR=number=\(.number) url=\(.url)"' 2>/dev/null
+    EXISTING_COUNT=$(echo "$EXISTING" | jq 'length' 2>/dev/null)
+    [ -z "$EXISTING_COUNT" ] && EXISTING_COUNT=0
+    echo "EXISTING_PR_COUNT=$EXISTING_COUNT"
+    if [ "$EXISTING_COUNT" = "0" ]; then
+      echo "STATE=empty"
+    else
+      echo "$EXISTING" | jq -r '.[] | "EXISTING_PR=number=\(.number) url=\(.url)"' 2>/dev/null
+    fi
   fi
 
   # Section: Decision Journal

--- a/plugins/flow/commands/pr.md
+++ b/plugins/flow/commands/pr.md
@@ -28,8 +28,6 @@ Full PR creation workflow with multi-faceted review, quality gates, and structur
 
 ## Phase 1: EXPLORE
 
-Pre-executed at command load (`!` prefix) — pre-flight, branch context, commits/diff, issue context, existing-PR check, and journal entry all reach the agent as prompt context.
-
 ```!
 # 1. Pre-flight checks
 BRANCH=$(git branch --show-current)

--- a/plugins/flow/commands/release.md
+++ b/plugins/flow/commands/release.md
@@ -14,7 +14,7 @@ Tier 3 operation — **always requires human confirmation**.
 
 ## Phase 1: Gather Context
 
-Pre-executed at command load (`!` prefix) — current tag, merged PRs, and recent commits all reach the agent as prompt context. Phase 2 version calculation and Phase 4 publish steps stay inline (they depend on $ARGUMENTS classification and user confirmation).
+Phase 2 version calculation and Phase 4 publish steps stay inline (they depend on $ARGUMENTS classification and user confirmation).
 
 ```!
 # 1. Current version (latest tag)

--- a/plugins/flow/commands/release.md
+++ b/plugins/flow/commands/release.md
@@ -14,9 +14,9 @@ Tier 3 operation — **always requires human confirmation**.
 
 ## Phase 1: Gather Context
 
-**Parallel operations:**
+Pre-executed at command load (`!` prefix) — current tag, merged PRs, and recent commits all reach the agent as prompt context. Phase 2 version calculation and Phase 4 publish steps stay inline (they depend on $ARGUMENTS classification and user confirmation).
 
-```bash
+```!
 # 1. Current version (latest tag)
 LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "none")
 echo "Current version: $LAST_TAG"
@@ -38,6 +38,8 @@ if [ "$LAST_TAG" != "none" ]; then
 else
   git log --oneline -20
 fi
+
+true
 ```
 
 ## Phase 2: Calculate Version

--- a/plugins/flow/commands/release.md
+++ b/plugins/flow/commands/release.md
@@ -17,26 +17,38 @@ Tier 3 operation — **always requires human confirmation**.
 Phase 2 version calculation and Phase 4 publish steps stay inline (they depend on $ARGUMENTS classification and user confirmation).
 
 ```!
-# 1. Current version (latest tag)
+# Output: `###`-headed sections + KEY=value per
+# `references/command-output-format.md`.
+
+echo "### Current Version"
 LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "none")
-echo "Current version: $LAST_TAG"
+echo "LAST_TAG=$LAST_TAG"
+echo "TAG_PREFIX=v"   # default; settings.release.tagPrefix may override at Phase 2
 
-# 2. Release tag prefix from settings
-TAG_PREFIX="v"  # default, read from settings.release.tagPrefix
-
-# 3. Merged PRs since last release
+echo ""
+echo "### Merged PRs Since Last Release"
 if [ "$LAST_TAG" != "none" ]; then
-  SINCE=$(git log -1 --format=%aI "$LAST_TAG")
-  gh pr list --state merged --search "merged:>=$SINCE" --json number,title,labels --limit 50
+  SINCE=$(git log -1 --format=%aI "$LAST_TAG" 2>/dev/null)
+  MERGED_JSON=$(gh pr list --state merged --search "merged:>=$SINCE" --json number,title,labels --limit 50 2>/dev/null)
+  echo "SINCE=$SINCE"
 else
-  gh pr list --state merged --json number,title,labels --limit 20
+  MERGED_JSON=$(gh pr list --state merged --json number,title,labels --limit 20 2>/dev/null)
+  echo "SINCE=(first release — using 20 most recent merged PRs)"
+fi
+MERGED_COUNT=$(echo "$MERGED_JSON" | jq 'length' 2>/dev/null || echo "0")
+echo "MERGED_PR_COUNT=$MERGED_COUNT"
+if [ "$MERGED_COUNT" = "0" ]; then
+  echo "STATE=empty"
+else
+  echo "$MERGED_JSON" | jq -r '.[] | "MERGED_PR=number=\(.number) labels=\"\([.labels[].name] | join(","))\" title=\"\(.title)\""' 2>/dev/null
 fi
 
-# 4. Commits since last release
+echo ""
+echo "### Commits Since Last Release"
 if [ "$LAST_TAG" != "none" ]; then
-  git log --oneline "$LAST_TAG"..HEAD
+  git log --oneline "$LAST_TAG"..HEAD 2>/dev/null | sed 's/^/COMMIT=/'
 else
-  git log --oneline -20
+  git log --oneline -20 2>/dev/null | sed 's/^/COMMIT=/'
 fi
 
 true

--- a/plugins/flow/commands/release.md
+++ b/plugins/flow/commands/release.md
@@ -29,18 +29,26 @@ echo ""
 echo "### Merged PRs Since Last Release"
 if [ "$LAST_TAG" != "none" ]; then
   SINCE=$(git log -1 --format=%aI "$LAST_TAG" 2>/dev/null)
-  MERGED_JSON=$(gh pr list --state merged --search "merged:>=$SINCE" --json number,title,labels --limit 50 2>/dev/null)
+  MERGED_JSON=$(gh pr list --state merged --search "merged:>=$SINCE" --json number,title,labels --limit 50 2>/dev/null); GH_EXIT=$?
   echo "SINCE=$SINCE"
 else
-  MERGED_JSON=$(gh pr list --state merged --json number,title,labels --limit 20 2>/dev/null)
-  echo "SINCE=(first release — using 20 most recent merged PRs)"
+  MERGED_JSON=$(gh pr list --state merged --json number,title,labels --limit 20 2>/dev/null); GH_EXIT=$?
+  # Quote: value contains parens, whitespace, em-dash (rule 2 of
+  # references/command-output-format.md).
+  echo "SINCE=\"(first release — using 20 most recent merged PRs)\""
 fi
-MERGED_COUNT=$(echo "$MERGED_JSON" | jq 'length' 2>/dev/null || echo "0")
-echo "MERGED_PR_COUNT=$MERGED_COUNT"
-if [ "$MERGED_COUNT" = "0" ]; then
-  echo "STATE=empty"
+if [ $GH_EXIT -ne 0 ]; then
+  echo "MERGED_PR_COUNT=0"
+  echo "STATE=unavailable"
 else
-  echo "$MERGED_JSON" | jq -r '.[] | "MERGED_PR=number=\(.number) labels=\"\([.labels[].name] | join(","))\" title=\"\(.title)\""' 2>/dev/null
+  MERGED_COUNT=$(echo "$MERGED_JSON" | jq 'length' 2>/dev/null)
+  [ -z "$MERGED_COUNT" ] && MERGED_COUNT=0
+  echo "MERGED_PR_COUNT=$MERGED_COUNT"
+  if [ "$MERGED_COUNT" = "0" ]; then
+    echo "STATE=empty"
+  else
+    echo "$MERGED_JSON" | jq -r '.[] | "MERGED_PR=number=\(.number) labels=\"\([.labels[].name] | join(","))\" title=\"\(.title)\""' 2>/dev/null
+  fi
 fi
 
 echo ""

--- a/plugins/flow/commands/release.md
+++ b/plugins/flow/commands/release.md
@@ -53,10 +53,17 @@ fi
 
 echo ""
 echo "### Commits Since Last Release"
+# Capture so an empty range (right after a release) emits STATE=empty
+# rather than a silent heading.
 if [ "$LAST_TAG" != "none" ]; then
-  git log --oneline "$LAST_TAG"..HEAD 2>/dev/null | sed 's/^/COMMIT=/'
+  COMMITS_RANGE=$(git log --oneline "$LAST_TAG"..HEAD 2>/dev/null)
 else
-  git log --oneline -20 2>/dev/null | sed 's/^/COMMIT=/'
+  COMMITS_RANGE=$(git log --oneline -20 2>/dev/null)
+fi
+if [ -z "$COMMITS_RANGE" ]; then
+  echo "STATE=empty"
+else
+  printf '%s\n' "$COMMITS_RANGE" | sed 's/^/COMMIT=/'
 fi
 
 true

--- a/plugins/flow/commands/resolve.md
+++ b/plugins/flow/commands/resolve.md
@@ -34,13 +34,17 @@ Determine invocation mode from `$ARGUMENTS`:
 
 ### Validation
 
-```bash
+Pre-executed at command load (`!` prefix) — conflict state reaches the agent as prompt context.
+
+```!
 # Check for active merge/rebase state
 if [ -f .git/MERGE_HEAD ] || [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]; then
   echo "ACTIVE_CONFLICT"
 else
   echo "NO_ACTIVE_CONFLICT"
 fi
+
+true
 ```
 
 - If mode is PR: verify `gh auth status` succeeds
@@ -62,19 +66,23 @@ If `mergeable == "MERGEABLE"` (no conflicts), report "No conflicts found" and ex
 
 Run these in parallel:
 
-**1a. List conflicted files and classify types:**
+**1a. List conflicted files and classify types** (pre-executed via `!`):
 
-```bash
+```!
 git diff --name-only --diff-filter=U
-git status --porcelain | grep "^[UAD][UAD] "
+git status --porcelain | grep "^[UAD][UAD] " || true
+
+true
 ```
 
-**1b. Count conflict hunks per file:**
+**1b. Count conflict hunks per file** (pre-executed via `!`):
 
-```bash
+```!
 git diff --name-only --diff-filter=U | while IFS= read -r f; do
-  echo "$f: $(grep -c '<<<<<<<' "$f") hunks"
+  [ -f "$f" ] && echo "$f: $(grep -c '<<<<<<<' "$f" || echo 0) hunks" || true
 done
+
+true
 ```
 
 **1c. Discover build/test commands** via capability-discovery skill.

--- a/plugins/flow/commands/resolve.md
+++ b/plugins/flow/commands/resolve.md
@@ -89,7 +89,13 @@ Run these in parallel:
 
 echo "### Conflicted Files"
 CONFLICTED=$(git diff --name-only --diff-filter=U 2>/dev/null)
-CONFLICTED_COUNT=$(printf '%s\n' "$CONFLICTED" | grep -c '.' || echo "0")
+# Note: `grep -c '.' || echo 0` produces a multi-line `0\n0` on empty input
+# (grep exits 1, the `||` ALSO fires) — use explicit empty-check instead.
+if [ -z "$CONFLICTED" ]; then
+  CONFLICTED_COUNT=0
+else
+  CONFLICTED_COUNT=$(printf '%s\n' "$CONFLICTED" | wc -l | tr -d ' ')
+fi
 echo "CONFLICTED_COUNT=$CONFLICTED_COUNT"
 if [ "$CONFLICTED_COUNT" = "0" ]; then
   echo "STATE=empty"
@@ -99,7 +105,14 @@ fi
 
 echo ""
 echo "#### Status filter (UU/UD/AU types)"
-git status --porcelain 2>/dev/null | grep "^[UAD][UAD] " | sed 's/^/STATUS=/' || true
+# Capture into a var so an empty match emits an explicit STATE=empty sentinel
+# rather than a silent heading.
+STATUS_LINES=$(git status --porcelain 2>/dev/null | grep "^[UAD][UAD] " || true)
+if [ -z "$STATUS_LINES" ]; then
+  echo "STATE=empty"
+else
+  printf '%s\n' "$STATUS_LINES" | sed 's/^/STATUS=/'
+fi
 
 true
 ```
@@ -111,15 +124,25 @@ true
 # `references/command-output-format.md`.
 
 echo "### Hunks Per Conflicted File"
-ANY=0
-git diff --name-only --diff-filter=U 2>/dev/null | while IFS= read -r f; do
-  if [ -f "$f" ]; then
-    HUNKS=$(grep -c '<<<<<<<' "$f" 2>/dev/null || echo 0)
-    echo "HUNKS=file=$f count=$HUNKS"
-    ANY=1
-  fi
-done
-[ "$ANY" = "0" ] && echo "STATE=empty"
+# Capture into a var so the loop runs in the parent shell (no subshell pipe).
+# Previous form `git diff … | while … done; [ "$ANY" = "0" ] && …` ran the
+# loop in a subshell so `ANY=1` never propagated and `STATE=empty` ALWAYS
+# fired even when HUNKS records were just emitted (contradictory output).
+CONFLICTED_LIST=$(git diff --name-only --diff-filter=U 2>/dev/null)
+ANY_EXISTING=0
+if [ -n "$CONFLICTED_LIST" ]; then
+  while IFS= read -r f; do
+    if [ -f "$f" ]; then
+      # `grep -c` always prints a number; the `|| echo 0` form would ALSO
+      # fire on grep's exit 1 (no matches) and produce a multi-line `0\n0`.
+      HUNKS=$(grep -c '<<<<<<<' "$f" 2>/dev/null || true)
+      [ -z "$HUNKS" ] && HUNKS=0
+      echo "HUNKS=file=$f count=$HUNKS"
+      ANY_EXISTING=1
+    fi
+  done <<< "$CONFLICTED_LIST"
+fi
+[ "$ANY_EXISTING" = "0" ] && echo "STATE=empty"
 
 true
 ```

--- a/plugins/flow/commands/resolve.md
+++ b/plugins/flow/commands/resolve.md
@@ -51,7 +51,8 @@ case "$ARG1" in
 esac
 
 echo "### Resolve Mode"
-echo "RESOLVE_TARGET=${RESOLVE_TARGET:-(none — in-progress merge mode)}"
+# Quote parenthesized fallback per command-output-format.md rule 2.
+echo "RESOLVE_TARGET=${RESOLVE_TARGET:-\"(none — in-progress merge mode)\"}"
 if [ -f .git/MERGE_HEAD ] || [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]; then
   echo "CONFLICT_STATE=active"
 else

--- a/plugins/flow/commands/resolve.md
+++ b/plugins/flow/commands/resolve.md
@@ -41,18 +41,21 @@ Determine invocation mode from `$ARGUMENTS`:
 # (`;`, `|`, `$`, spaces, etc.) is rejected with empty RESOLVE_TARGET so the
 # trailing context can't reach downstream shell. Trailing prose after the
 # first whitespace is fine.
+#
+# Output: `###`-headed sections + KEY=value per
+# `references/command-output-format.md`.
 ARG1="${ARGUMENTS%% *}"
 case "$ARG1" in
   ''|*[!a-zA-Z0-9._/-]*) RESOLVE_TARGET="" ;;
   *) RESOLVE_TARGET="$ARG1" ;;
 esac
-echo "RESOLVE_TARGET=$RESOLVE_TARGET"
 
-# Check for active merge/rebase state
+echo "### Resolve Mode"
+echo "RESOLVE_TARGET=${RESOLVE_TARGET:-(none — in-progress merge mode)}"
 if [ -f .git/MERGE_HEAD ] || [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]; then
-  echo "ACTIVE_CONFLICT"
+  echo "CONFLICT_STATE=active"
 else
-  echo "NO_ACTIVE_CONFLICT"
+  echo "CONFLICT_STATE=inactive"
 fi
 
 true
@@ -81,8 +84,22 @@ Run these in parallel:
 **1a. List conflicted files and classify types** (pre-executed via `!`):
 
 ```!
-git diff --name-only --diff-filter=U
-git status --porcelain | grep "^[UAD][UAD] " || true
+# Output: `###`-headed section + labeled records per
+# `references/command-output-format.md`.
+
+echo "### Conflicted Files"
+CONFLICTED=$(git diff --name-only --diff-filter=U 2>/dev/null)
+CONFLICTED_COUNT=$(printf '%s\n' "$CONFLICTED" | grep -c '.' || echo "0")
+echo "CONFLICTED_COUNT=$CONFLICTED_COUNT"
+if [ "$CONFLICTED_COUNT" = "0" ]; then
+  echo "STATE=empty"
+else
+  printf '%s\n' "$CONFLICTED" | sed 's/^/CONFLICTED_FILE=/'
+fi
+
+echo ""
+echo "#### Status filter (UU/UD/AU types)"
+git status --porcelain 2>/dev/null | grep "^[UAD][UAD] " | sed 's/^/STATUS=/' || true
 
 true
 ```
@@ -90,9 +107,19 @@ true
 **1b. Count conflict hunks per file** (pre-executed via `!`):
 
 ```!
-git diff --name-only --diff-filter=U | while IFS= read -r f; do
-  [ -f "$f" ] && echo "$f: $(grep -c '<<<<<<<' "$f" || echo 0) hunks" || true
+# Output: `###`-headed section + one record per file per
+# `references/command-output-format.md`.
+
+echo "### Hunks Per Conflicted File"
+ANY=0
+git diff --name-only --diff-filter=U 2>/dev/null | while IFS= read -r f; do
+  if [ -f "$f" ]; then
+    HUNKS=$(grep -c '<<<<<<<' "$f" 2>/dev/null || echo 0)
+    echo "HUNKS=file=$f count=$HUNKS"
+    ANY=1
+  fi
 done
+[ "$ANY" = "0" ] && echo "STATE=empty"
 
 true
 ```

--- a/plugins/flow/commands/resolve.md
+++ b/plugins/flow/commands/resolve.md
@@ -1,6 +1,6 @@
 ---
 description: "Resolve merge conflicts on the current branch or for a pull request. Detects conflict types, analyzes both sides, applies per-file resolution strategies, and verifies the result compiles and passes tests."
-argument-hint: [pr-number-or-branch]
+argument-hint: [pr-number-or-branch] [free-form context]
 allowed-tools: Bash, Read, Write, Edit, Agent, Skill, AskUserQuestion, TaskCreate, TaskList, TaskUpdate, TaskGet, Grep, Glob
 ---
 
@@ -37,6 +37,19 @@ Determine invocation mode from `$ARGUMENTS`:
 Pre-executed at command load (`!` prefix) — conflict state reaches the agent as prompt context.
 
 ```!
+# Take the first whitespace-separated token; accept only if it matches the
+# safe set [a-zA-Z0-9._/-] (covers digit-only PR numbers AND typical branch
+# names like `feature/foo-bar.v2`). A token containing shell metacharacters
+# (`;`, `|`, `$`, spaces, etc.) is rejected with empty RESOLVE_TARGET so the
+# trailing context can't reach downstream shell. Trailing prose after the
+# first whitespace is fine.
+ARG1="${ARGUMENTS%% *}"
+case "$ARG1" in
+  ''|*[!a-zA-Z0-9._/-]*) RESOLVE_TARGET="" ;;
+  *) RESOLVE_TARGET="$ARG1" ;;
+esac
+echo "RESOLVE_TARGET=$RESOLVE_TARGET"
+
 # Check for active merge/rebase state
 if [ -f .git/MERGE_HEAD ] || [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]; then
   echo "ACTIVE_CONFLICT"
@@ -53,8 +66,9 @@ true
 ### PR Mode Setup
 
 ```bash
-# Fetch PR details and attempt merge
-gh pr view $ARGUMENTS --json headRefName,baseRefName,mergeable,title
+# Fetch PR details and attempt merge. Uses $RESOLVE_TARGET extracted by the
+# Phase 0 `!` block above (digit-or-safe-branch-name; trailing context stripped).
+gh pr view "$RESOLVE_TARGET" --json headRefName,baseRefName,mergeable,title
 git fetch origin
 git checkout <headRefName>
 git merge origin/<baseRefName> --no-commit --no-ff

--- a/plugins/flow/commands/resolve.md
+++ b/plugins/flow/commands/resolve.md
@@ -34,8 +34,6 @@ Determine invocation mode from `$ARGUMENTS`:
 
 ### Validation
 
-Pre-executed at command load (`!` prefix) — conflict state reaches the agent as prompt context.
-
 ```!
 # Take the first whitespace-separated token; accept only if it matches the
 # safe set [a-zA-Z0-9._/-] (covers digit-only PR numbers AND typical branch

--- a/plugins/flow/commands/review.md
+++ b/plugins/flow/commands/review.md
@@ -70,7 +70,13 @@ else
   echo ""
   echo "### Diff Files"
   DIFF_FILES=$(gh pr diff "$PR_NUM" --name-only 2>/dev/null)
-  DIFF_FILE_COUNT=$(printf '%s\n' "$DIFF_FILES" | grep -c '.' || echo "0")
+  # `grep -c '.' || echo 0` produces multi-line `0\n0` on empty input — use
+  # explicit empty-check.
+  if [ -z "$DIFF_FILES" ]; then
+    DIFF_FILE_COUNT=0
+  else
+    DIFF_FILE_COUNT=$(printf '%s\n' "$DIFF_FILES" | wc -l | tr -d ' ')
+  fi
   echo "DIFF_FILE_COUNT=$DIFF_FILE_COUNT"
   if [ "$DIFF_FILE_COUNT" = "0" ]; then
     echo "STATE=empty"

--- a/plugins/flow/commands/review.md
+++ b/plugins/flow/commands/review.md
@@ -26,28 +26,57 @@ Multi-faceted code review with parallel analysis. Follows Explore > Plan > Code 
 # Take the first whitespace-separated token; accept only if it is all digits.
 # A non-numeric token (e.g., "foo42" or "evil;rm") is rejected with empty
 # PR_NUM so it never reaches the prompt context or any downstream shell.
+#
+# Output: `###`-headed sections + KEY=value per
+# `references/command-output-format.md`. STATE=blocked on bad input.
 ARG1="${ARGUMENTS%% *}"
 case "$ARG1" in
   ''|*[!0-9]*) PR_NUM="" ;;
   *) PR_NUM="$ARG1" ;;
 esac
 
+echo "### PR Reference"
 if [ -z "$PR_NUM" ]; then
-  echo "ERROR: PR number required (all-digit). Usage: /flow:review <pr-number>"
+  echo "STATE=blocked"
+  echo "ERROR=PR number required (all-digit). Usage: /flow:review <pr-number>"
 else
+  echo "STATE=ok"
   echo "PR_NUM=$PR_NUM"
 
-  # 1. PR details
-  gh pr view "$PR_NUM" --json title,body,headRefName,baseRefName,changedFiles,additions,deletions,labels,author,reviews 2>/dev/null
+  # Section: PR Details
+  echo ""
+  echo "### PR Details"
+  gh pr view "$PR_NUM" --json title,headRefName,baseRefName,changedFiles,additions,deletions,labels,author,reviews --jq '"TITLE=\"\(.title)\"\nHEAD_BRANCH=\(.headRefName)\nBASE_BRANCH=\(.baseRefName)\nAUTHOR=@\(.author.login)\nCHANGED_FILES=\(.changedFiles)\nADDITIONS=\(.additions)\nDELETIONS=\(.deletions)\nLABELS=\([.labels[].name] | join(","))\nREVIEW_COUNT=\(.reviews | length)"' 2>/dev/null
 
-  # 2. Linked issue
-  gh pr view "$PR_NUM" --json body --jq '.body' 2>/dev/null | grep -oE '#[0-9]+' | head -1 | tr -d '#'
+  # Section: Linked Issue (parsed from PR body)
+  echo ""
+  echo "### Linked Issue"
+  LINKED=$(gh pr view "$PR_NUM" --json body --jq '.body' 2>/dev/null | grep -oE '#[0-9]+' | head -1 | tr -d '#')
+  echo "LINKED_ISSUE=${LINKED:-none}"
 
-  # 3. Previous reviews (follow-up detection)
-  gh pr view "$PR_NUM" --json reviews --jq '.reviews[] | "\(.state) by \(.author.login)"' 2>/dev/null
+  # Section: Previous Reviews (follow-up detection)
+  echo ""
+  echo "### Previous Reviews"
+  PREV_JSON=$(gh pr view "$PR_NUM" --json reviews --jq '.reviews' 2>/dev/null)
+  PREV_COUNT=$(echo "$PREV_JSON" | jq 'length' 2>/dev/null || echo "0")
+  echo "REVIEW_COUNT=$PREV_COUNT"
+  if [ "$PREV_COUNT" = "0" ]; then
+    echo "STATE=empty"
+  else
+    echo "$PREV_JSON" | jq -r '.[] | "REVIEW=state=\(.state) by=@\(.author.login) at=\(.submittedAt)"' 2>/dev/null
+  fi
 
-  # 4. Diff
-  gh pr diff "$PR_NUM" --name-only 2>/dev/null
+  # Section: Diff Files
+  echo ""
+  echo "### Diff Files"
+  DIFF_FILES=$(gh pr diff "$PR_NUM" --name-only 2>/dev/null)
+  DIFF_FILE_COUNT=$(printf '%s\n' "$DIFF_FILES" | grep -c '.' || echo "0")
+  echo "DIFF_FILE_COUNT=$DIFF_FILE_COUNT"
+  if [ "$DIFF_FILE_COUNT" = "0" ]; then
+    echo "STATE=empty"
+  else
+    printf '%s\n' "$DIFF_FILES" | sed 's/^/DIFF_FILE=/'
+  fi
 fi
 
 true
@@ -74,22 +103,46 @@ case "$ARG1" in
   *) PR_NUM="$ARG1" ;;
 esac
 
+echo "### Previous Review Cycles"
 if [ -z "$PR_NUM" ]; then
-  echo "ERROR: PR number required (all-digit)"
+  echo "STATE=blocked"
+  echo "ERROR=PR number required (all-digit)"
 else
+  echo "STATE=ok"
   REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
-  gh api "repos/$REPO/pulls/$PR_NUM/reviews" --jq '
+
+  # Sub-section: review-cycle markers (in PR review bodies)
+  echo ""
+  echo "#### Review-cycle markers"
+  REVIEW_CYCLES=$(gh api "repos/$REPO/pulls/$PR_NUM/reviews" --jq '
     [.[] | select(.body | test("FLOW_REVIEW_CYCLE")) | {
       cycle: (.body | capture("FLOW_REVIEW_CYCLE:(?<n>[0-9]+)") | .n),
       findings: (.body | capture("FINDINGS:\\[(?<f>[^\\]]+)\\]") | .f)
-    }]' 2>/dev/null
+    }]' 2>/dev/null)
+  REVIEW_CYCLE_COUNT=$(echo "$REVIEW_CYCLES" | jq 'length' 2>/dev/null || echo "0")
+  echo "REVIEW_CYCLE_COUNT=$REVIEW_CYCLE_COUNT"
+  if [ "$REVIEW_CYCLE_COUNT" = "0" ]; then
+    echo "STATE=empty"
+  else
+    echo "$REVIEW_CYCLES" | jq -r '.[] | "REVIEW_CYCLE=cycle=\(.cycle) findings=\"\(.findings)\""' 2>/dev/null
+  fi
 
-  gh api "repos/$REPO/issues/$PR_NUM/comments" --jq '
+  # Sub-section: resolution-cycle markers (in PR/issue comments)
+  echo ""
+  echo "#### Resolution-cycle markers"
+  RESOLUTION_CYCLES=$(gh api "repos/$REPO/issues/$PR_NUM/comments" --jq '
     [.[] | select(.body | test("FLOW_RESOLUTION_CYCLE")) | {
       cycle: (.body | capture("FLOW_RESOLUTION_CYCLE:(?<n>[0-9]+)") | .n),
       resolved: (.body | capture("RESOLVED:\\[(?<r>[^\\]]*?)\\]") | .r),
       escalated: (.body | capture("ESCALATED:\\[(?<e>[^\\]]*?)\\]") | .e)
-    }]' 2>/dev/null
+    }]' 2>/dev/null)
+  RESOLUTION_CYCLE_COUNT=$(echo "$RESOLUTION_CYCLES" | jq 'length' 2>/dev/null || echo "0")
+  echo "RESOLUTION_CYCLE_COUNT=$RESOLUTION_CYCLE_COUNT"
+  if [ "$RESOLUTION_CYCLE_COUNT" = "0" ]; then
+    echo "STATE=empty"
+  else
+    echo "$RESOLUTION_CYCLES" | jq -r '.[] | "RESOLUTION_CYCLE=cycle=\(.cycle) resolved=\"\(.resolved // "")\" escalated=\"\(.escalated // "")\""' 2>/dev/null
+  fi
 fi
 
 true
@@ -118,6 +171,7 @@ Implements the paired-reviewer + challenge-round protocol. The `team-coordinatio
 **Path A gate check** (mandatory before paired dispatch — runs before A.1).
 
 ```!
+echo "### Path A Gate"
 # AGENTTEAMS_GATE_BEGIN
 # Resolve agentTeams from the standard Claude Code settings cascade.
 # Precedence (highest first — first non-empty value wins):
@@ -228,6 +282,15 @@ else
 fi
 # AGENTTEAMS_GATE_END
 echo "USE_PATH_A=$USE_PATH_A"
+# Dispatch signal: enabled when both keys passed (agentTeams + env var);
+# disabled otherwise. The agent reads PATH_A_STATE for the section dispatch
+# and USE_PATH_A for the raw 0/1 flag (preserved for backward compat with
+# downstream prose referencing it).
+if [ "$USE_PATH_A" = "1" ]; then
+  echo "PATH_A_STATE=enabled"
+else
+  echo "PATH_A_STATE=disabled"
+fi
 
 true
 ```

--- a/plugins/flow/commands/review.md
+++ b/plugins/flow/commands/review.md
@@ -57,13 +57,23 @@ else
   # Section: Previous Reviews (follow-up detection)
   echo ""
   echo "### Previous Reviews"
-  PREV_JSON=$(gh pr view "$PR_NUM" --json reviews --jq '.reviews' 2>/dev/null)
-  PREV_COUNT=$(echo "$PREV_JSON" | jq 'length' 2>/dev/null || echo "0")
-  echo "REVIEW_COUNT=$PREV_COUNT"
-  if [ "$PREV_COUNT" = "0" ]; then
-    echo "STATE=empty"
+  # Capture gh exit separately. Without this, `jq 'length' | echo "0"` on a
+  # failed gh call (auth, network) produces no output (jq 1.8 empty-input
+  # ⇒ exit 0) so `||` doesn't fire, COUNT stays empty, and the section
+  # silently leaks `REVIEW_COUNT=` (bare empty).
+  PREV_JSON=$(gh pr view "$PR_NUM" --json reviews --jq '.reviews' 2>/dev/null); GH_EXIT=$?
+  if [ $GH_EXIT -ne 0 ]; then
+    echo "REVIEW_COUNT=0"
+    echo "STATE=unavailable"
   else
-    echo "$PREV_JSON" | jq -r '.[] | "REVIEW=state=\(.state) by=@\(.author.login) at=\(.submittedAt)"' 2>/dev/null
+    PREV_COUNT=$(echo "$PREV_JSON" | jq 'length' 2>/dev/null)
+    [ -z "$PREV_COUNT" ] && PREV_COUNT=0
+    echo "REVIEW_COUNT=$PREV_COUNT"
+    if [ "$PREV_COUNT" = "0" ]; then
+      echo "STATE=empty"
+    else
+      echo "$PREV_JSON" | jq -r '.[] | "REVIEW=state=\(.state) by=@\(.author.login) at=\(.submittedAt)"' 2>/dev/null
+    fi
   fi
 
   # Section: Diff Files

--- a/plugins/flow/commands/review.md
+++ b/plugins/flow/commands/review.md
@@ -20,47 +20,69 @@ Multi-faceted code review with parallel analysis. Follows Explore > Plan > Code 
 
 ## Phase 1: EXPLORE
 
-**Parallel operations:**
+Pre-executed at command load (`!` prefix) — PR details, linked issue, previous reviews, and diff-name listing all reach the agent as prompt context. `gh pr checkout` stays inline below (mutating working tree).
+
+```!
+# Take the first whitespace-separated token as the PR number; the rest of
+# $ARGUMENTS is free-form context for the agent.
+PR_NUM="${ARGUMENTS%% *}"
+
+if [ -z "$PR_NUM" ]; then
+  echo "ERROR: PR number required. Usage: /flow:review <pr-number>"
+else
+  echo "PR_NUM=$PR_NUM"
+
+  # 1. PR details
+  gh pr view "$PR_NUM" --json title,body,headRefName,baseRefName,changedFiles,additions,deletions,labels,author,reviews
+
+  # 2. Linked issue
+  gh pr view "$PR_NUM" --json body --jq '.body' | grep -oE '#[0-9]+' | head -1 | tr -d '#'
+
+  # 3. Previous reviews (follow-up detection)
+  gh pr view "$PR_NUM" --json reviews --jq '.reviews[] | "\(.state) by \(.author.login)"'
+
+  # 4. Diff
+  gh pr diff "$PR_NUM" --name-only
+fi
+
+true
+```
+
+Then check out the PR branch (mutating, runs inline):
 
 ```bash
-# 1. PR details
-gh pr view $ARGUMENTS --json title,body,headRefName,baseRefName,changedFiles,additions,deletions,labels,author,reviews
-
-# 2. Linked issue
-gh pr view $ARGUMENTS --json body --jq '.body' | grep -oE '#[0-9]+' | head -1 | tr -d '#'
-
-# 3. Previous reviews (follow-up detection)
-gh pr view $ARGUMENTS --json reviews --jq '.reviews[] | "\(.state) by \(.author.login)"'
-
-# 4. Checkout PR branch
-gh pr checkout $ARGUMENTS
-
-# 5. Diff
-gh pr diff $ARGUMENTS --name-only
+gh pr checkout "$PR_NUM"
 ```
 
 **Agent(Explore)**: "Read the changed files in this PR and understand the context. What modules are affected? What patterns are being followed or changed?"
 
 Check for previous reviews — if this is a follow-up review, focus on changes since last review.
 
-**Parse structured findings from previous review/resolution cycles** (follow-up reviews only):
+**Parse structured findings from previous review/resolution cycles** (follow-up reviews only). Pre-executed at command load (`!` prefix).
 
-```bash
-# Parse previous review findings (from review bodies)
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-gh api repos/$REPO/pulls/$ARGUMENTS/reviews --jq '
-  [.[] | select(.body | test("FLOW_REVIEW_CYCLE")) | {
-    cycle: (.body | capture("FLOW_REVIEW_CYCLE:(?<n>[0-9]+)") | .n),
-    findings: (.body | capture("FINDINGS:\\[(?<f>[^\\]]+)\\]") | .f)
-  }]'
+```!
+# Parse previous review findings + resolution outcomes
+PR_NUM="${ARGUMENTS%% *}"
 
-# Parse previous resolution outcomes (from issue comments posted via gh pr comment)
-gh api repos/$REPO/issues/$ARGUMENTS/comments --jq '
-  [.[] | select(.body | test("FLOW_RESOLUTION_CYCLE")) | {
-    cycle: (.body | capture("FLOW_RESOLUTION_CYCLE:(?<n>[0-9]+)") | .n),
-    resolved: (.body | capture("RESOLVED:\\[(?<r>[^\\]]*?)\\]") | .r),
-    escalated: (.body | capture("ESCALATED:\\[(?<e>[^\\]]*?)\\]") | .e)
-  }]'
+if [ -z "$PR_NUM" ]; then
+  echo "ERROR: PR number required"
+else
+  REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+  gh api "repos/$REPO/pulls/$PR_NUM/reviews" --jq '
+    [.[] | select(.body | test("FLOW_REVIEW_CYCLE")) | {
+      cycle: (.body | capture("FLOW_REVIEW_CYCLE:(?<n>[0-9]+)") | .n),
+      findings: (.body | capture("FINDINGS:\\[(?<f>[^\\]]+)\\]") | .f)
+    }]' 2>/dev/null
+
+  gh api "repos/$REPO/issues/$PR_NUM/comments" --jq '
+    [.[] | select(.body | test("FLOW_RESOLUTION_CYCLE")) | {
+      cycle: (.body | capture("FLOW_RESOLUTION_CYCLE:(?<n>[0-9]+)") | .n),
+      resolved: (.body | capture("RESOLVED:\\[(?<r>[^\\]]*?)\\]") | .r),
+      escalated: (.body | capture("ESCALATED:\\[(?<e>[^\\]]*?)\\]") | .e)
+    }]' 2>/dev/null
+fi
+
+true
 ```
 
 If previous cycles exist, build a **Previous Feedback Status** table and cross-reference each finding's location against `git diff` to verify resolution.
@@ -83,9 +105,9 @@ TaskCreate("Holdout validation", "Cross-reference self-review claims against act
 
 Implements the paired-reviewer + challenge-round protocol. The `team-coordination` skill (`plugins/flow/skills/team-coordination/SKILL.md`) is the protocol contract.
 
-**Path A gate check** (mandatory before paired dispatch — runs before A.1):
+**Path A gate check** (mandatory before paired dispatch — runs before A.1). Pre-executed at command load (`!` prefix) — the resolved `USE_PATH_A` flag reaches the agent as prompt context.
 
-```bash
+```!
 # AGENTTEAMS_GATE_BEGIN
 # Resolve agentTeams from the standard Claude Code settings cascade.
 # Precedence (highest first — first non-empty value wins):
@@ -195,6 +217,9 @@ else
   fi
 fi
 # AGENTTEAMS_GATE_END
+echo "USE_PATH_A=$USE_PATH_A"
+
+true
 ```
 
 If `USE_PATH_A=0`, skip the rest of Path A and dispatch Path B below.
@@ -360,7 +385,7 @@ Apply the consolidation table from `team-coordination/SKILL.md` Phase 4. For eac
 | One raised, other timed out / errored | none | **MEDIUM** | `unchallenged` |
 | Both raised, both DISAGREE'd | n/a | **DROPPED** | excluded from output, logged below |
 
-**DROPPED findings** are logged to `.decisions/issue-{N}.md` (where N = the issue this PR addresses) under a `## Dropped after challenge (PR #$ARGUMENTS, cycle {N})` heading with the finding details and both DISAGREE reasons. They never appear in the rendered tables or the FLOW_REVIEW_CYCLE marker.
+**DROPPED findings** are logged to `.decisions/issue-{N}.md` (where N = the issue this PR addresses) under a `## Dropped after challenge (PR #$PR_NUM, cycle {N})` heading with the finding details and both DISAGREE reasons. They never appear in the rendered tables or the FLOW_REVIEW_CYCLE marker.
 
 **Manifest emit** — for each DROPPED finding, append a `dropped-finding` artifact to the journal manifest so `/flow:learn` can detect repeated drop reasons across cycles (a recurring drop reason is a learnable signal):
 
@@ -372,7 +397,7 @@ Apply the consolidation table from `team-coordination/SKILL.md` Phase 4. For eac
   --metadata finding_id=$FINDING_ID \
   --metadata facet=$FACET \
   --metadata reason="$REASON" \
-  --metadata pr=$ARGUMENTS
+  --metadata pr="$PR_NUM"
 ```
 
 Repeat once per dropped finding. The freeform `## Dropped after challenge` section preserves the verbose details (both DISAGREE reasons, file:line); the manifest entry is the queryable index.
@@ -387,7 +412,7 @@ If any of A.1's variants failed (timeout, error, did-not-spawn), apply the fallb
 | Both variants failed for facet F | Re-dispatch single Agent for that facet using the Path B prompt. Note in output: `facet F: re-dispatched as single-reviewer (both variants failed)`. |
 | Challenge round failed for a facet | Skip A.3 for that facet; keep A.1 findings as `unchallenged`. Note in output: `facet F: challenge skipped (challenge prompt failed)`. |
 | A.2 auto-consensus matching errored on finding F (e.g., malformed `file:line`) | Skip auto-consensus for F; route F through A.3 challenge as if non-consensus. Log `LEDGER_WARN: PR#{N} A.2 skipped F:<id> due to <reason>` to stderr. |
-| A.4 consolidation lookup missing for finding F (e.g., orphaned challenge response) | Emit F as `unchallenged` MEDIUM. Append to `.decisions/issue-{N}.md` (where N = the issue this PR addresses) under a `## Consolidation gaps (PR #$ARGUMENTS, cycle {N})` heading with the orphan reason. Create the journal file with frontmatter if it does not exist. **Also emit `--type consolidation-gap`** via `bin/journal-record.sh` with `cycle`, `finding_id`, `reason`, and `pr` metadata so the manifest carries a machine-readable trail of fallback fires. |
+| A.4 consolidation lookup missing for finding F (e.g., orphaned challenge response) | Emit F as `unchallenged` MEDIUM. Append to `.decisions/issue-{N}.md` (where N = the issue this PR addresses) under a `## Consolidation gaps (PR #$PR_NUM, cycle {N})` heading with the orphan reason. Create the journal file with frontmatter if it does not exist. **Also emit `--type consolidation-gap`** via `bin/journal-record.sh` with `cycle`, `finding_id`, `reason`, and `pr` metadata so the manifest carries a machine-readable trail of fallback fires. |
 
 #### A.6 — Emit consolidated output
 
@@ -444,7 +469,7 @@ TaskUpdate each review task as agents complete.
 3. **Display findings** (finding-first pattern):
 
 ```markdown
-## Review Summary for PR #$ARGUMENTS
+## Review Summary for PR #$PR_NUM
 
 ### Findings: P1: {X}, P2: {Y}, P3: {Z}
 
@@ -460,7 +485,7 @@ TaskUpdate each review task as agents complete.
 4. **Determine review mode** — compare PR author vs current user:
 
    ```bash
-   PR_AUTHOR=$(gh pr view $ARGUMENTS --json author --jq '.author.login')
+   PR_AUTHOR=$(gh pr view "$PR_NUM" --json author --jq '.author.login')
    CURRENT_USER=$(gh api user --jq '.login')
    ```
 
@@ -524,18 +549,18 @@ TaskUpdate each review task as agents complete.
    - When Path A had per-facet fallbacks, individual findings from fallback facets carry `unchallenged` disposition with MEDIUM confidence — emit them in the 7-field form alongside the rest. Mixed-form rows within a single marker are NOT permitted (parsers tolerate variable field count, but emitting both forms in one row list would be confusing); pad fallback findings to 7 fields with `MEDIUM|unchallenged`.
 
    Post the review:
-   - Self-review → `gh pr review $ARGUMENTS --comment --body "$BODY"`
-   - External + P1 findings → `gh pr review $ARGUMENTS --request-changes --body "$BODY"`
-   - External + P2 findings (no P1) → `gh pr review $ARGUMENTS --request-changes --body "$BODY"`
-   - External + P3 only → `gh pr review $ARGUMENTS --comment --body "$BODY"` (fix-expected, not approve-with-nits)
-   - External + No findings → `gh pr review $ARGUMENTS --approve --body "$BODY"`
+   - Self-review → `gh pr review "$PR_NUM" --comment --body "$BODY"`
+   - External + P1 findings → `gh pr review "$PR_NUM" --request-changes --body "$BODY"`
+   - External + P2 findings (no P1) → `gh pr review "$PR_NUM" --request-changes --body "$BODY"`
+   - External + P3 only → `gh pr review "$PR_NUM" --comment --body "$BODY"` (fix-expected, not approve-with-nits)
+   - External + No findings → `gh pr review "$PR_NUM" --approve --body "$BODY"`
 
    TaskUpdate(postCommentTaskId, status: "completed", result: "PASS — review posted as {approve/request-changes/comment}")
 
-   **Manifest emit** — record the review-cycle artifact in the issue's journal manifest. Use the issue number associated with this PR (parse from PR body: `gh pr view $ARGUMENTS --json body --jq '.body' | grep -oE '#[0-9]+' | head -1 | tr -d '#'`):
+   **Manifest emit** — record the review-cycle artifact in the issue's journal manifest. Use the issue number associated with this PR (parse from PR body: `gh pr view "$PR_NUM" --json body --jq '.body' | grep -oE '#[0-9]+' | head -1 | tr -d '#'`):
 
    ```bash
-   ISSUE=$(gh pr view $ARGUMENTS --json body --jq '.body' | grep -oE '#[0-9]+' | head -1 | tr -d '#')
+   ISSUE=$(gh pr view "$PR_NUM" --json body --jq '.body' | grep -oE '#[0-9]+' | head -1 | tr -d '#')
    if [ -n "$ISSUE" ]; then
      "${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/journal-record.sh" \
        --issue $ISSUE \
@@ -543,7 +568,7 @@ TaskUpdate each review task as agents complete.
        --metadata cycle=$CYCLE_NUMBER \
        --metadata path={A|B} \
        --metadata findings_count=$TOTAL \
-       --metadata pr=$ARGUMENTS
+       --metadata pr="$PR_NUM"
    fi
    ```
 
@@ -551,7 +576,7 @@ TaskUpdate each review task as agents complete.
 
 8. **Verify posting**: TaskList — confirm "Post review comment" or "Post self-review comment" task is completed. Do NOT proceed to step 9 until this is verified.
 
-9. **Post-review**: If self-review fixed everything, suggest `/flow:pr`. If external review, suggest `/flow:address $ARGUMENTS` for the PR author.
+9. **Post-review**: If self-review fixed everything, suggest `/flow:pr`. If external review, suggest `/flow:address $PR_NUM` for the PR author.
 
 ## Tier Classification
 

--- a/plugins/flow/commands/review.md
+++ b/plugins/flow/commands/review.md
@@ -1,6 +1,6 @@
 ---
 description: "Review a pull request with multi-faceted analysis. Supports both single-session parallel review and agent team adversarial review."
-argument-hint: <pr-number>
+argument-hint: <pr-number> [free-form context]
 allowed-tools: Bash, Read, Write, Edit, Agent, AskUserQuestion, TaskCreate, TaskList, TaskUpdate, Skill, Grep, Glob
 ---
 
@@ -23,26 +23,31 @@ Multi-faceted code review with parallel analysis. Follows Explore > Plan > Code 
 Pre-executed at command load (`!` prefix) — PR details, linked issue, previous reviews, and diff-name listing all reach the agent as prompt context. `gh pr checkout` stays inline below (mutating working tree).
 
 ```!
-# Take the first whitespace-separated token as the PR number; the rest of
-# $ARGUMENTS is free-form context for the agent.
-PR_NUM="${ARGUMENTS%% *}"
+# Take the first whitespace-separated token; accept only if it is all digits.
+# A non-numeric token (e.g., "foo42" or "evil;rm") is rejected with empty
+# PR_NUM so it never reaches the prompt context or any downstream shell.
+ARG1="${ARGUMENTS%% *}"
+case "$ARG1" in
+  ''|*[!0-9]*) PR_NUM="" ;;
+  *) PR_NUM="$ARG1" ;;
+esac
 
 if [ -z "$PR_NUM" ]; then
-  echo "ERROR: PR number required. Usage: /flow:review <pr-number>"
+  echo "ERROR: PR number required (all-digit). Usage: /flow:review <pr-number>"
 else
   echo "PR_NUM=$PR_NUM"
 
   # 1. PR details
-  gh pr view "$PR_NUM" --json title,body,headRefName,baseRefName,changedFiles,additions,deletions,labels,author,reviews
+  gh pr view "$PR_NUM" --json title,body,headRefName,baseRefName,changedFiles,additions,deletions,labels,author,reviews 2>/dev/null
 
   # 2. Linked issue
-  gh pr view "$PR_NUM" --json body --jq '.body' | grep -oE '#[0-9]+' | head -1 | tr -d '#'
+  gh pr view "$PR_NUM" --json body --jq '.body' 2>/dev/null | grep -oE '#[0-9]+' | head -1 | tr -d '#'
 
   # 3. Previous reviews (follow-up detection)
-  gh pr view "$PR_NUM" --json reviews --jq '.reviews[] | "\(.state) by \(.author.login)"'
+  gh pr view "$PR_NUM" --json reviews --jq '.reviews[] | "\(.state) by \(.author.login)"' 2>/dev/null
 
   # 4. Diff
-  gh pr diff "$PR_NUM" --name-only
+  gh pr diff "$PR_NUM" --name-only 2>/dev/null
 fi
 
 true
@@ -61,13 +66,18 @@ Check for previous reviews — if this is a follow-up review, focus on changes s
 **Parse structured findings from previous review/resolution cycles** (follow-up reviews only). Pre-executed at command load (`!` prefix).
 
 ```!
-# Parse previous review findings + resolution outcomes
-PR_NUM="${ARGUMENTS%% *}"
+# Parse previous review findings + resolution outcomes. PR_NUM is digit-validated
+# (matches Phase 1 block); a non-digit token rejects rather than reaching shell.
+ARG1="${ARGUMENTS%% *}"
+case "$ARG1" in
+  ''|*[!0-9]*) PR_NUM="" ;;
+  *) PR_NUM="$ARG1" ;;
+esac
 
 if [ -z "$PR_NUM" ]; then
-  echo "ERROR: PR number required"
+  echo "ERROR: PR number required (all-digit)"
 else
-  REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+  REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
   gh api "repos/$REPO/pulls/$PR_NUM/reviews" --jq '
     [.[] | select(.body | test("FLOW_REVIEW_CYCLE")) | {
       cycle: (.body | capture("FLOW_REVIEW_CYCLE:(?<n>[0-9]+)") | .n),

--- a/plugins/flow/commands/review.md
+++ b/plugins/flow/commands/review.md
@@ -20,7 +20,7 @@ Multi-faceted code review with parallel analysis. Follows Explore > Plan > Code 
 
 ## Phase 1: EXPLORE
 
-Pre-executed at command load (`!` prefix) — PR details, linked issue, previous reviews, and diff-name listing all reach the agent as prompt context. `gh pr checkout` stays inline below (mutating working tree).
+`gh pr checkout` stays inline below (mutating working tree); read-only context-gathering is in the `!` block.
 
 ```!
 # Take the first whitespace-separated token; accept only if it is all digits.
@@ -63,7 +63,7 @@ gh pr checkout "$PR_NUM"
 
 Check for previous reviews — if this is a follow-up review, focus on changes since last review.
 
-**Parse structured findings from previous review/resolution cycles** (follow-up reviews only). Pre-executed at command load (`!` prefix).
+**Parse structured findings from previous review/resolution cycles** (follow-up reviews only).
 
 ```!
 # Parse previous review findings + resolution outcomes. PR_NUM is digit-validated
@@ -115,7 +115,7 @@ TaskCreate("Holdout validation", "Cross-reference self-review claims against act
 
 Implements the paired-reviewer + challenge-round protocol. The `team-coordination` skill (`plugins/flow/skills/team-coordination/SKILL.md`) is the protocol contract.
 
-**Path A gate check** (mandatory before paired dispatch — runs before A.1). Pre-executed at command load (`!` prefix) — the resolved `USE_PATH_A` flag reaches the agent as prompt context.
+**Path A gate check** (mandatory before paired dispatch — runs before A.1).
 
 ```!
 # AGENTTEAMS_GATE_BEGIN

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -38,7 +38,7 @@ This command operates with these domain skills loaded:
 
 ## Phase 0: PRE-FLIGHT
 
-Pure bash validation. Pre-executed at command load (`!` prefix) so the agent sees PASS/BLOCKED in the prompt and fails fast before spending tokens.
+Pure bash validation — fails fast before any agent reasoning.
 
 ```!
 # Take the first whitespace-separated token; accept only if it is all digits.
@@ -106,8 +106,6 @@ Gather all context before planning.
 - Phase 3 becomes: reproduce → isolate root cause → write failing test → fix → verify
 
 **Note**: `debugging-patterns` activates automatically for ALL issues when any verification step fails (build, test, server start, smoke test). No `bug` label required.
-
-Pre-executed at command load (`!` prefix) — issue details, comments, default branch, and git state all reach the agent as prompt context.
 
 ```!
 # Digit-validate ISSUE_NUM (matches Phase 0 block).

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -152,7 +152,7 @@ Acceptance criteria alone do not describe the full specification. Before buildin
 Skill(specification-capture):
   Inputs:
   - Issue context: {pre-fetched issue title, body, comments, labels}
-  - Journal path: .decisions/issue-$ARGUMENTS.md
+  - Journal path: .decisions/issue-$ISSUE_NUM.md
   - Invocation reason: start
 ```
 
@@ -160,7 +160,7 @@ The skill returns the captured specification (non-goals, failure modes, interfac
 
 After the skill returns, verify per the skill's "Verification gates" section:
 
-1. The journal `.decisions/issue-$ARGUMENTS.md` contains a `## Specification` heading
+1. The journal `.decisions/issue-$ISSUE_NUM.md` contains a `## Specification` heading
 2. All three element subsections (`### Non-goals`, `### Failure modes`, `### Interface contracts`) are present and non-empty (or `none — {reason}` for failure-mode categories that don't apply)
 3. The returned payload matches the journal contents
 
@@ -170,7 +170,7 @@ If any check fails, halt and re-invoke the skill with the failure noted. Do NOT 
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/journal-record.sh" \
-  --issue $ARGUMENTS \
+  --issue "$ISSUE_NUM" \
   --type specification \
   --metadata by=specification-capture \
   --metadata elements=non-goals,failure-modes,interface-contracts
@@ -220,7 +220,7 @@ Only after every criterion shows PASS or user-approved MANUAL can the workflow p
 **Assign the issue:**
 
 ```bash
-gh issue edit $ARGUMENTS --add-assignee @me
+gh issue edit "$ISSUE_NUM" --add-assignee @me
 ```
 
 ## Phase 2: PLAN
@@ -231,7 +231,7 @@ Create branch and decompose tasks.
 
 ```bash
 git fetch origin $DEFAULT_BRANCH
-git checkout -b "feature/issue-$ARGUMENTS-{kebab-desc}" "origin/$DEFAULT_BRANCH"
+git checkout -b "feature/issue-${ISSUE_NUM}-{kebab-desc}" "origin/$DEFAULT_BRANCH"
 ```
 
 **Initialize decision journal:**
@@ -240,7 +240,7 @@ git checkout -b "feature/issue-$ARGUMENTS-{kebab-desc}" "origin/$DEFAULT_BRANCH"
 mkdir -p .decisions
 ```
 
-Write journal header to `.decisions/issue-$ARGUMENTS.md`.
+Write journal header to `.decisions/issue-$ISSUE_NUM.md`.
 
 **Task decomposition** — dispatch implementation-planner agent:
 
@@ -254,7 +254,7 @@ A task is not "done" until all three are complete. Splitting them into three sib
 
 ```
 Agent(implementation-planner):
-  "Parse acceptance criteria from issue #$ARGUMENTS and create atomic tasks.
+  "Parse acceptance criteria from issue #$ISSUE_NUM and create atomic tasks.
    Issue context: {pre-fetched issue title, body, comments}
    Specification (from EXPLORE): {non-goals, failure modes, interface contracts}
    Spec Validation Gate results: {criterion -> verification command mapping}
@@ -296,13 +296,13 @@ Check each task for these failure modes:
 
 If ANY task fails the Stranger Test, the plan is incomplete. The agent must either rewrite the task to close the gap, or issue a Proactive-Autonomy escalation asking the user to fill in the missing context. Only after every task passes the Stranger Test can the workflow proceed to Phase 3.
 
-Record the Stranger Test result to `.decisions/issue-$ARGUMENTS.md` under a `## Stranger Test` heading with either "PASS — {N} tasks reviewed" or "BLOCK — {task id}: {failure mode}".
+Record the Stranger Test result to `.decisions/issue-$ISSUE_NUM.md` under a `## Stranger Test` heading with either "PASS — {N} tasks reviewed" or "BLOCK — {task id}: {failure mode}".
 
 **Manifest emit** — append the stranger-test artifact (alongside the freeform `## Stranger Test` section) so the manifest captures the gate's outcome:
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/journal-record.sh" \
-  --issue $ARGUMENTS \
+  --issue "$ISSUE_NUM" \
   --type stranger-test \
   --metadata result={PASS|BLOCK} \
   --metadata task_count=$N
@@ -463,7 +463,7 @@ Prove everything works with fix-forward:
 
    ```bash
    "${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/journal-record.sh" \
-     --issue $ARGUMENTS \
+     --issue "$ISSUE_NUM" \
      --type verdict \
      --metadata result={PASS|FAIL|NEEDS-HUMAN-REVIEW}
    ```

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -38,11 +38,19 @@ This command operates with these domain skills loaded:
 
 ## Phase 0: PRE-FLIGHT
 
-Pure bash validation. No LLM calls. Fail fast before spending tokens.
+Pure bash validation. Pre-executed at command load (`!` prefix) so the agent sees PASS/BLOCKED in the prompt and fails fast before spending tokens.
 
-```bash
+```!
+# Take the first whitespace-separated token as the issue number;
+# the rest of $ARGUMENTS is free-form context for the agent.
+# (Users often invoke as `/flow:start 42 (the search bar bug)`.)
+ISSUE_NUM="${ARGUMENTS%% *}"
+
 ERRORS=0
 WARNINGS=0
+
+# 0. Issue number required
+[ -z "$ISSUE_NUM" ] && echo "PREFLIGHT FAIL: Issue number required" && ERRORS=$((ERRORS+1))
 
 # 1. Clean git state
 [ -n "$(git status --porcelain)" ] && echo "PREFLIGHT FAIL: Uncommitted changes" && ERRORS=$((ERRORS+1))
@@ -54,18 +62,26 @@ git symbolic-ref HEAD >/dev/null 2>&1 || { echo "PREFLIGHT FAIL: Detached HEAD";
 gh auth status >/dev/null 2>&1 || { echo "PREFLIGHT FAIL: gh CLI not authenticated"; ERRORS=$((ERRORS+1)); }
 
 # 4. Issue exists and is open
-ISSUE_STATE=$(gh issue view $ARGUMENTS --json state --jq '.state' 2>/dev/null)
-[ "$ISSUE_STATE" != "OPEN" ] && echo "PREFLIGHT FAIL: Issue #$ARGUMENTS not found or not open (state: ${ISSUE_STATE:-not found})" && ERRORS=$((ERRORS+1))
+if [ -n "$ISSUE_NUM" ]; then
+  ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --json state --jq '.state' 2>/dev/null)
+  [ "$ISSUE_STATE" != "OPEN" ] && echo "PREFLIGHT FAIL: Issue #$ISSUE_NUM not found or not open (state: ${ISSUE_STATE:-not found})" && ERRORS=$((ERRORS+1))
+fi
 
 # 5. Remote accessible
 git ls-remote --exit-code origin >/dev/null 2>&1 || { echo "PREFLIGHT FAIL: Cannot reach remote 'origin'"; ERRORS=$((ERRORS+1)); }
 
 # 6. Already on feature branch (warning only)
-git branch --show-current | grep -q "issue-$ARGUMENTS" && echo "PREFLIGHT WARN: Already on branch for issue #$ARGUMENTS" && WARNINGS=$((WARNINGS+1))
+[ -n "$ISSUE_NUM" ] && git branch --show-current | grep -q "issue-$ISSUE_NUM" && echo "PREFLIGHT WARN: Already on branch for issue #$ISSUE_NUM" && WARNINGS=$((WARNINGS+1))
 
+echo "ISSUE_NUM=$ISSUE_NUM"
 echo "PREFLIGHT: $ERRORS error(s), $WARNINGS warning(s)"
-[ $ERRORS -gt 0 ] && echo "PREFLIGHT: BLOCKED" && exit 1
-echo "PREFLIGHT: PASSED"
+if [ $ERRORS -gt 0 ]; then
+  echo "PREFLIGHT: BLOCKED"
+else
+  echo "PREFLIGHT: PASSED"
+fi
+
+true
 ```
 
 If pre-flight fails, stop. Do not proceed to EXPLORE.
@@ -79,17 +95,18 @@ Gather all context before planning.
 
 **Note**: `debugging-patterns` activates automatically for ALL issues when any verification step fails (build, test, server start, smoke test). No `bug` label required.
 
-Execute these in parallel:
+Pre-executed at command load (`!` prefix) — issue details, comments, default branch, and git state all reach the agent as prompt context.
 
-**Parallel Bash calls:**
+```!
+ISSUE_NUM="${ARGUMENTS%% *}"
+[ -z "$ISSUE_NUM" ] && { echo "ERROR: issue number required"; exit 1; }
 
-```bash
 # 1. Issue details
-gh issue view $ARGUMENTS --json title,body,labels,assignees,milestone
+gh issue view "$ISSUE_NUM" --json title,body,labels,assignees,milestone
 
 # 2. Issue comments
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-gh api repos/$REPO/issues/$ARGUMENTS/comments --jq '.[] | "---\n@\(.user.login):\n\(.body)\n"'
+gh api "repos/$REPO/issues/$ISSUE_NUM/comments" --jq '.[] | "---\n@\(.user.login):\n\(.body)\n"'
 
 # 3. Default branch and repo info
 DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
@@ -98,6 +115,8 @@ echo "DEFAULT_BRANCH=$DEFAULT_BRANCH"
 # 4. Current git state
 git status --short
 git branch --show-current
+
+true
 ```
 
 **Parallel Agent + Skill calls:**

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -47,6 +47,10 @@ Pure bash validation — fails fast before any agent reasoning.
 # (notably `git checkout -b "feature/issue-${ISSUE_NUM}-..."`). Users can still
 # invoke as `/flow:start 42 (the search bar bug)` — the trailing prose is
 # stripped by the first-token extraction.
+#
+# Output: `### Pre-Flight` heading + PREFLIGHT_FAIL=/PREFLIGHT_WARN= lines
+# per check + final PREFLIGHT_STATE=PASSED|BLOCKED sentinel. See
+# `references/command-output-format.md`.
 ARG1="${ARGUMENTS%% *}"
 case "$ARG1" in
   ''|*[!0-9]*) ISSUE_NUM="" ;;
@@ -55,48 +59,55 @@ esac
 
 ERRORS=0
 WARNINGS=0
+FAIL_REASONS=""
+WARN_REASONS=""
+fail() { FAIL_REASONS="${FAIL_REASONS}PREFLIGHT_FAIL=$1"$'\n'; ERRORS=$((ERRORS+1)); }
+warn() { WARN_REASONS="${WARN_REASONS}PREFLIGHT_WARN=$1"$'\n'; WARNINGS=$((WARNINGS+1)); }
 
 # 0. Issue number required (all-digit; non-digit input is rejected above)
-[ -z "$ISSUE_NUM" ] && echo "PREFLIGHT FAIL: Issue number required (all-digit)" && ERRORS=$((ERRORS+1))
+[ -z "$ISSUE_NUM" ] && fail "Issue number required (all-digit)"
 
 # 1. Clean git state
-[ -n "$(git status --porcelain)" ] && echo "PREFLIGHT FAIL: Uncommitted changes" && ERRORS=$((ERRORS+1))
+[ -n "$(git status --porcelain)" ] && fail "Uncommitted changes"
 
 # 2. Not detached HEAD
-git symbolic-ref HEAD >/dev/null 2>&1 || { echo "PREFLIGHT FAIL: Detached HEAD"; ERRORS=$((ERRORS+1)); }
+git symbolic-ref HEAD >/dev/null 2>&1 || fail "Detached HEAD"
 
 # 3. gh CLI authenticated
-gh auth status >/dev/null 2>&1 || { echo "PREFLIGHT FAIL: gh CLI not authenticated"; ERRORS=$((ERRORS+1)); }
+gh auth status >/dev/null 2>&1 || fail "gh CLI not authenticated"
 
 # 4. Issue exists and is open
 if [ -n "$ISSUE_NUM" ]; then
   ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --json state --jq '.state' 2>/dev/null)
-  [ "$ISSUE_STATE" != "OPEN" ] && echo "PREFLIGHT FAIL: Issue #$ISSUE_NUM not found or not open (state: ${ISSUE_STATE:-not found})" && ERRORS=$((ERRORS+1))
+  [ "$ISSUE_STATE" != "OPEN" ] && fail "Issue #$ISSUE_NUM not found or not open (state: ${ISSUE_STATE:-not found})"
 fi
 
 # 5. Remote accessible
-git ls-remote --exit-code origin >/dev/null 2>&1 || { echo "PREFLIGHT FAIL: Cannot reach remote 'origin'"; ERRORS=$((ERRORS+1)); }
+git ls-remote --exit-code origin >/dev/null 2>&1 || fail "Cannot reach remote 'origin'"
 
 # 6. Already on feature branch (warning only)
 # Short-circuits silently if not on a matching branch — the chain is a single
 # statement, so failure of any link (no ISSUE_NUM, no match, etc.) just skips
-# the warn without aborting the block. Symmetric in spirit with line 67's
-# `[ "$ISSUE_STATE" != "OPEN" ] && ...` ERRORS chain — both rely on `set -e`
-# being off (which it is, here) plus the implicit truthy semantics of `&&`.
-[ -n "$ISSUE_NUM" ] && git branch --show-current | grep -q "issue-$ISSUE_NUM" && echo "PREFLIGHT WARN: Already on branch for issue #$ISSUE_NUM" && WARNINGS=$((WARNINGS+1))
+# the warn without aborting the block.
+[ -n "$ISSUE_NUM" ] && git branch --show-current | grep -q "issue-$ISSUE_NUM" && warn "Already on branch for issue #$ISSUE_NUM"
 
+echo "### Pre-Flight"
 echo "ISSUE_NUM=$ISSUE_NUM"
-echo "PREFLIGHT: $ERRORS error(s), $WARNINGS warning(s)"
+echo "PREFLIGHT_ERRORS=$ERRORS"
+echo "PREFLIGHT_WARNINGS=$WARNINGS"
 if [ $ERRORS -gt 0 ]; then
-  echo "PREFLIGHT: BLOCKED"
+  echo "PREFLIGHT_STATE=BLOCKED"
 else
-  echo "PREFLIGHT: PASSED"
+  echo "PREFLIGHT_STATE=PASSED"
 fi
+# Emit collected reasons (one per line, may be empty)
+printf '%s' "$FAIL_REASONS"
+printf '%s' "$WARN_REASONS"
 
 true
 ```
 
-If pre-flight fails, stop. Do not proceed to EXPLORE.
+If `PREFLIGHT_STATE=BLOCKED`, stop. Do not proceed to EXPLORE. The `PREFLIGHT_FAIL=` lines under the section enumerate the reasons.
 
 ## Phase 1: EXPLORE
 
@@ -115,23 +126,48 @@ case "$ARG1" in
   *) ISSUE_NUM="$ARG1" ;;
 esac
 
+echo "### Issue Reference"
 if [ -z "$ISSUE_NUM" ]; then
-  echo "ERROR: issue number required (all-digit; Phase 0 PRE-FLIGHT carries the authoritative BLOCKED signal)"
+  echo "STATE=blocked"
+  echo "ERROR=issue number required (all-digit; Phase 0 PRE-FLIGHT carries the authoritative BLOCKED signal)"
 else
-  # 1. Issue details
-  gh issue view "$ISSUE_NUM" --json title,body,labels,assignees,milestone 2>/dev/null
+  echo "STATE=ok"
+  echo "ISSUE_NUM=$ISSUE_NUM"
 
-  # 2. Issue comments
+  # Section: Issue Details
+  echo ""
+  echo "### Issue Details"
+  gh issue view "$ISSUE_NUM" --json title,body,labels,assignees,milestone --jq '
+    "TITLE=\"\(.title)\"\nLABELS=\([.labels[].name] | join(","))\nASSIGNEES=\([.assignees[].login] | map("@" + .) | join(","))\nMILESTONE=\(.milestone.title // "(none)")\nBODY_LENGTH=\(.body | length)"
+  ' 2>/dev/null
+  # Issue body is variable-length; emit it under a sub-heading so the agent
+  # can locate and read it as prose rather than parse it as fields.
+  echo ""
+  echo "#### Issue Body"
+  gh issue view "$ISSUE_NUM" --json body --jq '.body' 2>/dev/null
+
+  # Section: Issue Comments
+  echo ""
+  echo "### Issue Comments"
   REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
-  gh api "repos/$REPO/issues/$ISSUE_NUM/comments" --jq '.[] | "---\n@\(.user.login):\n\(.body)\n"' 2>/dev/null
+  COMMENT_COUNT=$(gh api "repos/$REPO/issues/$ISSUE_NUM/comments" --jq 'length' 2>/dev/null || echo "0")
+  echo "COMMENT_COUNT=$COMMENT_COUNT"
+  if [ "$COMMENT_COUNT" = "0" ]; then
+    echo "STATE=empty"
+  else
+    gh api "repos/$REPO/issues/$ISSUE_NUM/comments" --jq '.[] | "COMMENT=author=@\(.user.login) at=\(.created_at) length=\(.body | length)"' 2>/dev/null
+  fi
 
-  # 3. Default branch and repo info
+  # Section: Repo Context
+  echo ""
+  echo "### Repo Context"
   DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
+  echo "REPO=$REPO"
   echo "DEFAULT_BRANCH=$DEFAULT_BRANCH"
-
-  # 4. Current git state
-  git status --short
-  git branch --show-current
+  echo "CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)"
+  STATUS_LINES=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+  echo "UNCOMMITTED_COUNT=$STATUS_LINES"
+  [ "$STATUS_LINES" != "0" ] && git status --short 2>/dev/null | head -20 | sed 's/^/UNCOMMITTED_LINE=/'
 fi
 
 true

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -1,6 +1,6 @@
 ---
 description: "Start work on a GitHub issue. Assigns issue, creates branch, decomposes tasks from acceptance criteria, and guides implementation with autonomous execution."
-argument-hint: <issue-number-or-url>
+argument-hint: <issue-number-or-url> [free-form context]
 allowed-tools: Bash, Read, Write, Edit, Agent, Skill, AskUserQuestion, TaskCreate, TaskList, TaskUpdate, TaskGet, Grep, Glob
 ---
 

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -99,22 +99,25 @@ Pre-executed at command load (`!` prefix) — issue details, comments, default b
 
 ```!
 ISSUE_NUM="${ARGUMENTS%% *}"
-[ -z "$ISSUE_NUM" ] && { echo "ERROR: issue number required"; exit 1; }
 
-# 1. Issue details
-gh issue view "$ISSUE_NUM" --json title,body,labels,assignees,milestone
+if [ -z "$ISSUE_NUM" ]; then
+  echo "ERROR: issue number required (Phase 0 PRE-FLIGHT carries the authoritative BLOCKED signal)"
+else
+  # 1. Issue details
+  gh issue view "$ISSUE_NUM" --json title,body,labels,assignees,milestone
 
-# 2. Issue comments
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-gh api "repos/$REPO/issues/$ISSUE_NUM/comments" --jq '.[] | "---\n@\(.user.login):\n\(.body)\n"'
+  # 2. Issue comments
+  REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+  gh api "repos/$REPO/issues/$ISSUE_NUM/comments" --jq '.[] | "---\n@\(.user.login):\n\(.body)\n"' 2>/dev/null
 
-# 3. Default branch and repo info
-DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
-echo "DEFAULT_BRANCH=$DEFAULT_BRANCH"
+  # 3. Default branch and repo info
+  DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
+  echo "DEFAULT_BRANCH=$DEFAULT_BRANCH"
 
-# 4. Current git state
-git status --short
-git branch --show-current
+  # 4. Current git state
+  git status --short
+  git branch --show-current
+fi
 
 true
 ```

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -41,16 +41,23 @@ This command operates with these domain skills loaded:
 Pure bash validation. Pre-executed at command load (`!` prefix) so the agent sees PASS/BLOCKED in the prompt and fails fast before spending tokens.
 
 ```!
-# Take the first whitespace-separated token as the issue number;
-# the rest of $ARGUMENTS is free-form context for the agent.
-# (Users often invoke as `/flow:start 42 (the search bar bug)`.)
-ISSUE_NUM="${ARGUMENTS%% *}"
+# Take the first whitespace-separated token; accept only if it is all digits.
+# A non-numeric token (e.g., "foo42" or "evil;rm") is rejected with empty
+# ISSUE_NUM so it never reaches the prompt context or any downstream shell
+# (notably `git checkout -b "feature/issue-${ISSUE_NUM}-..."`). Users can still
+# invoke as `/flow:start 42 (the search bar bug)` — the trailing prose is
+# stripped by the first-token extraction.
+ARG1="${ARGUMENTS%% *}"
+case "$ARG1" in
+  ''|*[!0-9]*) ISSUE_NUM="" ;;
+  *) ISSUE_NUM="$ARG1" ;;
+esac
 
 ERRORS=0
 WARNINGS=0
 
-# 0. Issue number required
-[ -z "$ISSUE_NUM" ] && echo "PREFLIGHT FAIL: Issue number required" && ERRORS=$((ERRORS+1))
+# 0. Issue number required (all-digit; non-digit input is rejected above)
+[ -z "$ISSUE_NUM" ] && echo "PREFLIGHT FAIL: Issue number required (all-digit)" && ERRORS=$((ERRORS+1))
 
 # 1. Clean git state
 [ -n "$(git status --porcelain)" ] && echo "PREFLIGHT FAIL: Uncommitted changes" && ERRORS=$((ERRORS+1))
@@ -71,6 +78,11 @@ fi
 git ls-remote --exit-code origin >/dev/null 2>&1 || { echo "PREFLIGHT FAIL: Cannot reach remote 'origin'"; ERRORS=$((ERRORS+1)); }
 
 # 6. Already on feature branch (warning only)
+# Short-circuits silently if not on a matching branch — the chain is a single
+# statement, so failure of any link (no ISSUE_NUM, no match, etc.) just skips
+# the warn without aborting the block. Symmetric in spirit with line 67's
+# `[ "$ISSUE_STATE" != "OPEN" ] && ...` ERRORS chain — both rely on `set -e`
+# being off (which it is, here) plus the implicit truthy semantics of `&&`.
 [ -n "$ISSUE_NUM" ] && git branch --show-current | grep -q "issue-$ISSUE_NUM" && echo "PREFLIGHT WARN: Already on branch for issue #$ISSUE_NUM" && WARNINGS=$((WARNINGS+1))
 
 echo "ISSUE_NUM=$ISSUE_NUM"
@@ -98,16 +110,21 @@ Gather all context before planning.
 Pre-executed at command load (`!` prefix) — issue details, comments, default branch, and git state all reach the agent as prompt context.
 
 ```!
-ISSUE_NUM="${ARGUMENTS%% *}"
+# Digit-validate ISSUE_NUM (matches Phase 0 block).
+ARG1="${ARGUMENTS%% *}"
+case "$ARG1" in
+  ''|*[!0-9]*) ISSUE_NUM="" ;;
+  *) ISSUE_NUM="$ARG1" ;;
+esac
 
 if [ -z "$ISSUE_NUM" ]; then
-  echo "ERROR: issue number required (Phase 0 PRE-FLIGHT carries the authoritative BLOCKED signal)"
+  echo "ERROR: issue number required (all-digit; Phase 0 PRE-FLIGHT carries the authoritative BLOCKED signal)"
 else
   # 1. Issue details
-  gh issue view "$ISSUE_NUM" --json title,body,labels,assignees,milestone
+  gh issue view "$ISSUE_NUM" --json title,body,labels,assignees,milestone 2>/dev/null
 
   # 2. Issue comments
-  REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+  REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
   gh api "repos/$REPO/issues/$ISSUE_NUM/comments" --jq '.[] | "---\n@\(.user.login):\n\(.body)\n"' 2>/dev/null
 
   # 3. Default branch and repo info

--- a/plugins/flow/commands/status.md
+++ b/plugins/flow/commands/status.md
@@ -56,7 +56,8 @@ if [ "$AUTHORED_COUNT" = "0" ]; then
 else
   echo "$AUTHORED_JSON" | jq -r '.[] | (
     [.statusCheckRollup[]? | select(.__typename == "CheckRun")] as $checks |
-    "PR=\(.number) state=\(.state) review=\(.reviewDecision // "(none)") checks=\($checks | map(select(.conclusion == "SUCCESS")) | length)/\($checks | length) title=\"\(.title)\""
+    (if (.reviewDecision // "") == "" then "(none)" else .reviewDecision end) as $review |
+    "PR=\(.number) state=\(.state) review=\($review) checks=\($checks | map(select(.conclusion == "SUCCESS")) | length)/\($checks | length) title=\"\(.title)\""
   )' 2>/dev/null
 fi
 

--- a/plugins/flow/commands/status.md
+++ b/plugins/flow/commands/status.md
@@ -50,8 +50,8 @@ true
 Aggregate review findings across the user's open PRs (author OR assignee). See [`references/finding-ledger-parser.md`](../references/finding-ledger-parser.md) for the canonical marker schemas, queries, and state classification — the bash below applies that contract. Pre-executed at command load (`!` prefix).
 
 ```!
-ME=$(gh api user --jq '.login')
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+ME=$(gh api user --jq '.login' 2>/dev/null)
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
 
 # MARKERTRUST_GATE_BEGIN
 # Resolve trust list from the standard Claude Code settings cascade — same
@@ -73,6 +73,14 @@ for SETTINGS_PATH in "$LOCAL_SETTINGS" "$PROJECT_SETTINGS" "$USER_SETTINGS" "$PL
   fi
   [ -z "$CONFIGURED" ] && continue
   if echo "$CONFIGURED" | jq -e '. | type == "array" and length > 0 and all(.[]; type == "string")' >/dev/null 2>&1; then
+    # Warn (don't block) when an element falls outside the known GitHub
+    # `author_association` vocabulary — same defense-in-depth check as
+    # commands/merge.md, mirrored here so a typo surfaces during the
+    # aggregator pass too (matches the /flow:status read-only contract).
+    UNKNOWN_VALUES=$(echo "$CONFIGURED" | jq -r '.[] | select(. != "OWNER" and . != "MEMBER" and . != "COLLABORATOR" and . != "CONTRIBUTOR" and . != "FIRST_TIME_CONTRIBUTOR" and . != "FIRST_TIMER" and . != "MANNEQUIN" and . != "NONE")' 2>/dev/null | tr '\n' ',' | sed 's/,$//')
+    if [ -n "$UNKNOWN_VALUES" ]; then
+      echo "LEDGER_WARN: markerTrust in $SETTINGS_PATH contains values [$UNKNOWN_VALUES] not in the GitHub author_association vocabulary (OWNER, MEMBER, COLLABORATOR, CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, MANNEQUIN, NONE). These elements will match no authors — check for typos." >&2
+    fi
     TRUST_LIST="$CONFIGURED"
     break
   fi
@@ -116,7 +124,11 @@ else
     ESCALATED=$(echo "$RESOLUTION_BODY" | grep -o 'ESCALATED:\[[^]]*\]' | sed 's/^ESCALATED:\[//;s/\]$//' | tr -d ' ')
     DISPUTED=$(echo "$RESOLUTION_BODY"  | grep -o 'DISPUTED:\[[^]]*\]'  | sed 's/^DISPUTED:\[//;s/\]$//'  | tr -d ' ')
 
-    echo "$FINDINGS_RAW" | tr ',' '\n' | while IFS='|' read -r ID PRIORITY CAT LOC STATUS; do
+    # CAT and LOC are parsed but unused inside this loop — drop them with `_`
+    # so future code additions can't accidentally interpolate attacker-controlled
+    # fields without first applying `safe()` sanitization. If a future change
+    # needs them, replace `_ _` with named vars AND wrap each use with `safe()`.
+    echo "$FINDINGS_RAW" | tr ',' '\n' | while IFS='|' read -r ID PRIORITY _ _ STATUS; do
       [ -z "$ID" ] && continue
       # Reject IDs containing case-glob metacharacters (`*`, `?`, `[`, `]`) —
       # IDs are template-issued and should match [A-Za-z][A-Za-z0-9_-]*.

--- a/plugins/flow/commands/status.md
+++ b/plugins/flow/commands/status.md
@@ -13,8 +13,6 @@ _None — read-only status command. No skill invocations._
 
 ## Gather State
 
-Pre-executed at command load (`!` prefix) — the agent receives this output as part of the prompt, no Bash tool round-trip.
-
 ```!
 # 1. Current branch and uncommitted changes
 git branch --show-current
@@ -47,7 +45,7 @@ true
 
 ## Gather Findings Ledger
 
-Aggregate review findings across the user's open PRs (author OR assignee). See [`references/finding-ledger-parser.md`](../references/finding-ledger-parser.md) for the canonical marker schemas, queries, and state classification — the bash below applies that contract. Pre-executed at command load (`!` prefix).
+Aggregate review findings across the user's open PRs (author OR assignee). See [`references/finding-ledger-parser.md`](../references/finding-ledger-parser.md) for the canonical marker schemas, queries, and state classification — the bash below applies that contract.
 
 ```!
 ME=$(gh api user --jq '.login' 2>/dev/null)

--- a/plugins/flow/commands/status.md
+++ b/plugins/flow/commands/status.md
@@ -13,9 +13,9 @@ _None — read-only status command. No skill invocations._
 
 ## Gather State
 
-Execute all queries in parallel:
+Pre-executed at command load (`!` prefix) — the agent receives this output as part of the prompt, no Bash tool round-trip.
 
-```bash
+```!
 # 1. Current branch and uncommitted changes
 git branch --show-current
 git status --short | head -20
@@ -41,13 +41,15 @@ JOURNAL_DIR=".decisions"
 
 # 7. Learning pending
 [ -f "$HOME/.claude/flow-learn-pending" ] && echo "LEARNING PENDING: $(cat $HOME/.claude/flow-learn-pending)" || echo "No pending learning"
+
+true
 ```
 
 ## Gather Findings Ledger
 
-Aggregate review findings across the user's open PRs (author OR assignee). See [`references/finding-ledger-parser.md`](../references/finding-ledger-parser.md) for the canonical marker schemas, queries, and state classification — the bash below applies that contract.
+Aggregate review findings across the user's open PRs (author OR assignee). See [`references/finding-ledger-parser.md`](../references/finding-ledger-parser.md) for the canonical marker schemas, queries, and state classification — the bash below applies that contract. Pre-executed at command load (`!` prefix).
 
-```bash
+```!
 ME=$(gh api user --jq '.login')
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 
@@ -146,6 +148,8 @@ else
     done
   done | sort | uniq -c
 fi
+
+true
 ```
 
 The output of the loop is a tally like:

--- a/plugins/flow/commands/status.md
+++ b/plugins/flow/commands/status.md
@@ -34,43 +34,67 @@ echo "UNCOMMITTED_COUNT=$UNCOMMITTED_COUNT"
 [ "$UNCOMMITTED_COUNT" != "0" ] && git status --short 2>/dev/null | head -20 | sed 's/^/UNCOMMITTED_LINE=/'
 
 # Section: My Issues (Open)
+# Capture gh exit separately across all three sections below: gh failure
+# (auth, network, non-repo CWD) returns "" with non-zero exit; jq on empty
+# input produces no output + exit 0 (jq 1.8), so `|| echo "0"` doesn't fire
+# and the section silently leaks `<KEY>_COUNT=` (bare empty). Distinguish
+# `STATE=unavailable` (gh failed) from `STATE=empty` (gh ok, no records) per
+# `references/command-output-format.md` closed-vocab contract.
 echo ""
 echo "### My Issues (Open)"
-ASSIGNED_JSON=$(gh issue list --assignee @me --state open --limit 10 --json number,title,labels 2>/dev/null)
-ASSIGNED_COUNT=$(echo "$ASSIGNED_JSON" | jq 'length' 2>/dev/null || echo "0")
-echo "ASSIGNED_COUNT=$ASSIGNED_COUNT"
-if [ "$ASSIGNED_COUNT" = "0" ]; then
-  echo "STATE=empty"
+ASSIGNED_JSON=$(gh issue list --assignee @me --state open --limit 10 --json number,title,labels 2>/dev/null); GH_EXIT=$?
+if [ $GH_EXIT -ne 0 ]; then
+  echo "ASSIGNED_COUNT=0"
+  echo "STATE=unavailable"
 else
-  echo "$ASSIGNED_JSON" | jq -r '.[] | "ISSUE=\(.number) labels=\"\([.labels[].name] | join(","))\" title=\"\(.title)\""' 2>/dev/null
+  ASSIGNED_COUNT=$(echo "$ASSIGNED_JSON" | jq 'length' 2>/dev/null)
+  [ -z "$ASSIGNED_COUNT" ] && ASSIGNED_COUNT=0
+  echo "ASSIGNED_COUNT=$ASSIGNED_COUNT"
+  if [ "$ASSIGNED_COUNT" = "0" ]; then
+    echo "STATE=empty"
+  else
+    echo "$ASSIGNED_JSON" | jq -r '.[] | "ISSUE=\(.number) labels=\"\([.labels[].name] | join(","))\" title=\"\(.title)\""' 2>/dev/null
+  fi
 fi
 
 # Section: My PRs (authored)
 echo ""
 echo "### My PRs"
-AUTHORED_JSON=$(gh pr list --author @me --state open --json number,title,state,reviewDecision,statusCheckRollup 2>/dev/null)
-AUTHORED_COUNT=$(echo "$AUTHORED_JSON" | jq 'length' 2>/dev/null || echo "0")
-echo "AUTHORED_COUNT=$AUTHORED_COUNT"
-if [ "$AUTHORED_COUNT" = "0" ]; then
-  echo "STATE=empty"
+AUTHORED_JSON=$(gh pr list --author @me --state open --json number,title,state,reviewDecision,statusCheckRollup 2>/dev/null); GH_EXIT=$?
+if [ $GH_EXIT -ne 0 ]; then
+  echo "AUTHORED_COUNT=0"
+  echo "STATE=unavailable"
 else
-  echo "$AUTHORED_JSON" | jq -r '.[] | (
-    [.statusCheckRollup[]? | select(.__typename == "CheckRun")] as $checks |
-    (if (.reviewDecision // "") == "" then "(none)" else .reviewDecision end) as $review |
-    "PR=\(.number) state=\(.state) review=\($review) checks=\($checks | map(select(.conclusion == "SUCCESS")) | length)/\($checks | length) title=\"\(.title)\""
-  )' 2>/dev/null
+  AUTHORED_COUNT=$(echo "$AUTHORED_JSON" | jq 'length' 2>/dev/null)
+  [ -z "$AUTHORED_COUNT" ] && AUTHORED_COUNT=0
+  echo "AUTHORED_COUNT=$AUTHORED_COUNT"
+  if [ "$AUTHORED_COUNT" = "0" ]; then
+    echo "STATE=empty"
+  else
+    echo "$AUTHORED_JSON" | jq -r '.[] | (
+      [.statusCheckRollup[]? | select(.__typename == "CheckRun")] as $checks |
+      (if (.reviewDecision // "") == "" then "(none)" else .reviewDecision end) as $review |
+      "PR=\(.number) state=\(.state) review=\($review) checks=\($checks | map(select(.conclusion == "SUCCESS")) | length)/\($checks | length) title=\"\(.title)\""
+    )' 2>/dev/null
+  fi
 fi
 
 # Section: Awaiting My Review
 echo ""
 echo "### Awaiting My Review"
-REVIEW_JSON=$(gh pr list --search "review-requested:@me" --state open --json number,title,author 2>/dev/null)
-REVIEW_REQUESTED_COUNT=$(echo "$REVIEW_JSON" | jq 'length' 2>/dev/null || echo "0")
-echo "REVIEW_REQUESTED_COUNT=$REVIEW_REQUESTED_COUNT"
-if [ "$REVIEW_REQUESTED_COUNT" = "0" ]; then
-  echo "STATE=empty"
+REVIEW_JSON=$(gh pr list --search "review-requested:@me" --state open --json number,title,author 2>/dev/null); GH_EXIT=$?
+if [ $GH_EXIT -ne 0 ]; then
+  echo "REVIEW_REQUESTED_COUNT=0"
+  echo "STATE=unavailable"
 else
-  echo "$REVIEW_JSON" | jq -r '.[] | "PR=\(.number) author=@\(.author.login) title=\"\(.title)\""' 2>/dev/null
+  REVIEW_REQUESTED_COUNT=$(echo "$REVIEW_JSON" | jq 'length' 2>/dev/null)
+  [ -z "$REVIEW_REQUESTED_COUNT" ] && REVIEW_REQUESTED_COUNT=0
+  echo "REVIEW_REQUESTED_COUNT=$REVIEW_REQUESTED_COUNT"
+  if [ "$REVIEW_REQUESTED_COUNT" = "0" ]; then
+    echo "STATE=empty"
+  else
+    echo "$REVIEW_JSON" | jq -r '.[] | "PR=\(.number) author=@\(.author.login) title=\"\(.title)\""' 2>/dev/null
+  fi
 fi
 
 # Section: Decision Journal + Learning state

--- a/plugins/flow/commands/status.md
+++ b/plugins/flow/commands/status.md
@@ -14,31 +14,80 @@ _None — read-only status command. No skill invocations._
 ## Gather State
 
 ```!
-# 1. Current branch and uncommitted changes
-git branch --show-current
-git status --short | head -20
+# Output contract: `###`-headed sections mirroring the Display template below
+# (Current Branch / My Issues (Open) / My PRs / Awaiting My Review /
+# Decision Journal). Scalars use KEY=value; records use one labeled line per
+# entity (ISSUE=… / PR=…). Empty list-sections emit `STATE=empty` as a
+# positive sentinel — the agent matches a closed vocabulary, not silence.
+# See `references/command-output-format.md` for the canonical pattern.
 
-# 2. Commits ahead of default branch
+# Section: Current Branch
+echo "### Current Branch"
+BRANCH=$(git branch --show-current 2>/dev/null)
 DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
-git rev-list --count "$DEFAULT_BRANCH"..HEAD 2>/dev/null || echo "0"
+COMMITS_AHEAD=$(git rev-list --count "$DEFAULT_BRANCH"..HEAD 2>/dev/null || echo "0")
+UNCOMMITTED_COUNT=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+echo "BRANCH=$BRANCH"
+echo "DEFAULT_BRANCH=$DEFAULT_BRANCH"
+echo "COMMITS_AHEAD=$COMMITS_AHEAD"
+echo "UNCOMMITTED_COUNT=$UNCOMMITTED_COUNT"
+[ "$UNCOMMITTED_COUNT" != "0" ] && git status --short 2>/dev/null | head -20 | sed 's/^/UNCOMMITTED_LINE=/'
 
-# 3. Assigned issues
-gh issue list --assignee @me --state open --limit 10 --json number,title,labels
+# Section: My Issues (Open)
+echo ""
+echo "### My Issues (Open)"
+ASSIGNED_JSON=$(gh issue list --assignee @me --state open --limit 10 --json number,title,labels 2>/dev/null)
+ASSIGNED_COUNT=$(echo "$ASSIGNED_JSON" | jq 'length' 2>/dev/null || echo "0")
+echo "ASSIGNED_COUNT=$ASSIGNED_COUNT"
+if [ "$ASSIGNED_COUNT" = "0" ]; then
+  echo "STATE=empty"
+else
+  echo "$ASSIGNED_JSON" | jq -r '.[] | "ISSUE=\(.number) labels=\"\([.labels[].name] | join(","))\" title=\"\(.title)\""' 2>/dev/null
+fi
 
-# 4. Open PRs (authored)
-gh pr list --author @me --state open --json number,title,state,reviewDecision,statusCheckRollup
+# Section: My PRs (authored)
+echo ""
+echo "### My PRs"
+AUTHORED_JSON=$(gh pr list --author @me --state open --json number,title,state,reviewDecision,statusCheckRollup 2>/dev/null)
+AUTHORED_COUNT=$(echo "$AUTHORED_JSON" | jq 'length' 2>/dev/null || echo "0")
+echo "AUTHORED_COUNT=$AUTHORED_COUNT"
+if [ "$AUTHORED_COUNT" = "0" ]; then
+  echo "STATE=empty"
+else
+  echo "$AUTHORED_JSON" | jq -r '.[] | (
+    [.statusCheckRollup[]? | select(.__typename == "CheckRun")] as $checks |
+    "PR=\(.number) state=\(.state) review=\(.reviewDecision // "(none)") checks=\($checks | map(select(.conclusion == "SUCCESS")) | length)/\($checks | length) title=\"\(.title)\""
+  )' 2>/dev/null
+fi
 
-# 5. PRs needing my review
-gh pr list --search "review-requested:@me" --state open --json number,title,author
+# Section: Awaiting My Review
+echo ""
+echo "### Awaiting My Review"
+REVIEW_JSON=$(gh pr list --search "review-requested:@me" --state open --json number,title,author 2>/dev/null)
+REVIEW_REQUESTED_COUNT=$(echo "$REVIEW_JSON" | jq 'length' 2>/dev/null || echo "0")
+echo "REVIEW_REQUESTED_COUNT=$REVIEW_REQUESTED_COUNT"
+if [ "$REVIEW_REQUESTED_COUNT" = "0" ]; then
+  echo "STATE=empty"
+else
+  echo "$REVIEW_JSON" | jq -r '.[] | "PR=\(.number) author=@\(.author.login) title=\"\(.title)\""' 2>/dev/null
+fi
 
-# 6. Decision journal health. Resolved via bin/cascade-resolve.sh.
+# Section: Decision Journal + Learning state
+# `JOURNAL_DIR` is resolved via the standard settings cascade (bin/cascade-resolve.sh).
+echo ""
+echo "### Decision Journal"
 HELPER="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
 JOURNAL_DIR=".decisions"
 [ -x "$HELPER" ] && JOURNAL_DIR=$("$HELPER" --default ".decisions" '.journal.dir // empty')
-[ -d "$JOURNAL_DIR" ] && ls -la "$JOURNAL_DIR"/*.md 2>/dev/null | wc -l || echo "0"
-
-# 7. Learning pending
-[ -f "$HOME/.claude/flow-learn-pending" ] && echo "LEARNING PENDING: $(cat $HOME/.claude/flow-learn-pending)" || echo "No pending learning"
+JOURNAL_FILES=0
+[ -d "$JOURNAL_DIR" ] && JOURNAL_FILES=$(ls "$JOURNAL_DIR"/*.md 2>/dev/null | wc -l | tr -d ' ')
+echo "JOURNAL_DIR=$JOURNAL_DIR"
+echo "JOURNAL_FILES=$JOURNAL_FILES"
+if [ -f "$HOME/.claude/flow-learn-pending" ]; then
+  echo "LEARNING_PENDING=$(cat "$HOME/.claude/flow-learn-pending")"
+else
+  echo "LEARNING_PENDING=none"
+fi
 
 true
 ```
@@ -100,14 +149,26 @@ else
     '[.[] | select(.author.login == $me or (.assignees[].login? == $me))] | .[].number' 2>/dev/null || echo "LEDGER_UNAVAILABLE")
 fi
 
+echo "### Findings Ledger"
 if [ "$LEDGER_PRS" = "LEDGER_UNAVAILABLE" ]; then
-  echo "LEDGER: unavailable (gh API failed)"
+  echo "LEDGER_STATE=unavailable"
+elif [ -z "$LEDGER_PRS" ]; then
+  echo "LEDGER_STATE=no_open_prs"
 else
   # Sanitize attacker-controlled fields before display/echo: cap length and
   # strip non-printable bytes so a hostile review-body can't inject ANSI
   # escapes into LEDGER_WARN output. Defined once for the whole loop.
   safe() { printf '%s' "$1" | tr -cd '[:print:]' | cut -c1-64; }
-  for PR_NUM in $LEDGER_PRS; do
+  # Generate the PRIORITY|STATE tally to a variable so we can distinguish
+  # "no markers" (empty TALLY) from "findings present" (non-empty) and emit
+  # the right LEDGER_STATE sentinel for each.
+  #
+  # Wrapped in a function because bash's `$(...)` paren-matching collides
+  # with the `*)` patterns in the nested `case` statements below — the outer
+  # substitution would close on the first case-arm paren. Function isolation
+  # gives the case statements their own parse scope.
+  _collect_tally() {
+    for PR_NUM in $LEDGER_PRS; do
     REVIEW_BODY=$(gh api --paginate "repos/$REPO/pulls/$PR_NUM/reviews" 2>/dev/null \
       | jq -s -r --argjson trust "$TRUST_LIST" \
           'add | [.[] | select((.author_association as $a | $trust | index($a)) and (.body | test("FLOW_REVIEW_CYCLE:")))] | last | .body // ""')
@@ -156,21 +217,39 @@ else
       esac
       echo "${PRIORITY}|${STATE}"
     done
-  done | sort | uniq -c
+    done | sort | uniq -c
+  }
+  TALLY=$(_collect_tally)
+
+  if [ -z "$TALLY" ]; then
+    echo "LEDGER_STATE=no_markers"
+  else
+    echo "LEDGER_STATE=findings"
+    # Emit one TALLY_<PRIORITY>_<STATE>=COUNT line per row. The agent sums
+    # across STATE for each priority to render the Findings Ledger line per
+    # the rules in `## Render Rules` below.
+    echo "$TALLY" | while read -r count rest; do
+      ROW_PRIORITY="${rest%%|*}"
+      ROW_STATE="${rest#*|}"
+      echo "TALLY_${ROW_PRIORITY}_${ROW_STATE}=$count"
+    done
+  fi
 fi
 
 true
 ```
 
-The output of the loop is a tally like:
+The block emits one of four `LEDGER_STATE=` values, followed (only when `LEDGER_STATE=findings`) by one `TALLY_<PRIORITY>_<STATE>=<count>` line per `(priority, state)` row in the tally:
 
 ```
-   2 P1|in_fix_forward
-   1 P2|escalated
-   3 P3|in_fix_forward
+### Findings Ledger
+LEDGER_STATE=findings
+TALLY_P1_in_fix_forward=2
+TALLY_P2_escalated=1
+TALLY_P3_in_fix_forward=3
 ```
 
-Use this to render the Findings Ledger line per priority. If the loop produces no rows AND `LEDGER_PRS` was non-empty, the user has open PRs but no review markers yet — render `No open findings`.
+State values: `unavailable` (gh API failed) | `no_open_prs` (user has no open PRs) | `no_markers` (open PRs exist but no review markers parsed) | `findings` (at least one tally row follows). Render rules below convert the `TALLY_` lines into the single-line Findings Ledger output.
 
 ## Display
 
@@ -210,25 +289,27 @@ Use this to render the Findings Ledger line per priority. If the loop produces n
 
 ## Render Rules — Findings Ledger
 
-Convert the `PRIORITY|STATE` tally from the gather step into one line. Per-priority rules:
+Convert the `TALLY_<PRIORITY>_<STATE>=<count>` lines from the gather step into one Findings Ledger line. For each priority P1, P2, P3:
 
-- `0` findings at this priority → `P{n}: 0` (bare).
-- All findings at this priority share one state → `P{n}: K (state-label)`.
-- Multiple states at this priority → `P{n}: K (a STATE_A; b STATE_B)`.
+1. Sum all `TALLY_P{n}_*` counts. Call this `K`.
+2. `K == 0` → emit `P{n}: 0` (bare).
+3. `K > 0` and only one `TALLY_P{n}_*` row present → emit `P{n}: K (state-label)`.
+4. `K > 0` and multiple `TALLY_P{n}_*` rows → emit `P{n}: K (a STATE_A; b STATE_B)`, where `a, b` are the per-state counts.
 
-State labels:
+State labels (the `STATE` portion of the `TALLY_` key, mapped to a human-readable label):
 
-| State | Label |
+| State (key suffix) | Label |
 |-------|-------|
 | `in_fix_forward` | `in fix-forward` |
 | `escalated` | `ESCALATED` |
 | `disputed` | `DISPUTED` |
 
-Edge cases:
+Edge cases (driven by `LEDGER_STATE=`, NOT by silence):
 
-- `LEDGER_PRS` empty (no open PRs for user) → `No open findings.`
-- `LEDGER_PRS` non-empty but tally empty (no markers yet) → `No open findings.`
-- `LEDGER_UNAVAILABLE` (gh API failed) → `Findings Ledger unavailable — gh API failed.` (one-line cause).
+- `LEDGER_STATE=unavailable` → `Findings Ledger unavailable — gh API failed.`
+- `LEDGER_STATE=no_open_prs` → `No open findings.`
+- `LEDGER_STATE=no_markers` → `No open findings.`
+- `LEDGER_STATE=findings` → apply the per-priority rules above.
 
 Format matches the workshop slide mockup in `docs/flow-team-session/slides.md` (`/flow:status — what to expect` section, Findings Ledger row).
 

--- a/plugins/flow/references/command-output-format.md
+++ b/plugins/flow/references/command-output-format.md
@@ -1,0 +1,234 @@
+# Command `!` block output format
+
+Reference document. The canonical shape every `!`-prefixed bash block in `commands/*.md` should emit to stdout. The output is the **agent-readable context**: Claude Code pre-executes the block at command load and injects its stdout into the prompt where the fence was. There is no other reader — no downstream bash parses this output, and the source of the block is not visible to the agent. The shape below optimizes for one job: a fresh-session agent reading the rendered prompt top-to-bottom should know what every line is without re-reading the command file.
+
+## Why this format
+
+The first cycle of the `!`-prefix refactor emitted bare command output — `git branch --show-current` produced just `feature/flow-bang-prefix-context`, with no label. The agent had to map unlabeled lines to the right Display-template cell by inference from section ordering. With two `[]` lines from different `gh pr list` queries, the inference is brittle and silently breaks if the bash order drifts.
+
+The format here trades 1-2 lines of extra stdout per block for a deterministic agent-readable contract:
+
+- Section headings (`###`) match the Display template the agent will render into, so the mapping is name-to-name, not position-to-position.
+- `KEY=value` lines turn every scalar into a named field. Bash-order drift becomes harmless.
+- One labeled record per line (`PR=104 state=OPEN review=(none) ...`) replaces multi-line JSON the agent would otherwise have to mentally parse.
+- Empty list-sections emit `STATE=empty` so the agent matches a closed vocabulary instead of inferring meaning from silence.
+
+The pattern follows the same house style as `references/evidence-bundle-format.md` (markdown `###` headings nesting structured fields) and `references/finding-schema.md` (named fields, controlled vocabulary, enums).
+
+## Shape
+
+```markdown
+### {Section name}
+KEY=value
+KEY=value
+RECORD_LABEL=key1=val1 key2=val2 key3="quoted string"
+
+### {Next section}
+STATE=ok|empty|blocked|unavailable
+ERROR=human-readable message     # only when STATE=blocked
+KEY=value                        # only when STATE=ok
+```
+
+### Rules
+
+1. **Each logical section gets a `###` heading.** Heading text matches the Display-template heading where one exists (e.g., `### Current Branch`, `### My PRs`). For commands without a Display template, use a semantic name (`### Branch Context`, `### Issue Reference`).
+
+2. **Scalars use `KEY=value`.** No quoting required for single-token values. Use `KEY="value with spaces"` only when the value contains whitespace or shell metacharacters that would confuse a future bash consumer.
+
+3. **Records use one labeled line per entity.** A PR row becomes `PR=104 state=OPEN review=APPROVED checks=2/2-SUCCESS title="refactor: ..."`. The agent reads multiple records by reading multiple lines under the same heading. Field order within a record SHOULD be stable across runs.
+
+4. **Empty list-sections emit a positive sentinel.** Use `STATE=empty` (not silence, not `(none)`). The agent matches against the closed vocabulary `ok | empty | blocked | unavailable` — never against the empty string.
+
+5. **Error paths emit `STATE=blocked` + `ERROR=<message>`.** Replace inline `ERROR: ...` prefixes with the two-field form. The agent halts on `STATE=blocked` without parsing the message.
+
+6. **Unavailable states emit `STATE=unavailable` (or `<SECTION>_STATE=unavailable` when the section name is part of the contract, e.g., `LEDGER_STATE=unavailable`).** Reserved for transient infrastructure failures (gh API down, network unreachable). Distinct from `empty` — `unavailable` means "we don't know," `empty` means "we know there are zero."
+
+7. **Sections are separated by a blank `echo ""`.** Improves visual scanability in the rendered prompt without adding meaningful tokens.
+
+8. **The block always ends with `true`.** Inherited from the `!`-prefix discipline — guarantees exit 0 regardless of trailing pipeline behavior. See `references/finding-ledger-parser.md` for the same convention applied to marker blocks.
+
+### Sentinels — closed vocabulary
+
+| Sentinel | Meaning | When |
+|---|---|---|
+| `STATE=ok` | section's primary call succeeded; data follows | optional — agents may default to `ok` when no `STATE=` line is emitted under a section that has data |
+| `STATE=empty` | section's call succeeded; result set is empty | use for `gh pr list` returning `[]`, `git status --porcelain` with no output, etc. |
+| `STATE=blocked` | input validation failed; section cannot proceed | use after permissive-arg-extraction rejects a non-digit `$PR_NUM`, missing required positional, etc. |
+| `STATE=unavailable` | infrastructure failure; cannot determine state | use when `gh` exits non-zero, the network is unreachable, or a required helper is missing |
+
+Per-section state variables (e.g., `LEDGER_STATE=`, `PREFLIGHT_STATE=`) follow the same vocabulary but with a domain prefix when the section name disambiguates the meaning.
+
+## Worked example — `/flow:status` ! block #1
+
+Before (cycle-1 raw output — 8 unlabeled lines):
+
+```
+feature/flow-bang-prefix-context
+?? .handoff-pr103.md
+29
+[]
+[{"number":104,"reviewDecision":"","state":"OPEN","statusCheckRollup":[{"__typename":"CheckRun",...long JSON...}]}]
+[]
+       6
+LEARNING PENDING: 2026-05-15
+```
+
+After:
+
+```
+### Current Branch
+BRANCH=feature/flow-bang-prefix-context
+DEFAULT_BRANCH=main
+COMMITS_AHEAD=29
+UNCOMMITTED_COUNT=1
+UNCOMMITTED_LINE=?? .handoff-pr103.md
+
+### My Issues (Open)
+ASSIGNED_COUNT=0
+STATE=empty
+
+### My PRs
+AUTHORED_COUNT=1
+PR=104 state=OPEN review=(none) checks=2/2-SUCCESS title="refactor(flow): pre-execute read-only context via `!` prefix"
+
+### Awaiting My Review
+REVIEW_REQUESTED_COUNT=0
+STATE=empty
+
+### Decision Journal
+JOURNAL_DIR=.decisions
+JOURNAL_FILES=6
+LEARNING_PENDING=2026-05-15
+```
+
+The agent renders the Display template by reading section-by-section. Section names line up 1:1; field names are explicit; the JSON blob has been pre-parsed via `--jq` into a single labeled line.
+
+## Worked example — `/flow:merge` ledger gate (state machine)
+
+The ledger gate has four mutually exclusive outcomes. With the format above, each is a single line:
+
+```
+### Findings Ledger
+LEDGER_STATE=findings
+TALLY_P1_in_fix_forward=2
+TALLY_P2_escalated=1
+TALLY_P3_in_fix_forward=3
+```
+
+```
+### Findings Ledger
+LEDGER_STATE=no_markers
+```
+
+```
+### Findings Ledger
+LEDGER_STATE=no_open_prs
+```
+
+```
+### Findings Ledger
+LEDGER_STATE=unavailable
+```
+
+The agent matches against the closed vocabulary `{findings, no_markers, no_open_prs, unavailable}` to choose the right Render Rule branch, then (for `findings` only) reads the `TALLY_<PRIORITY>_<STATE>` lines.
+
+## Pre-shaping JSON for the agent
+
+When a block calls `gh ... --json ...`, the raw JSON is rarely the right shape for agent consumption. Use `--jq` to reduce it to one labeled record per line.
+
+Bad:
+
+```bash
+gh pr list --author @me --state open --json number,title,state,reviewDecision,statusCheckRollup
+```
+
+Good:
+
+```bash
+gh pr list --author @me --state open --json number,title,state,reviewDecision,statusCheckRollup --jq '
+  .[] | (
+    [.statusCheckRollup[]? | select(.__typename == "CheckRun")] as $checks |
+    "PR=\(.number) state=\(.state) review=\(.reviewDecision // "(none)") checks=\($checks | map(select(.conclusion == "SUCCESS")) | length)/\($checks | length) title=\"\(.title)\""
+  )'
+```
+
+Trade-off: shifts JSON-parsing work from the agent (token-expensive, error-prone) into bash (cheap, deterministic). Field selection happens once in bash; agent reads the labeled record directly. For richer record shapes that don't fit one line cleanly, fall back to a `### Sub-heading` per record:
+
+```
+### My PRs
+
+#### PR 104
+PR=104
+state=OPEN
+review=(none)
+checks=2/2-SUCCESS
+title=refactor(flow): pre-execute read-only context via `!` prefix
+review_count=1
+comment_count=4
+```
+
+Use the per-record subheading form sparingly — it's verbose. Single-line records cover most cases.
+
+## Quoting conventions
+
+- Scalars without whitespace or shell metacharacters: bare. `BRANCH=feature/foo-bar.v2`
+- Scalars with whitespace: double-quoted. `TITLE="refactor: pre-execute via ! prefix"`
+- Backticks inside titles: pass through unescaped if double-quoted. Agents read them as literal characters.
+- Newlines in values: AVOID. If a value naturally contains newlines (a multi-paragraph PR body, a multi-line diff), use the per-record subheading form and let the value occupy multiple unlabeled lines beneath a `BODY=` or `DIFF=` marker line.
+
+## Bash patterns
+
+### Function wrap for nested case-in-substitution
+
+Bash's `$(...)` paren-matching collides with `*)` case-arm patterns. When you need a `case` statement inside a captured pipeline:
+
+```bash
+# Wrong — bash sees the case `*)` as closing the substitution
+TALLY=$(for x in $items; do
+  case "$x" in
+    valid) ;;
+    *) echo "WARN: bad $x" >&2; continue ;;
+  esac
+  echo "$x"
+done | sort | uniq -c)
+```
+
+```bash
+# Right — function isolates the case from outer paren counting
+_collect_tally() {
+  for x in $items; do
+    case "$x" in
+      valid) ;;
+      *) echo "WARN: bad $x" >&2; continue ;;
+    esac
+    echo "$x"
+  done | sort | uniq -c
+}
+TALLY=$(_collect_tally)
+```
+
+### Cross-block state via stdout echo
+
+When a Phase 1 `!` block extracts state (e.g., `PR_NUM` from `$ARGUMENTS`) that subsequent inline `bash` blocks need, echo it explicitly:
+
+```bash
+echo "PR_NUM=$PR_NUM"
+```
+
+The agent reads the echoed value from the prompt context and substitutes it into later Bash tool calls. This is how the rendered prompt carries state between blocks — bash variables do NOT persist across separate Bash tool invocations.
+
+### Stderr suppression discipline
+
+Every `gh` call that returns stdout the agent will consume should use `2>/dev/null`. Network errors, auth failures, and rate-limit messages otherwise leak into prompt context as `command failed`-style noise where the agent expects structured data.
+
+## When to deviate
+
+This format is the default. Deviate only when:
+
+1. The block is a marker-emitting helper called from inside the bash (not directly read by the agent). Those use pipe-separated forms documented in `references/finding-ledger-parser.md` and `references/finding-schema.md`.
+
+2. The output is a verbatim user-visible diagnostic that the agent should echo unchanged (e.g., a `PREFLIGHT: BLOCKED` banner). In that case, keep the verbatim diagnostic AND add the structured form alongside, so the agent has both presentations available.
+
+3. A downstream bash consumer parses the output (none exist today across the flow plugin; if one is added, document the contract here and at the consumer site).
+
+In all other cases, follow the rules above.

--- a/plugins/flow/references/command-output-format.md
+++ b/plugins/flow/references/command-output-format.md
@@ -56,7 +56,19 @@ KEY=value                        # only when STATE=ok
 | `STATE=blocked` | input validation failed; section cannot proceed | use after permissive-arg-extraction rejects a non-digit `$PR_NUM`, missing required positional, etc. |
 | `STATE=unavailable` | infrastructure failure; cannot determine state | use when `gh` exits non-zero, the network is unreachable, or a required helper is missing |
 
-Per-section state variables (e.g., `LEDGER_STATE=`, `PREFLIGHT_STATE=`) follow the same vocabulary but with a domain prefix when the section name disambiguates the meaning.
+Per-section state variables (e.g., `LEDGER_STATE=`, `PREFLIGHT_STATE=`) follow the same vocabulary when they signal the same conditions (`ok`, `empty`, `blocked`, `unavailable`). The bare `STATE=` variable is always restricted to the four sentinels above.
+
+### Domain-specific state vocabularies
+
+A section MAY define a richer state vocabulary by introducing a `<DOMAIN>_STATE=` variable distinct from `STATE=`. This is allowed when the domain has more than four mutually exclusive outcomes that downstream rendering rules need to distinguish. The domain vocabulary MUST be:
+
+- Closed (enumerated explicitly at the consumer site — no free-text values).
+- Documented inline next to the consumer's Render Rules so the agent knows which values are valid.
+- Distinct from the bare `STATE=` sentinel — never shadow or extend `STATE=`'s four-value set.
+
+The canonical example is `LEDGER_STATE=`, defined by `/flow:status`'s Findings-Ledger section: `{findings, no_markers, no_open_prs, unavailable}`. The Render Rules in `commands/status.md` enumerate the four values and the per-value template. Without this extension the section would have to collapse "no markers yet" and "no open PRs" into the same `empty` sentinel, losing useful diagnostic information.
+
+When in doubt, prefer the four-value `STATE=` and add diagnostic detail in a separate `ERROR=` / `<KEY>=` line rather than extending the closed vocabulary.
 
 ## Worked example — `/flow:status` ! block #1
 

--- a/plugins/flow/references/command-output-format.md
+++ b/plugins/flow/references/command-output-format.md
@@ -56,7 +56,7 @@ KEY=value                        # only when STATE=ok
 | `STATE=blocked` | input validation failed; section cannot proceed | use after permissive-arg-extraction rejects a non-digit `$PR_NUM`, missing required positional, etc. |
 | `STATE=unavailable` | infrastructure failure; cannot determine state | use when `gh` exits non-zero, the network is unreachable, or a required helper is missing |
 
-Per-section state variables (e.g., `LEDGER_STATE=`, `PREFLIGHT_STATE=`) follow the same vocabulary when they signal the same conditions (`ok`, `empty`, `blocked`, `unavailable`). The bare `STATE=` variable is always restricted to the four sentinels above.
+Per-section state variables (e.g., `LEDGER_STATE=`, `PREFLIGHT_STATE=`) follow the same vocabulary when they signal the same conditions (`ok`, `empty`, `blocked`, `unavailable`). The bare `STATE=` variable is always restricted to the four sentinels above. For richer domain-specific state machines, see "Domain-specific state vocabularies" below.
 
 ### Domain-specific state vocabularies
 


### PR DESCRIPTION
## Pre-execute read-only context via `!` prefix

Implements the idea from [this X post](https://x.com/akshay_pachaar/status/2053380764805583212) for 8 flow plugin commands: read-only context-gathering bash pre-executes at command load via the `!` prefix, so the agent receives the output as part of the prompt and skips a Bash tool round-trip.

### The lean shape, applied per command

Each command's Phase 1 EXPLORE / Pre-flight / Gather-state bash block:
1. ` ```bash ` → ` ```! ` (rendered output gets injected at command load)
2. Trailing `true` so the block's exit code is deterministic
3. Permissive first-token extraction (`ARG1="${ARGUMENTS%% *}"`) for the commands that take a positional argument — supports natural usage like `/flow:address 2 (find and address all issues)`

Mutating bash (`git checkout`, `git push`, `gh release create`, etc.) stays inline because it must run conditionally based on agent decisions and user confirmation.

### Per-command summary

| Command | What gets pre-executed |
|---|---|
| `/flow:status` | Branch / status / commits-ahead / assigned issues / open PRs / journal health / findings ledger |
| `/flow:learn` | Resolved journal & proposal directory paths + file counts |
| `/flow:commit` | Status / branch context / branch diff / issue context / recent commits |
| `/flow:pr` | Pre-flight / commits / status / diff stat / issue context / existing-PR check / journal entry |
| `/flow:release` | Latest tag / merged PRs since tag / commit log |
| `/flow:address` | PR details / review comments / review summaries / conversation threads / cycle count |
| `/flow:resolve` | Active-conflict detection / conflicted file list / hunk counts |
| `/flow:start` | Pre-flight (clean state, gh auth, issue open, remote, branch) / issue details / comments / default branch / git state |

### Scope

8 commits, one per command. **No** helper extraction, **no** test harness, **no** new reference docs, **no** `disable-model-invocation` changes, **no** cycle-of-review hardening. Just the format swap + minimum-defensive trailing `true` + permissive arg extraction where applicable.

Estimated benefit: ~1 tool call saved per command invocation for context gathering.


---

## Scope and tracking

This is a maintenance refactor without a tracking issue — branch name `feature/flow-bang-prefix-context` diverges from the project's standard `feature/issue-{N}-{desc}` pattern (documented in `.claude/CLAUDE.md`) intentionally, because no `bug`/`enhancement` ticket drove the work. The trigger was a public idea ([Pachaar X post](https://x.com/akshay_pachaar/status/2053380764805583212)) the maintainer wanted to apply.

If we adopt a convention of issue-tracking every plugin refactor, this PR should be referenced from a retroactive tracking issue rather than rewritten.

## Self-review cycle 1 — applied fixes

Commits `be2a56d`..`c5162e9` apply F1–F6 from the self-review:

| Finding | Fix |
|---|---|
| F1 | start.md inline blocks pin `$ISSUE_NUM` (replaced raw `$ARGUMENTS` in 10 shell-context occurrences; narrative refs stay) |
| F2 | address.md Phase 4 inline blocks pin `$PR_NUM` (replaced raw `$ARGUMENTS` in 6 shell-context occurrences) |
| F3 | address.md `!` blocks now `echo "PR_NUM=$PR_NUM"` so cross-block state matches start.md's `ISSUE_NUM` echo |
| F4 | `argument-hint` widened to `<...> [free-form context]` in start.md and address.md frontmatter |
| F5 | `exit 1` in `!` blocks converted to `if/else` wrapping the happy path (start.md Phase 1, address.md Phase 1, address.md Cycle Tracking, pr.md Phase 1) — all 13 `!` blocks now reach trailing `true` on every code path |
| F6 | This note. |

P3 findings (F7–F12, resolve.md style + stderr suppression gaps + defense-in-depth) are not blocking and left for a follow-up.


---

## Audit expansion — cycle 2 scope

A post-fix-forward audit found **11 more `!`-candidate blocks across 9 untouched commands** (brainstorm, debug, design, explain, flow, issue, merge, review). All migrated in this cycle to bring the PR to "!-prefix everywhere it makes sense" status.

Commits `43c05b6`..`0d68333` (9 commits, one per command):

| Command | New `!` blocks | Permissive arg extraction | Pinned $ARGUMENTS → typed var |
|---|---|---|---|
| flow.md | 1 (state queries) | n/a (dispatcher) | n/a |
| explain.md | 1 (branch + journal + diff) | n/a (no args) | n/a |
| debug.md | 1 (git history) | n/a (narrative arg) | n/a |
| issue.md | 1 (repo + branch) | n/a (narrative arg) | n/a |
| brainstorm.md | 1 (issue + state) | ISSUE_NUM | inline ($ARGUMENTS kept in heading + Agent search prompt) |
| design.md | 1 (structure + issue + state) | ISSUE_NUM | inline ($ARGUMENTS kept in heading + Agent prompt + TaskCreate) |
| merge.md | 2 (Phase 1 + ledger gate) | PR_NUM | bash code + display headings → $PR_NUM |
| review.md | 3 (Phase 1 + prev cycles + AGENTTEAMS gate) | PR_NUM | bash code + display headings + self-suggest → $PR_NUM. Agent prompt templates keep $ARGUMENTS for semantic intent pass-through. |

### Scope after expansion

- **16 of 17 flow command files** (setup.md is excluded — initialization writes config, not read-only context) now use `!` prefix where read-only context gathering is deterministic
- **24 `!` blocks** total (up from 13 after fix-forward)
- 100% `bash -n` clean
- Permissive first-token extraction wherever `<pr-number>` or `<issue-number>` is the contract
- Mutating bash stays inline (gh pr checkout, gh pr merge, gh pr create, gh pr comment, gh release create, git tag, git push, git fetch, git checkout, mkdir, rm)

### Live tests (dry-run with bash -c)

| Test | ARGUMENTS | Outcome |
|---|---|---|
| merge.md Phase 1 | `"104"` | PR_NUM=104, all gh calls succeed, exit=0 ✓ |
| merge.md Phase 1 | `"104 (verify ledger gate)"` | PR_NUM=104, all gh calls succeed (parenthetical correctly stripped), exit=0 ✓ |
| merge.md Phase 1 | `""` | ERROR diagnostic, no gh calls, exit=0 (graceful fail) ✓ |
| review.md AGENTTEAMS gate | `"104"` | USE_PATH_A flag resolved, exit=0 ✓ |
| brainstorm.md | `"42 (search bar variations)"` | ISSUE_NUM=42, gh issue view 42 succeeds, exit=0 ✓ |
| design.md | `"alternative auth strategies"` (no digits) | ISSUE_NUM= (correctly empty), ls -la project structure, exit=0 ✓ |



---

## Self-review cycle 3 — fix-forward (post-review hardening)

Cycle 2 review (`FLOW_REVIEW_CYCLE:2`) surfaced 13 P2 + 6 P3 findings on the audit-expansion blocks. All addressed in commits `3ecb3a9`..`dd13fe5` across 8 commits:

| Finding | Class | Fix |
|---|---|---|
| F13 | correctness/security | merge.md ledger gate now captures gh exit via `$?` on separate assignment (PIPESTATUS after `$(gh \| jq)` does not capture gh — bash semantics). Consolidates 4 gh calls into 2 cached fetches. |
| S1 | security | merge.md/review.md/address.md `PR_NUM` extraction now digit-validates with all-digit `case` (rejects `"42;evil"` and similar). |
| S2 | security | start.md `ISSUE_NUM` extraction (Phase 0 + Phase 1) now digit-validates the same way. |
| F15 | correctness | brainstorm.md/design.md greedy `grep -oE '[0-9]+'` replaced with all-digit `case` (rejects `"foo42"` → `42` plucking). |
| S5/F7 | security | resolve.md PR Mode Setup now uses `$RESOLVE_TARGET` (safe-set extracted in Phase 0 ! block) instead of raw `$ARGUMENTS`. |
| S3 | security/hardening | merge.md + status.md trust-list parsing now warns when elements fall outside the GitHub `author_association` vocabulary (typo defense). |
| S4 | security/defense-in-depth | status.md findings-ledger drops unused `CAT`/`LOC` fields with `_` so future code addition can't silently interpolate attacker-controlled review-body fields. |
| C1 | docs | review.md/merge.md/resolve.md `argument-hint` widened to `[free-form context]` matching address.md/start.md precedent. |
| C3 | docs | "16 of 16" → "16 of 17" (this PR body). |
| E1–E9 | error-handling | 22 gh calls across 7 commands now suppress stderr with `2>/dev/null` — prevents auth/network errors from leaking into prompt context. |
| E10 | error-handling | merge.md `TRUST_LIST_DISPLAY` fallback now derives from `$TRUST_DEFAULT` constant rather than hard-coding the values. |
| E11 | style | start.md preflight short-circuit chain now has a clarifying comment. |

### Live verification (post-fix)

| Test | ARGUMENTS | Outcome |
|---|---|---|
| merge.md Phase 1 | `"104"` | PR_NUM=104, all gh calls succeed, exit=0 ✓ |
| merge.md Phase 1 | `"104 (verify ledger gate)"` | PR_NUM=104, parenthetical stripped, gh succeeds, exit=0 ✓ |
| merge.md Phase 1 | `"42;evil"` (S1) | ERROR diagnostic, no shell substitution, exit=0 ✓ |
| start.md Phase 0 | `"42;evil"` (S2) | PREFLIGHT FAIL, ISSUE_NUM= empty, exit=0 ✓ |
| brainstorm.md | `"foo42 strategy"` (F15) | ISSUE_NUM= empty (correctly), exit=0 ✓ |
| resolve.md Phase 0 | `"104;evil"` (S5) | RESOLVE_TARGET= empty, exit=0 ✓ |
| resolve.md Phase 0 | `"feature/foo-bar.v2"` (branch name) | RESOLVE_TARGET=feature/foo-bar.v2, exit=0 ✓ |
| merge.md ledger gate | `"104"` (F13) | Captures gh exit via $?, lists unresolved findings, exit=0 ✓ |
| review.md AGENTTEAMS gate | `"104"` | USE_PATH_A resolved deterministically, exit=0 ✓ |
| status.md findings-ledger | (no args) | Tally matches FLOW_REVIEW_CYCLE:2 marker, exit=0 ✓ |

24/24 `!` blocks `bash -n` clean. 11/11 representative smoke tests exit 0 with expected output.

### Final scope

- 28 commits on branch (8 initial + 4 cycle-1 fix-forward + 9 cycle-2 audit-expansion + 8 cycle-3 fix-forward minus 1 docs)
- 11 files touched in cycle 3 (+204/-92 lines)
- 24 `!` blocks across 16 of 17 command files; `setup.md` is excluded for the reason noted above


---

## Structured-output refactor (post-cycle-3, pre-cycle-4)

After cycle-3 hardening, the bash inside `!` blocks worked correctly but the rendered output was inconsistent — some blocks emitted bare lines, some used XML-like tags, others streamed raw `gh --json` output. Mid-session the maintainer asked whether the prompt-load output had enough structure for a fresh-context agent to consume without ambiguity.

Answer: no. So **all 24 `!` blocks across 16 commands were restructured** to a canonical contract codified in a new reference doc `plugins/flow/references/command-output-format.md`:

- Every region leads with a `### Section Name` markdown heading (or `#### Sub-section` for nested data).
- Single-fact data is `KEY=value`; multi-value records are one labeled line each (e.g., `PR=104 state=OPEN review=APPROVED checks=2/2 title="..."`).
- Every empty/error path emits a positive sentinel from a closed vocabulary: `STATE=ok | empty | blocked | unavailable`. No silent empties.
- JSON pre-shaped via `--jq` into labeled records (no raw blob streaming).
- Block always ends with `true` (inherited from `!`-prefix discipline).

Commits `9c369e9`..`78d565a` (4 commits, 17 files changed, **+1323/-377**):

| Commit | Scope |
|---|---|
| `9c369e9` | `/flow:status` — reference implementation (5 sections in block 1, ledger gate in block 2 with `LEDGER_STATE` domain vocabulary) |
| `6c0fa49` | New `references/command-output-format.md` — canonical pattern doc with 8 rules, closed-vocab state table, worked examples, when-to-deviate clause |
| `dfde9ad` | PR-lifecycle commands (`merge.md`, `review.md`, `start.md`, `address.md`, `pr.md`) — 5 files, 10 blocks |
| `78d565a` | Remaining commands (`resolve.md`, `commit.md`, `release.md`, `flow.md`, `brainstorm.md`, `design.md`, `explain.md`, `debug.md`, `learn.md`, `issue.md`) — 10 files, 12 blocks |

24/24 `!` blocks pass `bash -n` after the refactor. Hostile-input tests on every positional-arg command (`ARGUMENTS="42;evil"`) correctly emit `STATE=blocked` + `ERROR=` — cycle-3 security hardening fully preserved across the restructure.

---

## Self-review cycle 4 — fix-forward (structured-output regression sweep)

A comprehensive cycle-4 multi-agent review (`FLOW_REVIEW_CYCLE:4`) on the structured-output refactor surfaced **1 P1 + 4 P2 + 8 P3 regressions** — all introduced BY the restructuring, all in the EMPTY/ERROR paths (the parts hardest to test manually). Fully resolved in commits `5b45823`..`4aa5775` (7 atomic commits):

| Finding | Class | Fix |
|---|---|---|
| C4-1 | correctness (P1) | resolve.md `### Hunks Per Conflicted File` ran the file-listing loop in a pipe-subshell (`git diff \| while … ANY=1`). Parent `ANY` stayed 0, so `STATE=empty` ALWAYS fired even when HUNKS records were emitted (contradictory output). Replaced with here-string iteration in parent shell. |
| C4-2 | correctness (P2) | `COUNT=$(printf '%s\n' "$VAR" \| grep -c '.' \|\| echo "0")` produces multi-line `0\n0` on empty input (grep exits 1, the `\|\|` ALSO fires). Affected commit.md, resolve.md, review.md. Replaced with explicit empty-check + `wc -l`. |
| C4-3 | correctness (P2) | status.md `.reviewDecision // "(none)"` — jq `//` only triggers on `null`, NOT empty string. Same bug cycle-3 fixed in merge.md; never propagated. Applied the merge.md form (`if (.reviewDecision // "") == ""`). |
| C4-4 | correctness (P2) | When gh fails silently (`2>/dev/null`), `JSON=""`. jq 1.8 on empty input produces no output + exit 0, so `\|\| echo "0"` doesn't fire, `COUNT=""`, section silently leaks bare `<KEY>_COUNT=` line. Affected 10 sites across 7 files. Fix: capture `GH_EXIT=$?` separately, emit `STATE=unavailable` for gh failure vs `STATE=empty` for gh-ok-empty. |
| C4-5 | contract (P2) | resolve.md `#### Status filter (UU/UD/AU types)` silent-empty under heading when grep matched nothing. Captured + STATE=empty sentinel. |
| C4-P3-1..8 | contract / efficiency / docs (P3) | UNRESOLVED_COUNT now emits `STATE=unavailable` instead of encoding the sentinel as the value; parenthesized fallback values (`ISSUE_NUM=(none)`, `RESOLVE_TARGET=(none — in-progress merge mode)`, `SINCE=(first release...)`) now double-quoted per Rule 2; silent-empty `git log` / `git diff --stat` sections (release/debug/design/explain/commit/brainstorm) now capture + STATE=empty + KEY= prefix; pr.md double `git status --porcelain` invocation cached; command-output-format.md now documents domain-specific state vocabularies (e.g., `LEDGER_STATE`) as a sanctioned extension, reconciling line 59 with the worked example at 112-130. |

### Cycle-4 verification

| Test | ARGUMENTS | Outcome |
|---|---|---|
| resolve.md Hunks empty | (no conflicts) | `STATE=empty` only — no contradictory output (C4-1) ✓ |
| resolve.md Hunks with files | (simulated) | `HUNKS=file=… count=N`, no `STATE=empty` (C4-1) ✓ |
| status.md PR with empty reviewDecision | (live PR 104) | `review=(none)` correctly (C4-3) ✓ |
| status.md gh failure | `GH_HOST=nonexistent...` | `STATE=unavailable`, distinguished from empty (C4-4) ✓ |
| debug.md empty range | (no commits in HEAD~3..HEAD) | `STATE=empty` (C4-P3-3) ✓ |
| design.md ls labeling | (empty dir) | `ENTRY=` prefix on every `ls -la` row (C4-P3-7) ✓ |
| merge.md hostile arg | `"42;evil"` | `STATE=blocked` + `ERROR=` (cycle-3 intact) ✓ |

### Cumulative ledger

After cycle 4: **39 findings resolved across 4 review-and-address cycles** (F1–F6 + A1–A11 + cycle-3 sweep + C4-1 through C4-P3-8). Zero escalated, zero deferred, one disputed (F15 — git author identity, per maintainer direction). Every P1/P2/P3 either fixed in-PR or applied as Boy Scout cleanup in already-touched files.

### Final scope

- **40 commits on branch** (8 initial + 4 cycle-1 + 9 cycle-2 + 8 cycle-3 + 4 structured-output refactor + 7 cycle-4 fix-forward)
- **17 files modified** (`plugins/flow/commands/*.md` × 16 + `plugins/flow/references/command-output-format.md`)
- **+1190 / -237** vs `main` (per `git diff --stat`)
- **24 `!` blocks** across 16 of 17 command files; `setup.md` is excluded (initialization writes config, not read-only context)
- **100% `bash -n` clean** on the final state
- 0 `Bash` round-trips required for read-only context-gathering in the affected commands (the stated benefit of the refactor)
