### PR TITLE
test(flow): zero-dependency test harness for flow plugin

### DIFF
--- a/.github/workflows/flow-tests.yml
+++ b/.github/workflows/flow-tests.yml
@@ -31,11 +31,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install Python prerequisites
+        # journal-record.test.sh and promote-proposal.test.sh exercise the
+        # PyYAML-using helpers; validate-skill-input.test.sh exercises the
+        # jsonschema fallback. The helper scripts themselves skip-PASS when
+        # PyYAML is absent, but in CI we always want the strict path.
+        run: |
+          python3 --version
+          pip install --quiet pyyaml jsonschema
+
       - name: Verify test prerequisites
         run: |
           bash --version | head -1
           jq --version
           awk --version 2>/dev/null | head -1 || echo "awk: BSD/POSIX (no --version)"
+          python3 -c "import yaml; print('PyYAML', yaml.__version__)"
+          python3 -c "import jsonschema; print('jsonschema', jsonschema.__version__)"
 
       - name: Run flow tests
         run: plugins/flow/tests/run.sh

--- a/.github/workflows/flow-tests.yml
+++ b/.github/workflows/flow-tests.yml
@@ -1,10 +1,11 @@
-name: flow plugin tests
+name: Flow Plugin Tests
 
 on:
   pull_request:
     paths:
       - 'plugins/flow/bin/**'
       - 'plugins/flow/commands/**'
+      - 'plugins/flow/references/**'
       - 'plugins/flow/skills/**'
       - 'plugins/flow/tests/**'
       - '.github/workflows/flow-tests.yml'
@@ -14,6 +15,7 @@ on:
     paths:
       - 'plugins/flow/bin/**'
       - 'plugins/flow/commands/**'
+      - 'plugins/flow/references/**'
       - 'plugins/flow/skills/**'
       - 'plugins/flow/tests/**'
       - '.github/workflows/flow-tests.yml'
@@ -24,6 +26,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/flow-tests.yml
+++ b/.github/workflows/flow-tests.yml
@@ -36,9 +36,24 @@ jobs:
         # PyYAML-using helpers; validate-skill-input.test.sh exercises the
         # jsonschema fallback. The helper scripts themselves skip-PASS when
         # PyYAML is absent, but in CI we always want the strict path.
+        #
+        # Hardening notes:
+        # - `python3 -m pip` guarantees the install targets the same
+        #   interpreter the helpers will use (avoids the case where bare
+        #   `pip` resolves to a different Python on the runner image).
+        # - Versions are pinned to known-good releases so a CI run cannot
+        #   be silently affected by an upstream regression or a hostile
+        #   PyPI release. Bump intentionally when refreshing.
+        # - `--break-system-packages` is defensive against future runner
+        #   images that enforce PEP 668 "externally-managed-environment"
+        #   on the system Python (Ubuntu 24.04+). On current runners the
+        #   flag is a no-op; on PEP 668 systems it preserves the same
+        #   install path without requiring a venv setup step.
         run: |
           python3 --version
-          pip install --quiet pyyaml jsonschema
+          python3 -m pip install --quiet --break-system-packages \
+            'pyyaml==6.0.2' \
+            'jsonschema==4.23.0'
 
       - name: Verify test prerequisites
         run: |

--- a/.github/workflows/flow-tests.yml
+++ b/.github/workflows/flow-tests.yml
@@ -1,0 +1,38 @@
+name: flow plugin tests
+
+on:
+  pull_request:
+    paths:
+      - 'plugins/flow/bin/**'
+      - 'plugins/flow/commands/**'
+      - 'plugins/flow/skills/**'
+      - 'plugins/flow/tests/**'
+      - '.github/workflows/flow-tests.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'plugins/flow/bin/**'
+      - 'plugins/flow/commands/**'
+      - 'plugins/flow/skills/**'
+      - 'plugins/flow/tests/**'
+      - '.github/workflows/flow-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Verify test prerequisites
+        run: |
+          bash --version | head -1
+          jq --version
+          awk --version 2>/dev/null | head -1 || echo "awk: BSD/POSIX (no --version)"
+
+      - name: Run flow tests
+        run: plugins/flow/tests/run.sh

--- a/plugins/flow/tests/cascade-resolve.test.sh
+++ b/plugins/flow/tests/cascade-resolve.test.sh
@@ -9,22 +9,57 @@
 #     expression, unknown flag).
 #   - Per-source jq parse error → stderr WARN + skip + continue (not abort).
 #
-# Each test sets up an isolated CASCADE_DIR via mktemp, prepends it to the
-# search by pointing CLAUDE_PLUGIN_ROOT and overriding HOME, then asserts on
-# stdout/stderr/exit. Cleanup is via trap so a failed assertion doesn't
-# leak temp dirs.
+# Each test sets up an isolated scratch dir, runs assertions, and relies on
+# the file-level cleanup trap to remove temp resources. Cleanup paths are
+# registered in CLEANUP_PATHS; a single trap removes everything. Previously
+# the trap was rewritten mid-file to cover newly-allocated SHADOW dirs, which
+# was fragile — any third resource would have been silently leaked.
 
 HELPER="$REPO_ROOT/plugins/flow/bin/cascade-resolve.sh"
 
-# Single shared scratch root for all tests. Each test creates its own
-# subdirectory inside it so isolation is per-test.
-SCRATCH_ROOT=$(mktemp -d -t cascade-resolve.tests.XXXXXX)
-trap 'rm -rf "$SCRATCH_ROOT"' EXIT
+# Cleanup contract: every mktemp dir/file allocated by this test file is
+# appended to CLEANUP_PATHS; the EXIT trap removes them all at file end.
+# `${VAR:-}` guards each entry so an interrupted mid-allocation leaves a
+# coherent state for the trap.
+CLEANUP_PATHS=()
+_cleanup_all() {
+  local p
+  for p in "${CLEANUP_PATHS[@]:-}"; do
+    [ -n "$p" ] && rm -rf "$p" 2>/dev/null
+  done
+}
+trap _cleanup_all EXIT
 
+# Defensive mktemp wrapper: empty SCRATCH_ROOT would later cascade into
+# `mkdir -p "/.claude"` at filesystem root, which is exactly the kind of
+# pathological failure the harness should never produce. Fail fast instead.
+_mktemp_or_die() {
+  local kind="$1"; shift
+  local out
+  out=$(mktemp "$@" 2>/dev/null)
+  if [ -z "$out" ] || [ ! -e "$out" ]; then
+    echo "cascade-resolve.test.sh: mktemp failed for $kind" >&2
+    exit 2
+  fi
+  CLEANUP_PATHS+=("$out")
+  printf '%s' "$out"
+}
+
+SCRATCH_ROOT=$(_mktemp_or_die "SCRATCH_ROOT" -d -t cascade-resolve.tests.XXXXXX)
+
+# Each test creates its own subdirectory inside SCRATCH_ROOT. Per-test dirs
+# don't need separate CLEANUP_PATHS entries — they're under SCRATCH_ROOT,
+# which the trap recursively removes.
 _make_scratch() {
   local name="$1"
   local dir="$SCRATCH_ROOT/$name"
-  mkdir -p "$dir/.claude" "$dir/plugins/flow"
+  # Pre-build the four-tier layout. HOME points to "$dir/home" (not "$dir")
+  # so user-tier settings resolve to a path distinct from project-tier.
+  # Previously HOME=. plus pwd=$dir made USER_SETTINGS=./.claude/settings.flow.json
+  # which is the SAME path as PROJECT_SETTINGS — the precedence test silently
+  # tested "local > project > (project again, masquerading as user) > plugin"
+  # rather than the real 4-tier chain.
+  mkdir -p "$dir/.claude" "$dir/plugins/flow" "$dir/home/.claude"
   printf '%s\n' "$dir"
 }
 
@@ -32,42 +67,39 @@ _make_scratch() {
 _flow_test_begin "precedence: local > project > user > plugin"
 DIR=$(_make_scratch precedence)
 echo '{"journal": {"dir": "from-plugin"}}'  > "$DIR/plugins/flow/settings.json"
-echo '{"journal": {"dir": "from-user"}}'    > "$DIR/user-settings.json"
+echo '{"journal": {"dir": "from-user"}}'    > "$DIR/home/.claude/settings.flow.json"
 echo '{"journal": {"dir": "from-project"}}' > "$DIR/.claude/settings.flow.json"
 echo '{"journal": {"dir": "from-local"}}'   > "$DIR/.claude/settings.flow.local.json"
-(
-  cd "$DIR"
-  HOME=. CLAUDE_PLUGIN_ROOT="plugins/flow" \
-    "$HELPER" '.journal.dir // empty' 2>/dev/null
-) > "$DIR/out.txt"
-EXIT=$?
-OUT=$(cat "$DIR/out.txt")
-assert_equal "from-local" "$OUT" "local wins"
-assert_exit 0 "$EXIT" "exit 0"
 
-# Remove local; project wins.
+# All four tiers present → local wins.
+OUT=$(cd "$DIR" && HOME="$DIR/home" CLAUDE_PLUGIN_ROOT="plugins/flow" \
+  "$HELPER" '.journal.dir // empty' 2>/dev/null)
+assert_equal "from-local" "$OUT" "local wins"
+
+# Remove local → project wins.
 rm "$DIR/.claude/settings.flow.local.json"
-OUT=$(cd "$DIR" && HOME=. CLAUDE_PLUGIN_ROOT="plugins/flow" "$HELPER" '.journal.dir // empty' 2>/dev/null)
+OUT=$(cd "$DIR" && HOME="$DIR/home" CLAUDE_PLUGIN_ROOT="plugins/flow" \
+  "$HELPER" '.journal.dir // empty' 2>/dev/null)
 assert_equal "from-project" "$OUT" "project wins after local removed"
 
-# Remove project; user wins. HOME points to the test dir; user settings live
-# at $HOME/.claude/settings.flow.json.
+# Remove project → user wins (now reading a genuinely distinct file at
+# $DIR/home/.claude/settings.flow.json, not the project path).
 rm "$DIR/.claude/settings.flow.json"
-mkdir -p "$DIR/home/.claude"
-echo '{"journal": {"dir": "from-user"}}' > "$DIR/home/.claude/settings.flow.json"
-OUT=$(cd "$DIR" && HOME="$DIR/home" CLAUDE_PLUGIN_ROOT="plugins/flow" "$HELPER" '.journal.dir // empty' 2>/dev/null)
+OUT=$(cd "$DIR" && HOME="$DIR/home" CLAUDE_PLUGIN_ROOT="plugins/flow" \
+  "$HELPER" '.journal.dir // empty' 2>/dev/null)
 assert_equal "from-user" "$OUT" "user wins after project removed"
 
-# Remove user; plugin wins.
+# Remove user → plugin wins.
 rm "$DIR/home/.claude/settings.flow.json"
-OUT=$(cd "$DIR" && HOME="$DIR/home" CLAUDE_PLUGIN_ROOT="plugins/flow" "$HELPER" '.journal.dir // empty' 2>/dev/null)
+OUT=$(cd "$DIR" && HOME="$DIR/home" CLAUDE_PLUGIN_ROOT="plugins/flow" \
+  "$HELPER" '.journal.dir // empty' 2>/dev/null)
 assert_equal "from-plugin" "$OUT" "plugin wins after user removed"
 
 # --- Test 2: --default fallback when nothing resolves
 _flow_test_begin "default fallback when no source has key"
 DIR=$(_make_scratch default)
 echo '{"unrelated": true}' > "$DIR/plugins/flow/settings.json"
-OUT=$(cd "$DIR" && HOME="$DIR" CLAUDE_PLUGIN_ROOT="plugins/flow" \
+OUT=$(cd "$DIR" && HOME="$DIR/home" CLAUDE_PLUGIN_ROOT="plugins/flow" \
   "$HELPER" --default ".decisions" '.journal.dir // empty' 2>/dev/null)
 EXIT=$?
 assert_equal ".decisions" "$OUT" "default emitted"
@@ -77,7 +109,7 @@ assert_exit 0 "$EXIT" "default exits 0"
 _flow_test_begin "no default, no resolution → empty stdout exit 0"
 DIR=$(_make_scratch nodefault)
 echo '{}' > "$DIR/plugins/flow/settings.json"
-OUT=$(cd "$DIR" && HOME="$DIR" CLAUDE_PLUGIN_ROOT="plugins/flow" \
+OUT=$(cd "$DIR" && HOME="$DIR/home" CLAUDE_PLUGIN_ROOT="plugins/flow" \
   "$HELPER" '.journal.dir // empty' 2>/dev/null)
 EXIT=$?
 assert_equal "" "$OUT" "empty stdout"
@@ -87,8 +119,8 @@ assert_exit 0 "$EXIT" "exit 0"
 _flow_test_begin "--compact preserves JSON quoting"
 DIR=$(_make_scratch compact)
 echo '{"k": "v"}' > "$DIR/plugins/flow/settings.json"
-RAW=$(cd "$DIR" && HOME="$DIR" CLAUDE_PLUGIN_ROOT="plugins/flow" "$HELPER" '.k' 2>/dev/null)
-CMP=$(cd "$DIR" && HOME="$DIR" CLAUDE_PLUGIN_ROOT="plugins/flow" "$HELPER" --compact '.k' 2>/dev/null)
+RAW=$(cd "$DIR" && HOME="$DIR/home" CLAUDE_PLUGIN_ROOT="plugins/flow" "$HELPER" '.k' 2>/dev/null)
+CMP=$(cd "$DIR" && HOME="$DIR/home" CLAUDE_PLUGIN_ROOT="plugins/flow" "$HELPER" --compact '.k' 2>/dev/null)
 # jq -r drops the surrounding double-quotes; jq -c preserves them.
 assert_equal "v" "$RAW" "raw mode strips quotes"
 assert_equal '"v"' "$CMP" "compact mode preserves quotes"
@@ -114,56 +146,56 @@ _flow_test_begin "parse error per-source → WARN + skip + continue"
 DIR=$(_make_scratch parse_err)
 echo '{not valid json' > "$DIR/.claude/settings.flow.json"
 echo '{"journal": {"dir": "from-plugin"}}' > "$DIR/plugins/flow/settings.json"
-STDOUT_TMP=$(mktemp -t cascade.so.XXXXXX)
-STDERR_TMP=$(mktemp -t cascade.se.XXXXXX)
-(cd "$DIR" && HOME="$DIR" CLAUDE_PLUGIN_ROOT="plugins/flow" \
+STDOUT_TMP=$(_mktemp_or_die "STDOUT_TMP" -t cascade.so.XXXXXX)
+STDERR_TMP=$(_mktemp_or_die "STDERR_TMP" -t cascade.se.XXXXXX)
+(cd "$DIR" && HOME="$DIR/home" CLAUDE_PLUGIN_ROOT="plugins/flow" \
   "$HELPER" '.journal.dir // empty' >"$STDOUT_TMP" 2>"$STDERR_TMP")
 EXIT=$?
 OUT=$(cat "$STDOUT_TMP"); ERR=$(cat "$STDERR_TMP")
-rm -f "$STDOUT_TMP" "$STDERR_TMP"
 assert_equal "from-plugin" "$OUT" "fell through to plugin"
 assert_exit 0 "$EXIT" "exit 0 despite bad JSON"
 assert_contains "WARN: failed to parse" "$ERR" "stderr WARN was emitted"
 assert_contains "settings.flow.json" "$ERR" "WARN names the failing source"
 
-# --- Test 8: --default emits even when jq is missing (graceful degrade)
-# We need a PATH that finds /bin/bash and the POSIX utils the helper uses
-# (mktemp, tr, cut, rm) but NOT jq. macOS Sequoia ships jq in /usr/bin and
-# Homebrew puts it in /opt/homebrew/bin or /usr/local/bin, so neither /bin
-# nor /usr/bin is safe to pass through. Build a shadow PATH with symlinks
-# to every needed tool except jq — portable across macOS and CI runners.
-SHADOW=$(mktemp -d -t cascade.shadow.XXXXXX)
+# --- Tests 8 + 9: jq-missing graceful degrade
+# Construct a shadow PATH containing every needed tool EXCEPT jq. macOS
+# Sequoia ships jq in /usr/bin and Homebrew puts it in /opt/homebrew/bin or
+# /usr/local/bin, so neither /bin nor /usr/bin is safe to pass through.
+# Symlinks are created under a mktemp dir (0700 mode by default — a
+# co-tenant cannot inject a fake jq).
+SHADOW=$(_mktemp_or_die "SHADOW" -d -t cascade.shadow.XXXXXX)
 for tool in bash mktemp tr cut rm sh env cat; do
   T=$(command -v "$tool" 2>/dev/null) || continue
   ln -s "$T" "$SHADOW/$tool"
 done
-NO_JQ_PATH="$SHADOW"
-trap 'rm -rf "$SCRATCH_ROOT" "$SHADOW"' EXIT
+# Sanity-check the shadow was built. If `command -v bash` somehow returned
+# nothing, the helper invocations below would error opaquely.
+if [ ! -L "$SHADOW/bash" ]; then
+  echo "cascade-resolve.test.sh: shadow PATH missing bash symlink" >&2
+  exit 2
+fi
 
 _flow_test_begin "jq missing + --default → emit default, exit 0"
 DIR=$(_make_scratch nojq)
 echo '{"k": "v"}' > "$DIR/plugins/flow/settings.json"
-STDOUT_TMP=$(mktemp -t cascade.nojq.so.XXXXXX)
-STDERR_TMP=$(mktemp -t cascade.nojq.se.XXXXXX)
-(cd "$DIR" && HOME="$DIR" CLAUDE_PLUGIN_ROOT="plugins/flow" PATH="$NO_JQ_PATH" \
-  /bin/bash "$HELPER" --default "fallback" '.k' \
+STDOUT_TMP=$(_mktemp_or_die "STDOUT_TMP_NOJQ1" -t cascade.nojq.so.XXXXXX)
+STDERR_TMP=$(_mktemp_or_die "STDERR_TMP_NOJQ1" -t cascade.nojq.se.XXXXXX)
+(cd "$DIR" && HOME="$DIR/home" CLAUDE_PLUGIN_ROOT="plugins/flow" PATH="$SHADOW" \
+  "$SHADOW/bash" "$HELPER" --default "fallback" '.k' \
   >"$STDOUT_TMP" 2>"$STDERR_TMP")
 EXIT=$?
 OUT=$(cat "$STDOUT_TMP"); ERR=$(cat "$STDERR_TMP")
-rm -f "$STDOUT_TMP" "$STDERR_TMP"
 assert_equal "fallback" "$OUT" "default emitted on stdout"
 assert_exit 0 "$EXIT" "exit 0 with --default"
 assert_contains "jq not installed" "$ERR" "stderr WARN about missing jq"
 
-# --- Test 9: jq missing + no --default → exit 2
 _flow_test_begin "jq missing + no default → exit 2"
 DIR=$(_make_scratch nojq2)
 echo '{"k": "v"}' > "$DIR/plugins/flow/settings.json"
-STDERR_TMP=$(mktemp -t cascade.nojq2.se.XXXXXX)
-(cd "$DIR" && HOME="$DIR" CLAUDE_PLUGIN_ROOT="plugins/flow" PATH="$NO_JQ_PATH" \
-  /bin/bash "$HELPER" '.k' 2>"$STDERR_TMP")
+STDERR_TMP=$(_mktemp_or_die "STDERR_TMP_NOJQ2" -t cascade.nojq2.se.XXXXXX)
+(cd "$DIR" && HOME="$DIR/home" CLAUDE_PLUGIN_ROOT="plugins/flow" PATH="$SHADOW" \
+  "$SHADOW/bash" "$HELPER" '.k' 2>"$STDERR_TMP")
 EXIT=$?
 ERR=$(cat "$STDERR_TMP")
-rm -f "$STDERR_TMP"
 assert_exit 2 "$EXIT" "exit 2 without --default"
 assert_contains "jq not installed" "$ERR" "stderr WARN about missing jq"

--- a/plugins/flow/tests/cascade-resolve.test.sh
+++ b/plugins/flow/tests/cascade-resolve.test.sh
@@ -33,12 +33,22 @@ trap _cleanup_all EXIT
 # Defensive mktemp wrapper: empty SCRATCH_ROOT would later cascade into
 # `mkdir -p "/.claude"` at filesystem root, which is exactly the kind of
 # pathological failure the harness should never produce. Fail fast instead.
+#
+# Important: callers invoke this via `DIR=$(_mktemp_or_die ...)` — command
+# substitution runs the function in a SUBSHELL. A bare `exit 2` from inside
+# would only kill the subshell, leaving the caller with DIR="" and the test
+# continuing against the wrong paths. We `kill -INT $$` to deliver SIGINT to
+# the OUTER shell process (the sourced test), which run.sh's per-file
+# subshell will then propagate as a non-zero exit, surfaced as "no SUMMARY
+# line" by the runner. The `exit 2` after `kill` is belt-and-suspenders for
+# the unlikely case where SIGINT is masked.
 _mktemp_or_die() {
   local kind="$1"; shift
   local out
   out=$(mktemp "$@" 2>/dev/null)
   if [ -z "$out" ] || [ ! -e "$out" ]; then
     echo "cascade-resolve.test.sh: mktemp failed for $kind" >&2
+    kill -INT $$ 2>/dev/null
     exit 2
   fi
   CLEANUP_PATHS+=("$out")

--- a/plugins/flow/tests/cascade-resolve.test.sh
+++ b/plugins/flow/tests/cascade-resolve.test.sh
@@ -1,0 +1,169 @@
+# Tests for plugins/flow/bin/cascade-resolve.sh.
+#
+# Contract under test (from cascade-resolve.sh header):
+#   - Resolves a jq expression against four settings sources in precedence
+#     order: local > project > user > plugin.
+#   - --default fallback when no source resolves a non-empty value.
+#   - --compact preserves JSON quoting (uses jq -c instead of jq -r).
+#   - Exit 2 on infrastructure errors (jq missing without --default, missing
+#     expression, unknown flag).
+#   - Per-source jq parse error → stderr WARN + skip + continue (not abort).
+#
+# Each test sets up an isolated CASCADE_DIR via mktemp, prepends it to the
+# search by pointing CLAUDE_PLUGIN_ROOT and overriding HOME, then asserts on
+# stdout/stderr/exit. Cleanup is via trap so a failed assertion doesn't
+# leak temp dirs.
+
+HELPER="$REPO_ROOT/plugins/flow/bin/cascade-resolve.sh"
+
+# Single shared scratch root for all tests. Each test creates its own
+# subdirectory inside it so isolation is per-test.
+SCRATCH_ROOT=$(mktemp -d -t cascade-resolve.tests.XXXXXX)
+trap 'rm -rf "$SCRATCH_ROOT"' EXIT
+
+_make_scratch() {
+  local name="$1"
+  local dir="$SCRATCH_ROOT/$name"
+  mkdir -p "$dir/.claude" "$dir/plugins/flow"
+  printf '%s\n' "$dir"
+}
+
+# --- Test 1: precedence — local beats project beats user beats plugin
+_flow_test_begin "precedence: local > project > user > plugin"
+DIR=$(_make_scratch precedence)
+echo '{"journal": {"dir": "from-plugin"}}'  > "$DIR/plugins/flow/settings.json"
+echo '{"journal": {"dir": "from-user"}}'    > "$DIR/user-settings.json"
+echo '{"journal": {"dir": "from-project"}}' > "$DIR/.claude/settings.flow.json"
+echo '{"journal": {"dir": "from-local"}}'   > "$DIR/.claude/settings.flow.local.json"
+(
+  cd "$DIR"
+  HOME=. CLAUDE_PLUGIN_ROOT="plugins/flow" \
+    "$HELPER" '.journal.dir // empty' 2>/dev/null
+) > "$DIR/out.txt"
+EXIT=$?
+OUT=$(cat "$DIR/out.txt")
+assert_equal "from-local" "$OUT" "local wins"
+assert_exit 0 "$EXIT" "exit 0"
+
+# Remove local; project wins.
+rm "$DIR/.claude/settings.flow.local.json"
+OUT=$(cd "$DIR" && HOME=. CLAUDE_PLUGIN_ROOT="plugins/flow" "$HELPER" '.journal.dir // empty' 2>/dev/null)
+assert_equal "from-project" "$OUT" "project wins after local removed"
+
+# Remove project; user wins. HOME points to the test dir; user settings live
+# at $HOME/.claude/settings.flow.json.
+rm "$DIR/.claude/settings.flow.json"
+mkdir -p "$DIR/home/.claude"
+echo '{"journal": {"dir": "from-user"}}' > "$DIR/home/.claude/settings.flow.json"
+OUT=$(cd "$DIR" && HOME="$DIR/home" CLAUDE_PLUGIN_ROOT="plugins/flow" "$HELPER" '.journal.dir // empty' 2>/dev/null)
+assert_equal "from-user" "$OUT" "user wins after project removed"
+
+# Remove user; plugin wins.
+rm "$DIR/home/.claude/settings.flow.json"
+OUT=$(cd "$DIR" && HOME="$DIR/home" CLAUDE_PLUGIN_ROOT="plugins/flow" "$HELPER" '.journal.dir // empty' 2>/dev/null)
+assert_equal "from-plugin" "$OUT" "plugin wins after user removed"
+
+# --- Test 2: --default fallback when nothing resolves
+_flow_test_begin "default fallback when no source has key"
+DIR=$(_make_scratch default)
+echo '{"unrelated": true}' > "$DIR/plugins/flow/settings.json"
+OUT=$(cd "$DIR" && HOME="$DIR" CLAUDE_PLUGIN_ROOT="plugins/flow" \
+  "$HELPER" --default ".decisions" '.journal.dir // empty' 2>/dev/null)
+EXIT=$?
+assert_equal ".decisions" "$OUT" "default emitted"
+assert_exit 0 "$EXIT" "default exits 0"
+
+# --- Test 3: no default + no resolution → empty stdout + exit 0
+_flow_test_begin "no default, no resolution → empty stdout exit 0"
+DIR=$(_make_scratch nodefault)
+echo '{}' > "$DIR/plugins/flow/settings.json"
+OUT=$(cd "$DIR" && HOME="$DIR" CLAUDE_PLUGIN_ROOT="plugins/flow" \
+  "$HELPER" '.journal.dir // empty' 2>/dev/null)
+EXIT=$?
+assert_equal "" "$OUT" "empty stdout"
+assert_exit 0 "$EXIT" "exit 0"
+
+# --- Test 4: --compact preserves JSON quoting
+_flow_test_begin "--compact preserves JSON quoting"
+DIR=$(_make_scratch compact)
+echo '{"k": "v"}' > "$DIR/plugins/flow/settings.json"
+RAW=$(cd "$DIR" && HOME="$DIR" CLAUDE_PLUGIN_ROOT="plugins/flow" "$HELPER" '.k' 2>/dev/null)
+CMP=$(cd "$DIR" && HOME="$DIR" CLAUDE_PLUGIN_ROOT="plugins/flow" "$HELPER" --compact '.k' 2>/dev/null)
+# jq -r drops the surrounding double-quotes; jq -c preserves them.
+assert_equal "v" "$RAW" "raw mode strips quotes"
+assert_equal '"v"' "$CMP" "compact mode preserves quotes"
+
+# --- Test 5: missing expression → exit 2
+_flow_test_begin "missing expression → exit 2"
+OUT=$(cd "$SCRATCH_ROOT" && HOME="$SCRATCH_ROOT" "$HELPER" 2>&1)
+EXIT=$?
+assert_exit 2 "$EXIT" "exit 2"
+assert_contains "missing <jq-expression>" "$OUT" "stderr names the problem"
+
+# --- Test 6: unknown flag → exit 2
+_flow_test_begin "unknown flag → exit 2"
+OUT=$(cd "$SCRATCH_ROOT" && HOME="$SCRATCH_ROOT" "$HELPER" --bogus '.x' 2>&1)
+EXIT=$?
+assert_exit 2 "$EXIT" "exit 2"
+assert_contains "unknown flag" "$OUT" "stderr names the unknown flag"
+
+# --- Test 7: per-source parse error → stderr WARN + skip + continue
+# Project has a syntax-broken JSON; plugin has the correct value. Helper
+# should WARN about the project, skip it, and resolve from plugin.
+_flow_test_begin "parse error per-source → WARN + skip + continue"
+DIR=$(_make_scratch parse_err)
+echo '{not valid json' > "$DIR/.claude/settings.flow.json"
+echo '{"journal": {"dir": "from-plugin"}}' > "$DIR/plugins/flow/settings.json"
+STDOUT_TMP=$(mktemp -t cascade.so.XXXXXX)
+STDERR_TMP=$(mktemp -t cascade.se.XXXXXX)
+(cd "$DIR" && HOME="$DIR" CLAUDE_PLUGIN_ROOT="plugins/flow" \
+  "$HELPER" '.journal.dir // empty' >"$STDOUT_TMP" 2>"$STDERR_TMP")
+EXIT=$?
+OUT=$(cat "$STDOUT_TMP"); ERR=$(cat "$STDERR_TMP")
+rm -f "$STDOUT_TMP" "$STDERR_TMP"
+assert_equal "from-plugin" "$OUT" "fell through to plugin"
+assert_exit 0 "$EXIT" "exit 0 despite bad JSON"
+assert_contains "WARN: failed to parse" "$ERR" "stderr WARN was emitted"
+assert_contains "settings.flow.json" "$ERR" "WARN names the failing source"
+
+# --- Test 8: --default emits even when jq is missing (graceful degrade)
+# We need a PATH that finds /bin/bash and the POSIX utils the helper uses
+# (mktemp, tr, cut, rm) but NOT jq. macOS Sequoia ships jq in /usr/bin and
+# Homebrew puts it in /opt/homebrew/bin or /usr/local/bin, so neither /bin
+# nor /usr/bin is safe to pass through. Build a shadow PATH with symlinks
+# to every needed tool except jq — portable across macOS and CI runners.
+SHADOW=$(mktemp -d -t cascade.shadow.XXXXXX)
+for tool in bash mktemp tr cut rm sh env cat; do
+  T=$(command -v "$tool" 2>/dev/null) || continue
+  ln -s "$T" "$SHADOW/$tool"
+done
+NO_JQ_PATH="$SHADOW"
+trap 'rm -rf "$SCRATCH_ROOT" "$SHADOW"' EXIT
+
+_flow_test_begin "jq missing + --default → emit default, exit 0"
+DIR=$(_make_scratch nojq)
+echo '{"k": "v"}' > "$DIR/plugins/flow/settings.json"
+STDOUT_TMP=$(mktemp -t cascade.nojq.so.XXXXXX)
+STDERR_TMP=$(mktemp -t cascade.nojq.se.XXXXXX)
+(cd "$DIR" && HOME="$DIR" CLAUDE_PLUGIN_ROOT="plugins/flow" PATH="$NO_JQ_PATH" \
+  /bin/bash "$HELPER" --default "fallback" '.k' \
+  >"$STDOUT_TMP" 2>"$STDERR_TMP")
+EXIT=$?
+OUT=$(cat "$STDOUT_TMP"); ERR=$(cat "$STDERR_TMP")
+rm -f "$STDOUT_TMP" "$STDERR_TMP"
+assert_equal "fallback" "$OUT" "default emitted on stdout"
+assert_exit 0 "$EXIT" "exit 0 with --default"
+assert_contains "jq not installed" "$ERR" "stderr WARN about missing jq"
+
+# --- Test 9: jq missing + no --default → exit 2
+_flow_test_begin "jq missing + no default → exit 2"
+DIR=$(_make_scratch nojq2)
+echo '{"k": "v"}' > "$DIR/plugins/flow/settings.json"
+STDERR_TMP=$(mktemp -t cascade.nojq2.se.XXXXXX)
+(cd "$DIR" && HOME="$DIR" CLAUDE_PLUGIN_ROOT="plugins/flow" PATH="$NO_JQ_PATH" \
+  /bin/bash "$HELPER" '.k' 2>"$STDERR_TMP")
+EXIT=$?
+ERR=$(cat "$STDERR_TMP")
+rm -f "$STDERR_TMP"
+assert_exit 2 "$EXIT" "exit 2 without --default"
+assert_contains "jq not installed" "$ERR" "stderr WARN about missing jq"

--- a/plugins/flow/tests/command-frontmatter.test.sh
+++ b/plugins/flow/tests/command-frontmatter.test.sh
@@ -1,0 +1,192 @@
+# Static lint over plugins/flow/commands/*.md.
+#
+# What this catches (regression-of-record from PR #103 / PR #104 review cycles):
+#   - F3:  `!` block missing trailing `true` (start.md Phase 1 was the original miss)
+#   - C4-*: `!` block silently exits non-zero from a trailing pipeline
+#   - F2/F6: $ARGUMENTS interpolated into an `!` block without quoting/validation
+#   - C1:  `allowed-tools` Bash() pattern that no body invocation actually matches
+#   - Required Skills entry that doesn't resolve to a plugins/flow/skills/<name>/ dir
+#   - destructive shell commands inside an `!` block (! blocks are read-only context)
+#
+# Approach: parse each command file once into an in-memory representation
+# (frontmatter block + body + per-`!`-block bodies), then run each lint rule
+# against that representation. The block extractor uses awk for portability
+# (BSD/GNU awk both work).
+
+COMMANDS_DIR="$REPO_ROOT/plugins/flow/commands"
+SKILLS_DIR="$REPO_ROOT/plugins/flow/skills"
+
+# --- Test 1: every `!` block ends with `true`
+# Extract each `!` block's body (everything between ```! and the next ```),
+# strip trailing blanks, and assert the last meaningful line is exactly `true`.
+_flow_test_begin "every ! block ends with explicit 'true'"
+for FILE in "$COMMANDS_DIR"/*.md; do
+  CMD=$(basename "$FILE" .md)
+  # awk extracts ! blocks; emits one block per "BLOCK_START" / "BLOCK_END"
+  # delimited section. The block-index is appended so we can name failures.
+  BLOCKS=$(awk '
+    /^```!$/ { in_block=1; idx++; print "BLOCK_START " idx; next }
+    /^```$/ && in_block { in_block=0; print "BLOCK_END " idx; next }
+    in_block { print }
+  ' "$FILE")
+  [ -z "$BLOCKS" ] && continue
+
+  # Walk the awk output: for each block, capture lines and check the last
+  # non-blank line equals `true`.
+  CURRENT_BLOCK=""
+  CURRENT_IDX=""
+  while IFS= read -r LINE; do
+    case "$LINE" in
+      "BLOCK_START "*)
+        CURRENT_BLOCK=""
+        CURRENT_IDX="${LINE#BLOCK_START }"
+        ;;
+      "BLOCK_END "*)
+        # Strip trailing blank lines; check last is `true`.
+        LAST_NONBLANK=$(printf '%s' "$CURRENT_BLOCK" | awk 'NF { last=$0 } END { print last }')
+        if [ "$LAST_NONBLANK" != "true" ]; then
+          _flow_assert_fail "$CMD.md ! block #$CURRENT_IDX last line is '$LAST_NONBLANK', expected 'true'"
+        fi
+        CURRENT_BLOCK=""
+        ;;
+      *)
+        if [ -z "$CURRENT_BLOCK" ]; then
+          CURRENT_BLOCK="$LINE"
+        else
+          CURRENT_BLOCK=$(printf '%s\n%s' "$CURRENT_BLOCK" "$LINE")
+        fi
+        ;;
+    esac
+  done <<< "$BLOCKS"
+done
+# Single PASS marker covers all 16 commands when no fail fired.
+[ "$FLOW_TEST_FAIL" = "0" ] && _flow_assert_pass "all ! blocks across $(ls "$COMMANDS_DIR"/*.md | wc -l | tr -d ' ') commands end with 'true'"
+
+# --- Test 2: no destructive commands inside ! blocks
+# ! blocks are read-only context gatherers. Destructive verbs anywhere inside
+# (even commented) are a code smell at minimum and a footgun if uncommented.
+# We grep for verbs in word boundaries to avoid false positives in variable
+# names or substrings.
+_flow_test_begin "no destructive verbs inside ! blocks"
+PASS=1
+PROHIBITED='rm -rf|rm -f|rm[[:space:]]+-r|git[[:space:]]+push|git[[:space:]]+reset[[:space:]]+--hard|gh[[:space:]]+pr[[:space:]]+merge|gh[[:space:]]+pr[[:space:]]+close|gh[[:space:]]+release[[:space:]]+create|gh[[:space:]]+release[[:space:]]+delete|git[[:space:]]+tag[[:space:]]+-d|git[[:space:]]+branch[[:space:]]+-D'
+for FILE in "$COMMANDS_DIR"/*.md; do
+  CMD=$(basename "$FILE" .md)
+  # Extract block bodies (drop the BLOCK_START/END markers) and grep on them.
+  awk '
+    /^```!$/ { in_block=1; idx++; print "BLOCK_START " idx; next }
+    /^```$/ && in_block { in_block=0; print "BLOCK_END " idx; next }
+    in_block { print }
+  ' "$FILE" | grep -nE "$PROHIBITED" > /tmp/flow_dest_match.$$ 2>/dev/null || true
+  if [ -s /tmp/flow_dest_match.$$ ]; then
+    HITS=$(cat /tmp/flow_dest_match.$$)
+    _flow_assert_fail "$CMD.md contains destructive verb inside ! block: $HITS"
+    PASS=0
+  fi
+  rm -f /tmp/flow_dest_match.$$
+done
+[ "$PASS" = "1" ] && _flow_assert_pass "no destructive verbs in any ! block"
+
+# --- Test 3: $ARGUMENTS inside ! blocks is quoted or extracted via case
+# Acceptable forms inside an ! block:
+#   - "$ARGUMENTS"           (double-quoted scalar)
+#   - "${ARGUMENTS%% *}"     (first-token extraction; the case-validated form)
+#   - assigned to a var then used: ARG1="${ARGUMENTS%% *}"; then "$ARG1"
+# Unacceptable: bare $ARGUMENTS (word-split + glob risk).
+_flow_test_begin "\$ARGUMENTS in ! blocks is quoted or extracted"
+PASS=1
+for FILE in "$COMMANDS_DIR"/*.md; do
+  CMD=$(basename "$FILE" .md)
+  BODY=$(awk '
+    /^```!$/ { in_block=1; next }
+    /^```$/ && in_block { in_block=0; next }
+    in_block { print }
+  ' "$FILE")
+  [ -z "$BODY" ] && continue
+  # Look for any $ARGUMENTS occurrence that is NOT preceded by a quote-or-brace.
+  # Simplest robust check: bare \$ARGUMENTS appearing anywhere flags as fail.
+  # The accepted forms always have `{` or `"` immediately before ARGUMENTS:
+  #   "${ARGUMENTS...    "$ARGUMENTS"    ${ARGUMENTS  (inside other quoting)
+  # Bare $ARGUMENTS (no `{` immediately after `$`, no `"` before `$`) is the
+  # vulnerable form.
+  BAD=$(printf '%s\n' "$BODY" | grep -nE '(^|[^"\$])\$ARGUMENTS([^a-zA-Z_]|$)' || true)
+  if [ -n "$BAD" ]; then
+    _flow_assert_fail "$CMD.md has bare \$ARGUMENTS in ! block: $BAD"
+    PASS=0
+  fi
+done
+[ "$PASS" = "1" ] && _flow_assert_pass "all \$ARGUMENTS uses in ! blocks are quoted/extracted"
+
+# --- Test 4: Required Skills entries resolve to plugins/flow/skills/<name>/
+# Each command's "## Required Skills" section lists `- skill-name` bullets;
+# every name must correspond to an existing skills/ directory.
+_flow_test_begin "Required Skills entries resolve to skills/ directories"
+PASS=1
+for FILE in "$COMMANDS_DIR"/*.md; do
+  CMD=$(basename "$FILE" .md)
+  # Extract the Required Skills section: from "## Required Skills" up to the
+  # next "##" heading. Then grab the leading-token of each "- name" or
+  # "- `name`" bullet line.
+  SKILLS=$(awk '
+    /^## Required Skills/ { in_section=1; next }
+    /^## / && in_section { in_section=0 }
+    in_section && /^- / { print }
+  ' "$FILE" | sed -E 's/^- *`?([a-zA-Z0-9_-]+)`?.*/\1/' | grep -v '^_' | grep -v '^$')
+  [ -z "$SKILLS" ] && continue
+  while IFS= read -r SKILL; do
+    [ -z "$SKILL" ] && continue
+    # Permit two forms: `skills/<skill>/` or `skills/<skill>/SKILL.md`.
+    if [ ! -d "$SKILLS_DIR/$SKILL" ] && [ ! -f "$SKILLS_DIR/$SKILL/SKILL.md" ]; then
+      _flow_assert_fail "$CMD.md Required Skills references '$SKILL' but $SKILLS_DIR/$SKILL/ does not exist"
+      PASS=0
+    fi
+  done <<< "$SKILLS"
+done
+[ "$PASS" = "1" ] && _flow_assert_pass "all Required Skills references resolve"
+
+# --- Test 5: allowed-tools Bash(...) patterns have at least one matching body invocation
+# Frontmatter pattern: `Bash(<command-prefix>:*)`. For the literal-prefix form
+# we extract the prefix and assert the body contains it somewhere. Glob forms
+# (Bash(*) or Bash(:*)) are skipped — they match everything by definition.
+_flow_test_begin "allowed-tools Bash() prefixes have at least one body invocation"
+PASS=1
+for FILE in "$COMMANDS_DIR"/*.md; do
+  CMD=$(basename "$FILE" .md)
+  # Frontmatter is the first --- ... --- block.
+  FRONT=$(awk '
+    BEGIN { state=0 }
+    /^---$/ { state++; if (state==1) next; if (state==2) exit }
+    state==1 { print }
+  ' "$FILE")
+  # Body is everything after the closing --- of frontmatter.
+  BODY=$(awk '
+    BEGIN { state=0 }
+    /^---$/ { state++; next }
+    state>=2 { print }
+  ' "$FILE")
+  # Extract Bash(...) entries from allowed-tools. Multi-line allowed-tools
+  # (YAML list form) flatten to one line per entry.
+  PATTERNS=$(printf '%s\n' "$FRONT" | grep -oE 'Bash\([^)]+\)' | sed -E 's/^Bash\((.*)\)$/\1/')
+  [ -z "$PATTERNS" ] && continue
+  while IFS= read -r PATTERN; do
+    [ -z "$PATTERN" ] && continue
+    # Strip trailing `:*` if present — Claude Code's wildcard for "any args".
+    PREFIX="${PATTERN%:\*}"
+    # Skip pure-wildcard patterns.
+    case "$PREFIX" in
+      ""|"*") continue ;;
+    esac
+    # Expand ${CLAUDE_PLUGIN_ROOT:-plugins/flow} so the body grep can match
+    # the actual literal path in helper invocations.
+    EXPANDED=$(printf '%s' "$PREFIX" | sed 's|\${CLAUDE_PLUGIN_ROOT:-plugins/flow}|plugins/flow|g')
+    # Strip a leading `bash ` so a `Bash(bash plugins/flow/bin/foo.sh)` pattern
+    # matches a `plugins/flow/bin/foo.sh` body invocation that doesn't repeat
+    # the explicit interpreter.
+    CHECK="${EXPANDED#bash }"
+    if ! printf '%s' "$BODY" | grep -qF "$CHECK"; then
+      _flow_assert_fail "$CMD.md allowed-tools 'Bash($PATTERN)' has no matching body invocation (looked for '$CHECK')"
+      PASS=0
+    fi
+  done <<< "$PATTERNS"
+done
+[ "$PASS" = "1" ] && _flow_assert_pass "all literal Bash() prefixes resolve to body invocations"

--- a/plugins/flow/tests/command-frontmatter.test.sh
+++ b/plugins/flow/tests/command-frontmatter.test.sh
@@ -12,16 +12,41 @@
 # (frontmatter block + body + per-`!`-block bodies), then run each lint rule
 # against that representation. The block extractor uses awk for portability
 # (BSD/GNU awk both work).
+#
+# Trivial-pass guards: every lint that iterates over command files asserts a
+# minimum scan count (FILE_COUNT_FLOOR). An empty COMMANDS_DIR — or a future
+# refactor that silently moves command files elsewhere — would otherwise let
+# a broken lint report PASS over zero work.
 
 COMMANDS_DIR="$REPO_ROOT/plugins/flow/commands"
 SKILLS_DIR="$REPO_ROOT/plugins/flow/skills"
+# Floor matches the current count of command files (17 as of this writing).
+# A drop below this is either a real deletion (update the floor in the same
+# PR) or a path resolution bug (find and fix). Either way: fail loudly.
+FILE_COUNT_FLOOR=15
 
-# --- Test 1: every `!` block ends with `true`
-# Extract each `!` block's body (everything between ```! and the next ```),
-# strip trailing blanks, and assert the last meaningful line is exactly `true`.
-_flow_test_begin "every ! block ends with explicit 'true'"
+# Strip bash-style quoted spans from a body of text. Used by the $ARGUMENTS
+# lint to ignore safely-quoted occurrences. Removes "..." and '...' on a
+# best-effort line-local basis — sed has no notion of bash escape semantics,
+# so a `\"` inside a "..." span will close the span early. That's a
+# conservative false-positive (flags too much), never a false-negative
+# (misses unsafe forms), which is the right tradeoff for a lint.
+_strip_quoted() {
+  sed -e 's/"[^"]*"//g' -e "s/'[^']*'//g"
+}
+
+# --- Test 1: every `!` block ends with `true`, and no triple-backtick fences
+# appear inside an `!` block. The trailing-`true` check is the F3 regression
+# guard; the no-nested-fence assertion guarantees the awk extractor's
+# correctness (a `!` block containing a literal ``` line would silently
+# close the block early, hiding everything after it).
+_flow_test_begin "every ! block ends with explicit 'true' and contains no nested fences"
+PASS=1
+SCANNED=0
+BLOCK_COUNT=0
 for FILE in "$COMMANDS_DIR"/*.md; do
   CMD=$(basename "$FILE" .md)
+  SCANNED=$((SCANNED + 1))
   # awk extracts ! blocks; emits one block per "BLOCK_START" / "BLOCK_END"
   # delimited section. The block-index is appended so we can name failures.
   BLOCKS=$(awk '
@@ -32,7 +57,10 @@ for FILE in "$COMMANDS_DIR"/*.md; do
   [ -z "$BLOCKS" ] && continue
 
   # Walk the awk output: for each block, capture lines and check the last
-  # non-blank line equals `true`.
+  # non-blank line equals `true`. Also flag any line inside the block that
+  # is itself a triple-backtick fence (a nested fence would have terminated
+  # the awk extraction prematurely, but if the source markdown ever
+  # introduces one, we want a clear failure).
   CURRENT_BLOCK=""
   CURRENT_IDX=""
   while IFS= read -r LINE; do
@@ -40,14 +68,24 @@ for FILE in "$COMMANDS_DIR"/*.md; do
       "BLOCK_START "*)
         CURRENT_BLOCK=""
         CURRENT_IDX="${LINE#BLOCK_START }"
+        BLOCK_COUNT=$((BLOCK_COUNT + 1))
         ;;
       "BLOCK_END "*)
         # Strip trailing blank lines; check last is `true`.
         LAST_NONBLANK=$(printf '%s' "$CURRENT_BLOCK" | awk 'NF { last=$0 } END { print last }')
         if [ "$LAST_NONBLANK" != "true" ]; then
           _flow_assert_fail "$CMD.md ! block #$CURRENT_IDX last line is '$LAST_NONBLANK', expected 'true'"
+          PASS=0
         fi
         CURRENT_BLOCK=""
+        ;;
+      '```'*)
+        # A bare ``` inside a captured block can only mean a nested fence
+        # the awk pattern didn't recognize (the extractor swallowed it as
+        # block content rather than a terminator — possible only via 4+
+        # backticks or trailing whitespace on the closing fence). Flag.
+        _flow_assert_fail "$CMD.md ! block #$CURRENT_IDX contains a nested fence: $LINE"
+        PASS=0
         ;;
       *)
         if [ -z "$CURRENT_BLOCK" ]; then
@@ -59,31 +97,49 @@ for FILE in "$COMMANDS_DIR"/*.md; do
     esac
   done <<< "$BLOCKS"
 done
-# Single PASS marker covers all 16 commands when no fail fired.
-[ "$FLOW_TEST_FAIL" = "0" ] && _flow_assert_pass "all ! blocks across $(ls "$COMMANDS_DIR"/*.md | wc -l | tr -d ' ') commands end with 'true'"
+# Trivial-pass guard: assert we actually scanned the expected number of
+# files. An empty COMMANDS_DIR or a path-resolution bug would otherwise
+# silently produce a green PASS over zero work (T1).
+if [ "$SCANNED" -lt "$FILE_COUNT_FLOOR" ]; then
+  _flow_assert_fail "scanned only $SCANNED command files (floor=$FILE_COUNT_FLOOR); COMMANDS_DIR=$COMMANDS_DIR"
+  PASS=0
+fi
+[ "$PASS" = "1" ] && _flow_assert_pass "$BLOCK_COUNT ! blocks across $SCANNED commands end with 'true' (no nested fences)"
 
 # --- Test 2: no destructive commands inside ! blocks
-# ! blocks are read-only context gatherers. Destructive verbs anywhere inside
-# (even commented) are a code smell at minimum and a footgun if uncommented.
-# We grep for verbs in word boundaries to avoid false positives in variable
-# names or substrings.
+# ! blocks are read-only context gatherers. The lint flags destructive verbs
+# as a structural reminder — a commented `# git push` is still flagged so the
+# reader is forced to consciously remove it (or refactor it out of the !
+# block) before merge. Word boundaries on the left side prevent false hits
+# on substring matches like `magit push` or `/path/to/git push`.
 _flow_test_begin "no destructive verbs inside ! blocks"
 PASS=1
-PROHIBITED='rm -rf|rm -f|rm[[:space:]]+-r|git[[:space:]]+push|git[[:space:]]+reset[[:space:]]+--hard|gh[[:space:]]+pr[[:space:]]+merge|gh[[:space:]]+pr[[:space:]]+close|gh[[:space:]]+release[[:space:]]+create|gh[[:space:]]+release[[:space:]]+delete|git[[:space:]]+tag[[:space:]]+-d|git[[:space:]]+branch[[:space:]]+-D'
+# Each alternative is left-anchored with `(^|[^[:alnum:]_/-])` so a verb only
+# matches when it starts a token (the existing right side, e.g. `[[:space:]]+`,
+# already enforces a right boundary).
+LB='(^|[^[:alnum:]_/-])'
+PROHIBITED="${LB}(rm[[:space:]]+-(rf|fr|f|r[a-z]*)|git[[:space:]]+push|git[[:space:]]+reset[[:space:]]+--hard|gh[[:space:]]+pr[[:space:]]+merge|gh[[:space:]]+pr[[:space:]]+close|gh[[:space:]]+release[[:space:]]+create|gh[[:space:]]+release[[:space:]]+delete|git[[:space:]]+tag[[:space:]]+-d|git[[:space:]]+branch[[:space:]]+-D|git[[:space:]]+stash[[:space:]]+drop|find[[:space:]]+[^|]*-delete|xargs[[:space:]]+rm)"
 for FILE in "$COMMANDS_DIR"/*.md; do
   CMD=$(basename "$FILE" .md)
-  # Extract block bodies (drop the BLOCK_START/END markers) and grep on them.
+  # Per-file scratch (replaces predictable /tmp/$$ from earlier revisions —
+  # S1/SV1/CV2 — which was a TOCTOU/symlink-attack vector on shared hosts).
+  MATCH_TMP=$(mktemp -t flow_dest_match.XXXXXX 2>/dev/null) || {
+    _flow_assert_fail "mktemp failed for $CMD.md destructive-verb scratch"
+    PASS=0; continue
+  }
+  # Extract block bodies, strip shell comments (a `# do not run gh pr merge`
+  # in documentation prose is not a destructive command), and grep.
   awk '
     /^```!$/ { in_block=1; idx++; print "BLOCK_START " idx; next }
     /^```$/ && in_block { in_block=0; print "BLOCK_END " idx; next }
     in_block { print }
-  ' "$FILE" | grep -nE "$PROHIBITED" > /tmp/flow_dest_match.$$ 2>/dev/null || true
-  if [ -s /tmp/flow_dest_match.$$ ]; then
-    HITS=$(cat /tmp/flow_dest_match.$$)
+  ' "$FILE" | sed -E 's/[[:space:]]*#.*$//' | grep -nE "$PROHIBITED" > "$MATCH_TMP" 2>/dev/null || true
+  if [ -s "$MATCH_TMP" ]; then
+    HITS=$(cat "$MATCH_TMP")
     _flow_assert_fail "$CMD.md contains destructive verb inside ! block: $HITS"
     PASS=0
   fi
-  rm -f /tmp/flow_dest_match.$$
+  rm -f "$MATCH_TMP"
 done
 [ "$PASS" = "1" ] && _flow_assert_pass "no destructive verbs in any ! block"
 
@@ -92,8 +148,12 @@ done
 #   - "$ARGUMENTS"           (double-quoted scalar)
 #   - "${ARGUMENTS%% *}"     (first-token extraction; the case-validated form)
 #   - assigned to a var then used: ARG1="${ARGUMENTS%% *}"; then "$ARG1"
-# Unacceptable: bare $ARGUMENTS (word-split + glob risk).
-_flow_test_begin "\$ARGUMENTS in ! blocks is quoted or extracted"
+# Unacceptable: any unquoted form including bare $ARGUMENTS, ${ARGUMENTS},
+# or ${ARGUMENTS%% *} outside of double quotes. The previous "char-before"
+# regex over-accepted ${ARGUMENTS} because `$` was in the negative class to
+# permit `${...}` braces — but unquoted braces are still word-split-vulnerable.
+# Fix: strip all quoted spans first, then flag any remaining $ARGUMENTS form.
+_flow_test_begin "\$ARGUMENTS in ! blocks is inside double quotes"
 PASS=1
 for FILE in "$COMMANDS_DIR"/*.md; do
   CMD=$(basename "$FILE" .md)
@@ -103,25 +163,27 @@ for FILE in "$COMMANDS_DIR"/*.md; do
     in_block { print }
   ' "$FILE")
   [ -z "$BODY" ] && continue
-  # Look for any $ARGUMENTS occurrence that is NOT preceded by a quote-or-brace.
-  # Simplest robust check: bare \$ARGUMENTS appearing anywhere flags as fail.
-  # The accepted forms always have `{` or `"` immediately before ARGUMENTS:
-  #   "${ARGUMENTS...    "$ARGUMENTS"    ${ARGUMENTS  (inside other quoting)
-  # Bare $ARGUMENTS (no `{` immediately after `$`, no `"` before `$`) is the
-  # vulnerable form.
-  BAD=$(printf '%s\n' "$BODY" | grep -nE '(^|[^"\$])\$ARGUMENTS([^a-zA-Z_]|$)' || true)
+  # Strip "..." and '...' spans line-locally. What remains is everything
+  # NOT inside quotes (plus comments — those aren't shell-execution-relevant
+  # but if a comment contains a `$ARGUMENTS` it's just confusing, not a
+  # security issue, so we strip them too).
+  STRIPPED=$(printf '%s\n' "$BODY" | sed -E 's/[[:space:]]*#.*$//' | _strip_quoted)
+  # After stripping, ANY occurrence of $ARGUMENTS or ${ARGUMENTS is unsafe.
+  BAD=$(printf '%s\n' "$STRIPPED" | grep -nE '\$\{?ARGUMENTS' || true)
   if [ -n "$BAD" ]; then
-    _flow_assert_fail "$CMD.md has bare \$ARGUMENTS in ! block: $BAD"
+    _flow_assert_fail "$CMD.md has unquoted \$ARGUMENTS reference in ! block: $BAD"
     PASS=0
   fi
 done
-[ "$PASS" = "1" ] && _flow_assert_pass "all \$ARGUMENTS uses in ! blocks are quoted/extracted"
+[ "$PASS" = "1" ] && _flow_assert_pass "all \$ARGUMENTS references in ! blocks are double-quoted"
 
 # --- Test 4: Required Skills entries resolve to plugins/flow/skills/<name>/
 # Each command's "## Required Skills" section lists `- skill-name` bullets;
 # every name must correspond to an existing skills/ directory.
 _flow_test_begin "Required Skills entries resolve to skills/ directories"
 PASS=1
+SKILLS_SCANNED=0
+RESOLVED_COUNT=0
 for FILE in "$COMMANDS_DIR"/*.md; do
   CMD=$(basename "$FILE" .md)
   # Extract the Required Skills section: from "## Required Skills" up to the
@@ -133,8 +195,10 @@ for FILE in "$COMMANDS_DIR"/*.md; do
     in_section && /^- / { print }
   ' "$FILE" | sed -E 's/^- *`?([a-zA-Z0-9_-]+)`?.*/\1/' | grep -v '^_' | grep -v '^$')
   [ -z "$SKILLS" ] && continue
+  SKILLS_SCANNED=$((SKILLS_SCANNED + 1))
   while IFS= read -r SKILL; do
     [ -z "$SKILL" ] && continue
+    RESOLVED_COUNT=$((RESOLVED_COUNT + 1))
     # Permit two forms: `skills/<skill>/` or `skills/<skill>/SKILL.md`.
     if [ ! -d "$SKILLS_DIR/$SKILL" ] && [ ! -f "$SKILLS_DIR/$SKILL/SKILL.md" ]; then
       _flow_assert_fail "$CMD.md Required Skills references '$SKILL' but $SKILLS_DIR/$SKILL/ does not exist"
@@ -142,51 +206,83 @@ for FILE in "$COMMANDS_DIR"/*.md; do
     fi
   done <<< "$SKILLS"
 done
-[ "$PASS" = "1" ] && _flow_assert_pass "all Required Skills references resolve"
+# Sanity floor — every flow command has a Required Skills section.
+if [ "$SKILLS_SCANNED" -lt 5 ]; then
+  _flow_assert_fail "only $SKILLS_SCANNED commands had a Required Skills section (expected most of them)"
+  PASS=0
+fi
+[ "$PASS" = "1" ] && _flow_assert_pass "$RESOLVED_COUNT Required Skills references across $SKILLS_SCANNED commands resolve"
 
-# --- Test 5: allowed-tools Bash(...) patterns have at least one matching body invocation
-# Frontmatter pattern: `Bash(<command-prefix>:*)`. For the literal-prefix form
-# we extract the prefix and assert the body contains it somewhere. Glob forms
-# (Bash(*) or Bash(:*)) are skipped — they match everything by definition.
-_flow_test_begin "allowed-tools Bash() prefixes have at least one body invocation"
+# --- Test 5: allowed-tools Bash(...) prefix-validation logic works
+# Currently NO flow command file uses prefix-restricted `Bash(prefix:*)`
+# patterns — they all declare full `Bash` access. The previous form of this
+# test iterated over zero patterns and trivially passed (F6/TV6). Instead,
+# exercise the logic against synthetic fixtures: one frontmatter where the
+# prefix has a matching body invocation (must PASS), one where it doesn't
+# (must FAIL the inner check).
+#
+# When real `Bash(prefix:*)` patterns are introduced into the plugin, the
+# real-files sweep below is appended; for now the fixture is the test of record.
+_flow_test_begin "allowed-tools Bash() prefix check (synthetic fixture)"
 PASS=1
+
+_check_pattern_in_body() {
+  local front="$1" body="$2"
+  local pattern prefix check
+  printf '%s\n' "$front" | grep -oE 'Bash\([^)]+\)' | sed -E 's/^Bash\((.*)\)$/\1/' | while IFS= read -r pattern; do
+    [ -z "$pattern" ] && continue
+    prefix="${pattern%:\*}"
+    case "$prefix" in ""|"*") continue ;; esac
+    check="${prefix#bash }"
+    # `--` protects against a leading-dash check string (SV2: grep -qF
+    # would otherwise misinterpret a `-foo` pattern as a flag).
+    if printf '%s' "$body" | grep -qF -- "$check"; then
+      printf 'MATCH=%s\n' "$pattern"
+    else
+      printf 'MISS=%s|%s\n' "$pattern" "$check"
+    fi
+  done
+}
+
+# Fixture A: pattern HAS matching invocation → expected MATCH.
+RESULT=$(_check_pattern_in_body \
+  'allowed-tools: Bash(plugins/flow/bin/cascade-resolve.sh:*)' \
+  '... and then we run plugins/flow/bin/cascade-resolve.sh --default ... here')
+assert_contains "MATCH=plugins/flow/bin/cascade-resolve.sh:*" "$RESULT" "fixture A: real prefix matches body"
+
+# Fixture B: pattern has NO matching invocation → expected MISS.
+RESULT=$(_check_pattern_in_body \
+  'allowed-tools: Bash(plugins/flow/bin/no-such-helper.sh:*)' \
+  '... body talks about something else entirely ...')
+assert_contains "MISS=plugins/flow/bin/no-such-helper.sh:*" "$RESULT" "fixture B: orphan prefix is flagged"
+
+# Fixture C: ${CLAUDE_PLUGIN_ROOT:-plugins/flow} expansion in pattern.
+RESULT=$(_check_pattern_in_body \
+  'allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/foo.sh:*)' \
+  '... invokes plugins/flow/bin/foo.sh ...')
+# Note: the synthetic helper doesn't expand the literal — that's the real
+# linter's job. So this fixture is a MISS-by-literal, MATCH-by-expansion.
+# Verify the helper at least produces an output line.
+assert_match '^(MATCH|MISS)=' "$RESULT" "fixture C: helper emits a result line"
+
+# Real-files sweep — currently a no-op (no commands declare Bash(prefix:*)),
+# but the loop is structured so it activates the moment one is introduced.
 for FILE in "$COMMANDS_DIR"/*.md; do
   CMD=$(basename "$FILE" .md)
-  # Frontmatter is the first --- ... --- block.
-  FRONT=$(awk '
-    BEGIN { state=0 }
-    /^---$/ { state++; if (state==1) next; if (state==2) exit }
-    state==1 { print }
-  ' "$FILE")
-  # Body is everything after the closing --- of frontmatter.
-  BODY=$(awk '
-    BEGIN { state=0 }
-    /^---$/ { state++; next }
-    state>=2 { print }
-  ' "$FILE")
-  # Extract Bash(...) entries from allowed-tools. Multi-line allowed-tools
-  # (YAML list form) flatten to one line per entry.
+  FRONT=$(awk 'BEGIN{s=0} /^---$/{s++; if(s==1)next; if(s==2)exit} s==1{print}' "$FILE")
+  BODY=$(awk 'BEGIN{s=0} /^---$/{s++; next} s>=2{print}' "$FILE")
   PATTERNS=$(printf '%s\n' "$FRONT" | grep -oE 'Bash\([^)]+\)' | sed -E 's/^Bash\((.*)\)$/\1/')
   [ -z "$PATTERNS" ] && continue
   while IFS= read -r PATTERN; do
     [ -z "$PATTERN" ] && continue
-    # Strip trailing `:*` if present — Claude Code's wildcard for "any args".
     PREFIX="${PATTERN%:\*}"
-    # Skip pure-wildcard patterns.
-    case "$PREFIX" in
-      ""|"*") continue ;;
-    esac
-    # Expand ${CLAUDE_PLUGIN_ROOT:-plugins/flow} so the body grep can match
-    # the actual literal path in helper invocations.
+    case "$PREFIX" in ""|"*") continue ;; esac
     EXPANDED=$(printf '%s' "$PREFIX" | sed 's|\${CLAUDE_PLUGIN_ROOT:-plugins/flow}|plugins/flow|g')
-    # Strip a leading `bash ` so a `Bash(bash plugins/flow/bin/foo.sh)` pattern
-    # matches a `plugins/flow/bin/foo.sh` body invocation that doesn't repeat
-    # the explicit interpreter.
     CHECK="${EXPANDED#bash }"
-    if ! printf '%s' "$BODY" | grep -qF "$CHECK"; then
+    if ! printf '%s' "$BODY" | grep -qF -- "$CHECK"; then
       _flow_assert_fail "$CMD.md allowed-tools 'Bash($PATTERN)' has no matching body invocation (looked for '$CHECK')"
       PASS=0
     fi
   done <<< "$PATTERNS"
 done
-[ "$PASS" = "1" ] && _flow_assert_pass "all literal Bash() prefixes resolve to body invocations"
+[ "$PASS" = "1" ] && _flow_assert_pass "allowed-tools Bash() prefix linter handles synthetic fixtures correctly"

--- a/plugins/flow/tests/flow-escalate.test.sh
+++ b/plugins/flow/tests/flow-escalate.test.sh
@@ -1,0 +1,110 @@
+# Tests for plugins/flow/bin/flow-escalate.sh.
+#
+# Contract (from the helper's header):
+#   - Six required fields: --situation, --tried, --options, --recommendation,
+#     --time-sensitivity, --risk.
+#   - Options are semicolon-separated, each `<n>: <text>`.
+#   - Exit 0: prints formatted body to stdout.
+#   - Exit 1: missing required field. Usage printed to stderr.
+#   - Exit 2: invalid input (empty/malformed option, duplicate number).
+#   - Output: markdown body with six bold-headed sections matching the canonical
+#     shape in plugins/flow/references/escalation-format.md.
+
+HELPER="$REPO_ROOT/plugins/flow/bin/flow-escalate.sh"
+
+# Six valid fields, used by happy-path assertions and as a baseline for the
+# missing-field tests (drop one at a time).
+ALL_ARGS=(
+  --situation "Test situation"
+  --tried "Tried thing A and B"
+  --options "1: First option;2: Second option"
+  --recommendation "Pick option 1"
+  --time-sensitivity "blocking"
+  --risk "Defer means service stays broken"
+)
+
+# --- Test 1: happy path — all six fields → exit 0, valid markdown body
+_flow_test_begin "all six fields → exit 0, markdown body"
+OUT=$("$HELPER" "${ALL_ARGS[@]}" 2>/dev/null)
+EXIT=$?
+assert_exit 0 "$EXIT" "exit 0"
+assert_contains "**Situation** — Test situation"           "$OUT" "Situation section present"
+assert_contains "**What I tried** — Tried thing A and B"   "$OUT" "What I tried section present"
+assert_contains "**Options**:"                             "$OUT" "Options heading present"
+assert_contains "**Recommendation** — Pick option 1"       "$OUT" "Recommendation section present"
+assert_contains "**Time sensitivity** — blocking"          "$OUT" "Time sensitivity section present"
+assert_contains "**Risk** — Defer means service stays broken" "$OUT" "Risk section present"
+# Options must be re-numbered as a Markdown numbered list.
+assert_contains "1. First option"  "$OUT" "Option 1 rendered as numbered list"
+assert_contains "2. Second option" "$OUT" "Option 2 rendered as numbered list"
+
+# --- Test 2: missing each required field → exit 1
+# Loop the six fields, drop each in turn, assert exit 1 + usage on stderr.
+_flow_test_begin "missing required field → exit 1"
+FIELDS=(--situation --tried --options --recommendation --time-sensitivity --risk)
+for DROP in "${FIELDS[@]}"; do
+  ARGS=()
+  i=0
+  while [ $i -lt "${#ALL_ARGS[@]}" ]; do
+    if [ "${ALL_ARGS[$i]}" = "$DROP" ]; then
+      i=$((i + 2))   # skip flag + value
+      continue
+    fi
+    ARGS+=("${ALL_ARGS[$i]}" "${ALL_ARGS[$((i+1))]}")
+    i=$((i + 2))
+  done
+  ERR=$("$HELPER" "${ARGS[@]}" 2>&1 >/dev/null)
+  EXIT=$?
+  assert_exit 1 "$EXIT" "exit 1 when $DROP missing"
+  assert_contains "$DROP" "$ERR" "stderr names missing field $DROP"
+done
+
+# --- Test 3: malformed option (no `N:` prefix) → exit 2
+_flow_test_begin "malformed option → exit 2"
+ARGS=(
+  --situation S --tried T
+  --options "no-number-here"
+  --recommendation R --time-sensitivity blocking --risk R
+)
+ERR=$("$HELPER" "${ARGS[@]}" 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 2 "$EXIT" "exit 2 on malformed option"
+assert_contains "malformed option" "$ERR" "stderr explains malformed option"
+
+# --- Test 4: duplicate option number → exit 2
+_flow_test_begin "duplicate option number → exit 2"
+ARGS=(
+  --situation S --tried T
+  --options "1: First;1: Also first"
+  --recommendation R --time-sensitivity blocking --risk R
+)
+ERR=$("$HELPER" "${ARGS[@]}" 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 2 "$EXIT" "exit 2 on duplicate option number"
+assert_contains "duplicate option number" "$ERR" "stderr explains duplicate"
+
+# --- Test 5: empty options expansion → exit 2
+_flow_test_begin "empty options → exit 2"
+ARGS=(
+  --situation S --tried T
+  --options ";;"
+  --recommendation R --time-sensitivity blocking --risk R
+)
+ERR=$("$HELPER" "${ARGS[@]}" 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 2 "$EXIT" "exit 2 on zero-item options"
+assert_contains "zero items" "$ERR" "stderr names the zero-item case"
+
+# --- Test 6: unknown flag → exit 1
+_flow_test_begin "unknown flag → exit 1"
+ERR=$("$HELPER" --bogus value "${ALL_ARGS[@]}" 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 1 "$EXIT" "exit 1 on unknown flag"
+assert_contains "unknown argument" "$ERR" "stderr names the unknown flag"
+
+# --- Test 7: -h flag → exit 0, usage on stderr
+_flow_test_begin "-h prints usage and exits 0"
+ERR=$("$HELPER" -h 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 0 "$EXIT" "exit 0"
+assert_contains "All six fields are required" "$ERR" "usage text on stderr"

--- a/plugins/flow/tests/flow-escalate.test.sh
+++ b/plugins/flow/tests/flow-escalate.test.sh
@@ -39,8 +39,20 @@ assert_contains "1. First option"  "$OUT" "Option 1 rendered as numbered list"
 assert_contains "2. Second option" "$OUT" "Option 2 rendered as numbered list"
 
 # --- Test 2: missing each required field → exit 1
-# Loop the six fields, drop each in turn, assert exit 1 + usage on stderr.
+# Loop the six fields, drop each in turn, assert exit 1 + the per-field error
+# line on stderr. The "missing required fields: $DROP" form is significant —
+# the helper's usage block also lists every flag name, so a plain
+# `assert_contains "$DROP"` would pass even if the helper emitted "bad
+# input" (the usage block's flag enumeration would satisfy the check).
+# Anchor on the literal "missing required fields:" string so we catch a
+# regression that drops the per-field reporting.
 _flow_test_begin "missing required field → exit 1"
+# Precondition: ALL_ARGS must be even-length pairs so the inner `i+1`
+# subscript never overflows under `set -u`. Catches a future maintainer
+# adding a 7th flag without its value.
+if [ $(( ${#ALL_ARGS[@]} % 2 )) -ne 0 ]; then
+  _flow_assert_fail "ALL_ARGS has odd length ${#ALL_ARGS[@]}; cannot iterate as pairs"
+fi
 FIELDS=(--situation --tried --options --recommendation --time-sensitivity --risk)
 for DROP in "${FIELDS[@]}"; do
   ARGS=()
@@ -53,10 +65,21 @@ for DROP in "${FIELDS[@]}"; do
     ARGS+=("${ALL_ARGS[$i]}" "${ALL_ARGS[$((i+1))]}")
     i=$((i + 2))
   done
-  ERR=$("$HELPER" "${ARGS[@]}" 2>&1 >/dev/null)
+  # Capture stdout and stderr separately so we can also assert nothing
+  # leaked to stdout on the failure path (a happy-path stdout leak would be
+  # caught by Test 1; this catches the inverse).
+  STDOUT_TMP=$(mktemp -t flow-escalate.test.so.XXXXXX 2>/dev/null) || {
+    _flow_assert_fail "mktemp failed for stdout capture"
+    continue
+  }
+  ERR=$("$HELPER" "${ARGS[@]}" 2>&1 1>"$STDOUT_TMP")
   EXIT=$?
+  OUT=$(cat "$STDOUT_TMP"); rm -f "$STDOUT_TMP"
   assert_exit 1 "$EXIT" "exit 1 when $DROP missing"
-  assert_contains "$DROP" "$ERR" "stderr names missing field $DROP"
+  # Anchored substring — distinguishes the per-field error line from the
+  # usage-block enumeration that also contains every flag name.
+  assert_contains "missing required fields: $DROP" "$ERR" "stderr emits 'missing required fields: $DROP'"
+  assert_equal "" "$OUT" "no stdout output on failure path for $DROP"
 done
 
 # --- Test 3: malformed option (no `N:` prefix) → exit 2

--- a/plugins/flow/tests/journal-record.test.sh
+++ b/plugins/flow/tests/journal-record.test.sh
@@ -187,3 +187,122 @@ assert_exit 2 "$EXIT" "exit 2 when journal is a symlink"
 assert_contains "symlink" "$ERR" "stderr names the symlink refusal"
 # Confirm the redirect target was NOT written to.
 assert_equal "untouched" "$(cat "$TARGET_FILE")" "redirect target was not overwritten"
+# Inverse check (SV2_3): the symlink itself was not replaced by a real file.
+LINK_DEST=$(readlink "$DIR/.decisions/issue-99.md")
+assert_equal "$TARGET_FILE" "$LINK_DEST" "symlink at journal path was not rewritten"
+
+# --- Test 10: symlink rejection on LOCKFILE path (parallel O_NOFOLLOW guard)
+# journal-record.sh:147 also opens the lockfile with O_NOFOLLOW. A regression
+# removing it from the lockfile-open path would not be caught by Test 9
+# (which only stages a symlink at the journal file itself, not at the .lock
+# sibling). Mirror Test 9 for the lockfile.
+_flow_test_begin "symlink at lockfile path → exit 2 (O_NOFOLLOW)"
+DIR=$(_jr_mktemp_dir)
+mkdir -p "$DIR/.decisions"
+TARGET_FILE="$DIR/lock-redirect-target.md"
+echo "untouched-lock-target" > "$TARGET_FILE"
+ln -s "$TARGET_FILE" "$DIR/.decisions/issue-200.md.lock"
+ERR=$(_run_journal "$DIR" --issue 200 --type test 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 2 "$EXIT" "exit 2 when lockfile is a symlink"
+assert_contains "lockfile" "$ERR" "stderr names the lockfile refusal"
+assert_contains "symlink" "$ERR" "stderr names the symlink reason"
+assert_equal "untouched-lock-target" "$(cat "$TARGET_FILE")" "lockfile-redirect target was not overwritten"
+
+# --- Test 11: existing journal with unclosed frontmatter → exit 2 (refusal)
+# journal-record.sh:211-220 explicitly refuses to overwrite when the existing
+# journal has an opening `---` with no closing fence — a rewrite would
+# silently corrupt the body that itself starts with `---`. Pre-stage and verify.
+_flow_test_begin "existing journal with unclosed frontmatter → exit 2 (refuse to overwrite)"
+DIR=$(_jr_mktemp_dir)
+mkdir -p "$DIR/.decisions"
+cat > "$DIR/.decisions/issue-201.md" <<'BAD'
+---
+issue: 201
+created: '2026-01-01T00:00:00Z'
+artifacts: []
+no closing fence here
+BAD
+ORIGINAL=$(cat "$DIR/.decisions/issue-201.md")
+ERR=$(_run_journal "$DIR" --issue 201 --type test 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 2 "$EXIT" "exit 2 on unclosed frontmatter"
+assert_contains "unclosed frontmatter" "$ERR" "stderr names the unclosed-fence reason"
+assert_equal "$ORIGINAL" "$(cat "$DIR/.decisions/issue-201.md")" "existing journal was not overwritten"
+
+# --- Test 12: existing journal with malformed YAML → exit 2 (refusal)
+# journal-record.sh:221-226 catches yaml.YAMLError and refuses. Same regression
+# class as Test 11 but a different rejection branch.
+_flow_test_begin "existing journal with malformed YAML → exit 2 (refuse to overwrite)"
+DIR=$(_jr_mktemp_dir)
+mkdir -p "$DIR/.decisions"
+cat > "$DIR/.decisions/issue-202.md" <<'BAD'
+---
+issue: 202
+artifacts: [unclosed-list
+created: bad
+---
+
+body
+BAD
+ORIGINAL=$(cat "$DIR/.decisions/issue-202.md")
+ERR=$(_run_journal "$DIR" --issue 202 --type test 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 2 "$EXIT" "exit 2 on malformed YAML"
+assert_contains "invalid YAML" "$ERR" "stderr names the YAML parse failure"
+assert_equal "$ORIGINAL" "$(cat "$DIR/.decisions/issue-202.md")" "existing journal was not overwritten"
+
+# --- Test 13: existing journal with non-mapping frontmatter → exit 2 (refusal)
+# journal-record.sh:228-232 refuses when safe_load returns something other
+# than a dict (e.g., a top-level scalar or list). Without this guard the
+# `manifest.setdefault(...)` calls below would AttributeError.
+_flow_test_begin "existing journal with non-mapping frontmatter → exit 2 (refuse to overwrite)"
+DIR=$(_jr_mktemp_dir)
+mkdir -p "$DIR/.decisions"
+cat > "$DIR/.decisions/issue-203.md" <<'BAD'
+---
+- this
+- is
+- a
+- list
+---
+
+body
+BAD
+ORIGINAL=$(cat "$DIR/.decisions/issue-203.md")
+ERR=$(_run_journal "$DIR" --issue 203 --type test 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 2 "$EXIT" "exit 2 on non-mapping frontmatter"
+assert_contains "not a YAML mapping" "$ERR" "stderr names the shape mismatch"
+assert_equal "$ORIGINAL" "$(cat "$DIR/.decisions/issue-203.md")" "existing journal was not overwritten"
+
+# --- Test 14: flock concurrency contract — two concurrent invocations
+# journal-record.sh:155-159 uses fcntl.LOCK_EX to serialize same-issue writes.
+# A regression that demotes LOCK_EX → LOCK_SH, drops flock entirely, or moves
+# writes outside the lock would let two concurrent appends race on the
+# read-modify-write of artifacts[], potentially losing one writer's entry.
+# Verify by backgrounding two invocations with distinct metadata, waiting
+# for both, then asserting artifacts[] contains both entries.
+_flow_test_begin "concurrent invocations both append to artifacts[]"
+DIR=$(_jr_mktemp_dir)
+# Background two appends targeting the same --issue.
+_run_journal "$DIR" --issue 204 --type test --metadata writer=alpha >/dev/null 2>&1 &
+PID_A=$!
+_run_journal "$DIR" --issue 204 --type test --metadata writer=beta >/dev/null 2>&1 &
+PID_B=$!
+wait "$PID_A"; EXIT_A=$?
+wait "$PID_B"; EXIT_B=$?
+assert_exit 0 "$EXIT_A" "first concurrent invocation exits 0"
+assert_exit 0 "$EXIT_B" "second concurrent invocation exits 0"
+# Both writers' metadata must be present — neither lost to a read-modify-write race.
+WRITERS=$(python3 - "$DIR/.decisions/issue-204.md" <<'PYEOF'
+import sys, yaml
+with open(sys.argv[1]) as f:
+    c = f.read()
+end = c.find("\n---\n", 4)
+fm = yaml.safe_load(c[4:end])
+writers = sorted(a.get("writer", "") for a in fm["artifacts"])
+print(",".join(writers))
+PYEOF
+)
+assert_equal "alpha,beta" "$WRITERS" "both writers' artifacts persisted (no flock race)"

--- a/plugins/flow/tests/journal-record.test.sh
+++ b/plugins/flow/tests/journal-record.test.sh
@@ -28,11 +28,17 @@ _jr_cleanup() {
 }
 trap _jr_cleanup EXIT
 
+# See cascade-resolve.test.sh `_mktemp_or_die` for the kill-INT rationale —
+# the caller invokes this via `DIR=$(_jr_mktemp_dir)` which puts us in a
+# command-substitution subshell; a bare `exit 2` would only kill the subshell
+# and let the test continue against an empty $DIR, writing the helper's
+# output into REPO_ROOT instead of a scratch dir.
 _jr_mktemp_dir() {
   local out
   out=$(mktemp -d -t journal-record.tests.XXXXXX 2>/dev/null)
   if [ -z "$out" ] || [ ! -d "$out" ]; then
     echo "journal-record.test.sh: mktemp -d failed" >&2
+    kill -INT $$ 2>/dev/null
     exit 2
   fi
   JR_CLEANUP_PATHS+=("$out")

--- a/plugins/flow/tests/journal-record.test.sh
+++ b/plugins/flow/tests/journal-record.test.sh
@@ -1,0 +1,183 @@
+# Tests for plugins/flow/bin/journal-record.sh.
+#
+# Contract (from the helper's header):
+#   - Required args: --issue <N>, --type <artifact-type>.
+#   - Optional: --metadata key=value (repeatable).
+#   - Exit 0: artifact recorded.
+#   - Exit 1: missing arg, invalid metadata, non-integer issue.
+#   - Exit 2: infrastructure error (PyYAML missing, file unwritable, etc.).
+#   - Writes YAML frontmatter at .decisions/issue-{N}.md (or settings-configured
+#     directory) with atomic temp+rename, fcntl flock for concurrency, and
+#     O_NOFOLLOW for symlink-attack rejection.
+#   - Append-only: re-invocation appends to artifacts[]; never deduplicates.
+#
+# Prerequisites: python3 + PyYAML. Skipped (test PASS-with-skip-message) if
+# either is missing — CI provides both, but a developer on a stripped system
+# should see why the tests are no-ops rather than a cryptic exit.
+
+HELPER="$REPO_ROOT/plugins/flow/bin/journal-record.sh"
+
+# Reuse the cleanup pattern from cascade-resolve.test.sh: single trap, paths
+# accumulate in an array, fail-fast mktemp.
+JR_CLEANUP_PATHS=()
+_jr_cleanup() {
+  local p
+  for p in "${JR_CLEANUP_PATHS[@]:-}"; do
+    [ -n "$p" ] && rm -rf "$p" 2>/dev/null
+  done
+}
+trap _jr_cleanup EXIT
+
+_jr_mktemp_dir() {
+  local out
+  out=$(mktemp -d -t journal-record.tests.XXXXXX 2>/dev/null)
+  if [ -z "$out" ] || [ ! -d "$out" ]; then
+    echo "journal-record.test.sh: mktemp -d failed" >&2
+    exit 2
+  fi
+  JR_CLEANUP_PATHS+=("$out")
+  printf '%s' "$out"
+}
+
+# Helper: run journal-record.sh inside a scratch dir with $CLAUDE_PLUGIN_ROOT
+# set so the script's cascade-resolve.sh discovers `.decisions` as the journal
+# dir (the default — no settings.json present means cascade-resolve falls back
+# to the --default).
+_run_journal() {
+  local dir="$1"; shift
+  (cd "$dir" && CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/flow" "$HELPER" "$@")
+}
+
+# Skip the whole suite gracefully if python3 + PyYAML are unavailable.
+if ! command -v python3 >/dev/null 2>&1; then
+  _flow_test_begin "python3 prerequisite"
+  _flow_assert_pass "SKIP: python3 not installed"
+  return 0
+fi
+if ! python3 -c "import yaml" >/dev/null 2>&1; then
+  _flow_test_begin "PyYAML prerequisite"
+  _flow_assert_pass "SKIP: PyYAML not installed (apt install python3-yaml / pip install pyyaml)"
+  return 0
+fi
+
+# --- Test 1: missing --issue → exit 1
+_flow_test_begin "missing --issue → exit 1"
+DIR=$(_jr_mktemp_dir)
+ERR=$(_run_journal "$DIR" --type review-cycle 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 1 "$EXIT" "exit 1"
+assert_contains "--issue is required" "$ERR" "stderr names the missing arg"
+
+# --- Test 2: missing --type → exit 1
+_flow_test_begin "missing --type → exit 1"
+DIR=$(_jr_mktemp_dir)
+ERR=$(_run_journal "$DIR" --issue 42 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 1 "$EXIT" "exit 1"
+assert_contains "--type is required" "$ERR" "stderr names the missing arg"
+
+# --- Test 3: non-integer issue → exit 1
+_flow_test_begin "non-integer --issue → exit 1"
+DIR=$(_jr_mktemp_dir)
+ERR=$(_run_journal "$DIR" --issue abc --type review-cycle 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 1 "$EXIT" "exit 1"
+assert_contains "positive integer" "$ERR" "stderr explains integer requirement"
+
+# --- Test 4: unknown argument → exit 1
+_flow_test_begin "unknown argument → exit 1"
+DIR=$(_jr_mktemp_dir)
+ERR=$(_run_journal "$DIR" --bogus value --issue 42 --type t 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 1 "$EXIT" "exit 1"
+assert_contains "unknown argument" "$ERR" "stderr names the unknown flag"
+
+# --- Test 5: metadata with embedded newline → exit 1
+_flow_test_begin "metadata with newline → exit 1"
+DIR=$(_jr_mktemp_dir)
+ERR=$(_run_journal "$DIR" --issue 42 --type review-cycle --metadata $'key=line1\nline2' 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 1 "$EXIT" "exit 1"
+assert_contains "newline" "$ERR" "stderr names the safety reason"
+
+# --- Test 6: happy path — creates a valid manifest with one artifact
+_flow_test_begin "happy path: writes valid YAML manifest"
+DIR=$(_jr_mktemp_dir)
+ERR=$(_run_journal "$DIR" --issue 42 --type review-cycle \
+  --metadata cycle=1 --metadata path=A --metadata findings_count=3 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 0 "$EXIT" "exit 0"
+assert_file_exists "$DIR/.decisions/issue-42.md" "journal file created"
+# Parse and inspect the YAML frontmatter — defense against silent malformed output.
+# Use a heredoc (not `python3 -c '...'`) to avoid bash/python quoting collisions
+# with f-string content.
+PARSED=$(python3 - "$DIR/.decisions/issue-42.md" <<'PYEOF'
+import sys, yaml
+with open(sys.argv[1]) as f:
+    c = f.read()
+assert c.startswith("---\n"), "no frontmatter"
+end = c.find("\n---\n", 4)
+fm = yaml.safe_load(c[4:end])
+art = fm["artifacts"][0]
+print("issue={} type={} cycle={} path={} findings_count={}".format(
+    fm["issue"], art["type"], art["cycle"], art["path"], art["findings_count"]))
+PYEOF
+)
+assert_equal "issue=42 type=review-cycle cycle=1 path=A findings_count=3" "$PARSED" "manifest fields parse correctly"
+
+# --- Test 7: idempotent append — second invocation appends to artifacts[]
+_flow_test_begin "append: second invocation adds a second artifact"
+_run_journal "$DIR" --issue 42 --type stranger-test --metadata result=PASS --metadata task_count=5 >/dev/null 2>&1
+EXIT=$?
+assert_exit 0 "$EXIT" "second invocation exits 0"
+COUNT=$(python3 - "$DIR/.decisions/issue-42.md" <<'PYEOF'
+import sys, yaml
+with open(sys.argv[1]) as f:
+    c = f.read()
+end = c.find("\n---\n", 4)
+fm = yaml.safe_load(c[4:end])
+print(len(fm["artifacts"]))
+PYEOF
+)
+assert_equal "2" "$COUNT" "artifacts[] has 2 entries after append"
+
+# --- Test 8: metadata type coercion (int, bool, comma-list, string)
+_flow_test_begin "metadata coercion: int, bool, list, string"
+DIR=$(_jr_mktemp_dir)
+_run_journal "$DIR" --issue 7 --type test \
+  --metadata count=42 \
+  --metadata ready=true \
+  --metadata items=a,b,c \
+  --metadata note=hello >/dev/null 2>&1
+TYPES=$(python3 - "$DIR/.decisions/issue-7.md" <<'PYEOF'
+import sys, yaml
+with open(sys.argv[1]) as f:
+    c = f.read()
+end = c.find("\n---\n", 4)
+art = yaml.safe_load(c[4:end])["artifacts"][0]
+print("count={} ready={} items={}={} note={}".format(
+    type(art["count"]).__name__,
+    type(art["ready"]).__name__,
+    type(art["items"]).__name__,
+    art["items"],
+    art["note"]))
+PYEOF
+)
+assert_contains "count=int" "$TYPES" "numeric metadata coerced to int"
+assert_contains "ready=bool" "$TYPES" "true/false coerced to bool"
+assert_contains "items=list" "$TYPES" "comma-list coerced to list"
+assert_contains "note=hello" "$TYPES" "plain string preserved"
+
+# --- Test 9: symlink rejection — journal path is a pre-staged symlink
+_flow_test_begin "symlink at journal path → exit 2 (O_NOFOLLOW)"
+DIR=$(_jr_mktemp_dir)
+mkdir -p "$DIR/.decisions"
+TARGET_FILE="$DIR/elsewhere.md"
+echo "untouched" > "$TARGET_FILE"
+ln -s "$TARGET_FILE" "$DIR/.decisions/issue-99.md"
+ERR=$(_run_journal "$DIR" --issue 99 --type test 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 2 "$EXIT" "exit 2 when journal is a symlink"
+assert_contains "symlink" "$ERR" "stderr names the symlink refusal"
+# Confirm the redirect target was NOT written to.
+assert_equal "untouched" "$(cat "$TARGET_FILE")" "redirect target was not overwritten"

--- a/plugins/flow/tests/lib/assert.sh
+++ b/plugins/flow/tests/lib/assert.sh
@@ -30,7 +30,21 @@ _flow_assert_pass() {
 
 _flow_assert_fail() {
   FLOW_TEST_FAIL=$((FLOW_TEST_FAIL + 1))
-  local where="${BASH_SOURCE[2]##*/}:${BASH_LINENO[1]}"
+  # Depth-aware citation. Two call shapes exist:
+  #   (a) assert_equal/match/contains/... wraps _flow_assert_fail
+  #       → BASH_SOURCE[2] is the test file (one wrapper between us and caller)
+  #   (b) test body calls _flow_assert_fail directly (used by the static
+  #       lints in command-frontmatter.test.sh)
+  #       → BASH_SOURCE[1] is the test file (no wrapper)
+  # Picking the wrong depth produces citations like [run.sh:80] — the line
+  # in run.sh that sourced the test, not the assertion line. Detect by
+  # checking whether [1] is assert.sh.
+  local where
+  if [ "${BASH_SOURCE[1]##*/}" = "assert.sh" ]; then
+    where="${BASH_SOURCE[2]##*/}:${BASH_LINENO[1]}"
+  else
+    where="${BASH_SOURCE[1]##*/}:${BASH_LINENO[0]}"
+  fi
   printf 'FAIL %s — %s [%s]\n' "$FLOW_TEST_CURRENT" "$1" "$where"
 }
 

--- a/plugins/flow/tests/lib/assert.sh
+++ b/plugins/flow/tests/lib/assert.sh
@@ -1,0 +1,113 @@
+# Bash assertions for plugins/flow/tests.
+#
+# Each assertion emits PASS/FAIL to stdout with a file:line citation derived
+# from the caller's BASH_SOURCE/LINENO, and returns 0/1 so a calling script
+# can decide whether to keep going or abort. The runner aggregates pass/fail
+# counts via the FLOW_TEST_PASS / FLOW_TEST_FAIL counters maintained here.
+#
+# Conventions:
+#   - All assertions read FLOW_TEST_CURRENT (the current test name) to label
+#     output. Tests call _flow_test_begin "name" before assertions.
+#   - Assertions write to stdout (captured by run.sh); diagnostic detail goes
+#     to the same line so a tail of the output reads like a checklist.
+#   - No external dependencies beyond standard POSIX utilities.
+
+# Counters live in the test process. run.sh re-sources this file per test
+# file (each test runs in a fresh subshell), so the counters reset between
+# files but accumulate within a file.
+: "${FLOW_TEST_PASS:=0}"
+: "${FLOW_TEST_FAIL:=0}"
+: "${FLOW_TEST_CURRENT:=<unset>}"
+
+_flow_test_begin() {
+  FLOW_TEST_CURRENT="$1"
+}
+
+_flow_assert_pass() {
+  FLOW_TEST_PASS=$((FLOW_TEST_PASS + 1))
+  printf 'PASS %s — %s\n' "$FLOW_TEST_CURRENT" "$1"
+}
+
+_flow_assert_fail() {
+  FLOW_TEST_FAIL=$((FLOW_TEST_FAIL + 1))
+  local where="${BASH_SOURCE[2]##*/}:${BASH_LINENO[1]}"
+  printf 'FAIL %s — %s [%s]\n' "$FLOW_TEST_CURRENT" "$1" "$where"
+}
+
+# assert_equal <expected> <actual> [<label>]
+assert_equal() {
+  local expected="$1" actual="$2" label="${3:-equal}"
+  if [ "$expected" = "$actual" ]; then
+    _flow_assert_pass "$label"
+    return 0
+  fi
+  _flow_assert_fail "$label: expected '$expected', got '$actual'"
+  return 1
+}
+
+# assert_match <regex> <actual> [<label>]
+# Uses grep -E so the regex is ERE — same flavor the test bodies already use.
+assert_match() {
+  local pattern="$1" actual="$2" label="${3:-match}"
+  if printf '%s' "$actual" | grep -qE "$pattern"; then
+    _flow_assert_pass "$label"
+    return 0
+  fi
+  _flow_assert_fail "$label: '$actual' does not match /$pattern/"
+  return 1
+}
+
+# assert_contains <needle> <haystack> [<label>]
+# Literal substring match (no regex). Useful for asserting on multi-line
+# stderr where a regex special would need escaping.
+assert_contains() {
+  local needle="$1" haystack="$2" label="${3:-contains}"
+  case "$haystack" in
+    *"$needle"*)
+      _flow_assert_pass "$label"
+      return 0
+      ;;
+  esac
+  _flow_assert_fail "$label: missing '$needle'"
+  return 1
+}
+
+# assert_not_contains <needle> <haystack> [<label>]
+assert_not_contains() {
+  local needle="$1" haystack="$2" label="${3:-not-contains}"
+  case "$haystack" in
+    *"$needle"*)
+      _flow_assert_fail "$label: unexpectedly contains '$needle'"
+      return 1
+      ;;
+  esac
+  _flow_assert_pass "$label"
+  return 0
+}
+
+# assert_exit <expected> <actual> [<label>]
+assert_exit() {
+  local expected="$1" actual="$2" label="${3:-exit}"
+  if [ "$expected" = "$actual" ]; then
+    _flow_assert_pass "$label"
+    return 0
+  fi
+  _flow_assert_fail "$label: expected exit $expected, got $actual"
+  return 1
+}
+
+# assert_file_exists <path> [<label>]
+assert_file_exists() {
+  local path="$1" label="${2:-file-exists}"
+  if [ -f "$path" ]; then
+    _flow_assert_pass "$label"
+    return 0
+  fi
+  _flow_assert_fail "$label: $path missing"
+  return 1
+}
+
+# Print summary; called by run.sh after each test file completes.
+_flow_test_summary() {
+  printf 'SUMMARY pass=%d fail=%d\n' "$FLOW_TEST_PASS" "$FLOW_TEST_FAIL"
+}

--- a/plugins/flow/tests/promote-proposal.test.sh
+++ b/plugins/flow/tests/promote-proposal.test.sh
@@ -25,11 +25,15 @@ _pp_cleanup() {
 }
 trap _pp_cleanup EXIT
 
+# See cascade-resolve.test.sh `_mktemp_or_die` for the kill-INT rationale —
+# bare `exit 2` would only kill the command-substitution subshell, leaving
+# the test running against an empty DIR.
 _pp_mktemp_dir() {
   local out
   out=$(mktemp -d -t promote-proposal.tests.XXXXXX 2>/dev/null)
   if [ -z "$out" ] || [ ! -d "$out" ]; then
     echo "promote-proposal.test.sh: mktemp -d failed" >&2
+    kill -INT $$ 2>/dev/null
     exit 2
   fi
   PP_CLEANUP_PATHS+=("$out")
@@ -209,15 +213,24 @@ EXIT=$?
 assert_exit 1 "$EXIT" "exit 1"
 assert_contains "missing required body sections" "$ERR" "stderr names the missing sections"
 
-# --- Test 10: path containing newline → exit 1 (safety guard)
-_flow_test_begin "path with newline → exit 1"
+# --- Test 10: plain-ASCII path passes the newline-rejection safety check
+# The helper's newline/CR rejection branch (bin/promote-proposal.sh:58-63)
+# guards against programmatically-built $PROPOSAL paths containing embedded
+# newlines (POSIX permits `\n` in filenames; bash CAN pass them via array
+# expansion). Directly testing the rejection branch via a shell-arg-passed
+# newline-bearing path is awkward because the bash command line accepts the
+# newline, then the script's `[ ! -f "$PROPOSAL" ]` check at line 52 fires
+# FIRST when the test fixture creates a file with a `\n` in its name (the
+# subsequent open hits the kernel's path-resolution which usually rejects).
+#
+# DELIBERATE GAP: the rejection branch is not directly exercised here. This
+# test instead verifies the inverse — that a plain-ASCII path does NOT
+# false-positive — which is the regression direction most likely to matter
+# (a future tightening of the guard breaking innocent paths). A direct
+# rejection-branch test would need the helper to expose the guard as a
+# function, sourceable from a unit test; that refactor is out of scope.
+_flow_test_begin "plain-ASCII path does not trigger newline-rejection guard"
 DIR=$(_pp_mktemp_dir)
-# bash can't actually pass a literal newline through standard file paths;
-# the script's safety check is for the case where $PROPOSAL is built from
-# a programmatic source. Simulate by creating a real file then passing a
-# path with a $'\n' in it. mktemp won't create that file, so the script
-# will hit the file-not-found branch instead. We instead test the inverse:
-# a file whose path is plain ASCII passes the safety check (no false-positive).
 PROP="$DIR/plain.md"
 _write_valid_proposal "$PROP"
 OUT=$("$HELPER" --proposal "$PROP" --dry-run 2>&1)

--- a/plugins/flow/tests/promote-proposal.test.sh
+++ b/plugins/flow/tests/promote-proposal.test.sh
@@ -1,0 +1,244 @@
+# Tests for plugins/flow/bin/promote-proposal.sh.
+#
+# Contract (from the helper's header):
+#   Usage: promote-proposal.sh --proposal <path> [--dry-run]
+#
+#   Exit 0: validation passed (or dry-run completed).
+#   Exit 1: validation failed (missing fields, bad status, invalid name, etc.).
+#   Exit 2: infrastructure error (file not found, not in git repo, etc.).
+#
+# Tests focus on the validation path (using --dry-run to short-circuit before
+# the git/gh mutating steps). The gh-invoking branches are intentionally NOT
+# exercised — testing them properly requires a mock-gh stub plus a throwaway
+# branch, which is heavier than smoke-test scope.
+#
+# Prerequisites: python3 + PyYAML + git. Skipped gracefully if absent.
+
+HELPER="$REPO_ROOT/plugins/flow/bin/promote-proposal.sh"
+
+PP_CLEANUP_PATHS=()
+_pp_cleanup() {
+  local p
+  for p in "${PP_CLEANUP_PATHS[@]:-}"; do
+    [ -n "$p" ] && rm -rf "$p" 2>/dev/null
+  done
+}
+trap _pp_cleanup EXIT
+
+_pp_mktemp_dir() {
+  local out
+  out=$(mktemp -d -t promote-proposal.tests.XXXXXX 2>/dev/null)
+  if [ -z "$out" ] || [ ! -d "$out" ]; then
+    echo "promote-proposal.test.sh: mktemp -d failed" >&2
+    exit 2
+  fi
+  PP_CLEANUP_PATHS+=("$out")
+  printf '%s' "$out"
+}
+
+# Build a valid proposal file with the given name. Caller can override fields
+# by passing --status / --name etc. — we keep it minimal.
+_write_valid_proposal() {
+  local path="$1" name="${2:-test-fake-proposal}" status="${3:-proposal}"
+  cat > "$path" <<PROPOSAL
+---
+name: "$name"
+description: "[flow-learned] Test proposal — never promoted in practice."
+source-sessions:
+  - "2026-05-18 test session"
+evidence-count: 1
+status: $status
+proposed: "2026-05-18"
+---
+
+# Test fake proposal
+
+## Pattern Detected
+
+Something keeps happening.
+
+## Knowledge
+
+Do the thing.
+
+## Evidence
+
+Cite one journal entry.
+
+## Verification
+
+Check the thing.
+
+## Promotion Checklist
+
+- [ ] Reviewed
+PROPOSAL
+}
+
+# Skip if python3 / PyYAML / git unavailable.
+if ! command -v python3 >/dev/null 2>&1; then
+  _flow_test_begin "python3 prerequisite"
+  _flow_assert_pass "SKIP: python3 not installed"
+  return 0
+fi
+if ! python3 -c "import yaml" >/dev/null 2>&1; then
+  _flow_test_begin "PyYAML prerequisite"
+  _flow_assert_pass "SKIP: PyYAML not installed"
+  return 0
+fi
+if ! command -v git >/dev/null 2>&1; then
+  _flow_test_begin "git prerequisite"
+  _flow_assert_pass "SKIP: git not installed"
+  return 0
+fi
+
+# --- Test 1: missing --proposal → exit 1
+_flow_test_begin "missing --proposal → exit 1"
+ERR=$("$HELPER" 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 1 "$EXIT" "exit 1"
+assert_contains "--proposal is required" "$ERR" "stderr names the missing arg"
+
+# --- Test 2: proposal file not found → exit 2
+_flow_test_begin "proposal file not found → exit 2"
+ERR=$("$HELPER" --proposal /nonexistent/path.md 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 2 "$EXIT" "exit 2"
+assert_contains "not found" "$ERR" "stderr names the missing file"
+
+# --- Test 3: unknown argument → exit 1
+_flow_test_begin "unknown argument → exit 1"
+ERR=$("$HELPER" --bogus value 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 1 "$EXIT" "exit 1"
+assert_contains "unknown argument" "$ERR" "stderr names the unknown flag"
+
+# --- Test 4: missing YAML frontmatter → exit 1
+_flow_test_begin "no frontmatter → exit 1"
+DIR=$(_pp_mktemp_dir)
+PROP="$DIR/no-frontmatter.md"
+printf 'Just a body, no frontmatter.\n' > "$PROP"
+ERR=$("$HELPER" --proposal "$PROP" --dry-run 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 1 "$EXIT" "exit 1"
+assert_contains "missing YAML frontmatter" "$ERR" "stderr names the missing frontmatter"
+
+# --- Test 5: malformed YAML → exit 1
+_flow_test_begin "malformed YAML frontmatter → exit 1"
+DIR=$(_pp_mktemp_dir)
+PROP="$DIR/bad-yaml.md"
+cat > "$PROP" <<'BAD'
+---
+this is: [unclosed
+---
+
+body
+BAD
+ERR=$("$HELPER" --proposal "$PROP" --dry-run 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 1 "$EXIT" "exit 1"
+assert_contains "malformed YAML frontmatter" "$ERR" "stderr names YAML parse failure"
+
+# --- Test 6: missing required field → exit 1
+_flow_test_begin "missing required frontmatter field → exit 1"
+DIR=$(_pp_mktemp_dir)
+PROP="$DIR/missing-field.md"
+cat > "$PROP" <<'INCOMPLETE'
+---
+name: test-fake
+description: "[flow-learned] x"
+status: proposal
+---
+
+# fake
+
+## Pattern Detected
+## Knowledge
+## Evidence
+## Verification
+## Promotion Checklist
+INCOMPLETE
+ERR=$("$HELPER" --proposal "$PROP" --dry-run 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 1 "$EXIT" "exit 1"
+assert_contains "missing required frontmatter fields" "$ERR" "stderr names the missing fields"
+
+# --- Test 7: status != "proposal" → exit 1
+_flow_test_begin "status != 'proposal' → exit 1"
+DIR=$(_pp_mktemp_dir)
+PROP="$DIR/wrong-status.md"
+_write_valid_proposal "$PROP" "test-fake-proposal" "promoted"
+ERR=$("$HELPER" --proposal "$PROP" --dry-run 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 1 "$EXIT" "exit 1"
+assert_contains "status must be 'proposal'" "$ERR" "stderr names the wrong-status reason"
+
+# --- Test 8: invalid kebab-case name → exit 1
+_flow_test_begin "invalid kebab-case name → exit 1"
+DIR=$(_pp_mktemp_dir)
+PROP="$DIR/bad-name.md"
+_write_valid_proposal "$PROP" "BadCamelCase"
+ERR=$("$HELPER" --proposal "$PROP" --dry-run 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 1 "$EXIT" "exit 1"
+assert_contains "kebab-case" "$ERR" "stderr names the kebab-case requirement"
+
+# --- Test 9: missing required body section → exit 1
+_flow_test_begin "missing required body section → exit 1"
+DIR=$(_pp_mktemp_dir)
+PROP="$DIR/missing-section.md"
+cat > "$PROP" <<'INCOMPLETE'
+---
+name: test-fake-proposal
+description: "[flow-learned] x"
+source-sessions:
+  - "2026-05-18"
+evidence-count: 1
+status: proposal
+proposed: "2026-05-18"
+---
+
+# Body
+
+## Pattern Detected
+
+x
+INCOMPLETE
+ERR=$("$HELPER" --proposal "$PROP" --dry-run 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 1 "$EXIT" "exit 1"
+assert_contains "missing required body sections" "$ERR" "stderr names the missing sections"
+
+# --- Test 10: path containing newline → exit 1 (safety guard)
+_flow_test_begin "path with newline → exit 1"
+DIR=$(_pp_mktemp_dir)
+# bash can't actually pass a literal newline through standard file paths;
+# the script's safety check is for the case where $PROPOSAL is built from
+# a programmatic source. Simulate by creating a real file then passing a
+# path with a $'\n' in it. mktemp won't create that file, so the script
+# will hit the file-not-found branch instead. We instead test the inverse:
+# a file whose path is plain ASCII passes the safety check (no false-positive).
+PROP="$DIR/plain.md"
+_write_valid_proposal "$PROP"
+OUT=$("$HELPER" --proposal "$PROP" --dry-run 2>&1)
+EXIT=$?
+# Either DRY-RUN passes (exit 0) or it hits target-already-exists (exit 1).
+# We only care that the safety check did NOT trigger.
+assert_not_contains "newline/carriage-return" "$OUT" "no spurious newline rejection for plain path"
+
+# --- Test 11: --dry-run with a valid proposal → exit 0 (when the learned/
+# target does not already exist) OR exit 1 (target exists). Either way, we
+# expect a deterministic outcome, NOT exit 2 (infrastructure error). Use a
+# random name to avoid target-already-exists collisions with real skills.
+_flow_test_begin "--dry-run valid proposal → no infrastructure error"
+DIR=$(_pp_mktemp_dir)
+UNIQUE_NAME="test-fake-$(date +%s)-$$"
+PROP="$DIR/valid.md"
+_write_valid_proposal "$PROP" "$UNIQUE_NAME"
+OUT=$("$HELPER" --proposal "$PROP" --dry-run 2>&1)
+EXIT=$?
+# Exit must be 0 — random name guarantees the target dir does not exist.
+assert_exit 0 "$EXIT" "exit 0 for dry-run with valid never-before-seen name"
+assert_contains "DRY-RUN: validation passed for '$UNIQUE_NAME'" "$OUT" "dry-run prints the validated name"
+assert_contains "would copy" "$OUT" "dry-run describes the next step"
+assert_contains "feature/learn-promote-$UNIQUE_NAME" "$OUT" "dry-run names the planned branch"

--- a/plugins/flow/tests/promote-proposal.test.sh
+++ b/plugins/flow/tests/promote-proposal.test.sh
@@ -255,3 +255,46 @@ assert_exit 0 "$EXIT" "exit 0 for dry-run with valid never-before-seen name"
 assert_contains "DRY-RUN: validation passed for '$UNIQUE_NAME'" "$OUT" "dry-run prints the validated name"
 assert_contains "would copy" "$OUT" "dry-run describes the next step"
 assert_contains "feature/learn-promote-$UNIQUE_NAME" "$OUT" "dry-run names the planned branch"
+
+# --- Test 12: target SKILL.md already exists → exit 1 (refuse to overwrite)
+# bin/promote-proposal.sh:161-169 refuses when the target SKILL.md exists.
+# Pre-create the target inside REPO_ROOT/plugins/flow/skills/learned/<NAME>/
+# and verify the refusal. Cleanup the target via CLEANUP_PATHS so the test
+# is re-runnable.
+_flow_test_begin "target SKILL.md exists → exit 1 (refuse to overwrite)"
+DIR=$(_pp_mktemp_dir)
+NAME_EXISTS="test-fake-target-exists-$(date +%s)-$$-$RANDOM"
+PROP="$DIR/valid-exists.md"
+_write_valid_proposal "$PROP" "$NAME_EXISTS"
+# Pre-stage the target as if a prior promotion already landed.
+TARGET_DIR="$REPO_ROOT/plugins/flow/skills/learned/$NAME_EXISTS"
+mkdir -p "$TARGET_DIR"
+echo "pre-existing skill content" > "$TARGET_DIR/SKILL.md"
+PP_CLEANUP_PATHS+=("$TARGET_DIR")
+ERR=$("$HELPER" --proposal "$PROP" --dry-run 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 1 "$EXIT" "exit 1 when target SKILL.md exists"
+assert_contains "refusing to overwrite" "$ERR" "stderr names the refusal"
+# Confirm the existing SKILL.md was not touched.
+assert_equal "pre-existing skill content" "$(cat "$TARGET_DIR/SKILL.md")" "existing SKILL.md was not overwritten"
+
+# --- Test 13: target dir exists and is non-empty → exit 1 (refuse to clobber)
+# bin/promote-proposal.sh:176-180 refuses when TARGET_DIR exists with any
+# content other than the expected SKILL.md. This protects an in-progress
+# hand-promotion (e.g., references/foo.md placed manually before SKILL.md)
+# from being wiped on a python rewrite failure.
+_flow_test_begin "target dir non-empty (no SKILL.md) → exit 1 (refuse to clobber)"
+DIR=$(_pp_mktemp_dir)
+NAME_DIRTY="test-fake-dirty-dir-$(date +%s)-$$-$RANDOM"
+PROP="$DIR/valid-dirty.md"
+_write_valid_proposal "$PROP" "$NAME_DIRTY"
+TARGET_DIR="$REPO_ROOT/plugins/flow/skills/learned/$NAME_DIRTY"
+mkdir -p "$TARGET_DIR/references"
+echo "stray content" > "$TARGET_DIR/references/foo.md"
+PP_CLEANUP_PATHS+=("$TARGET_DIR")
+ERR=$("$HELPER" --proposal "$PROP" --dry-run 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 1 "$EXIT" "exit 1 when target dir is non-empty"
+assert_contains "exists and is non-empty" "$ERR" "stderr names the clobber refusal"
+# Confirm the stray content was not touched.
+assert_equal "stray content" "$(cat "$TARGET_DIR/references/foo.md")" "stray content preserved"

--- a/plugins/flow/tests/run.sh
+++ b/plugins/flow/tests/run.sh
@@ -12,7 +12,11 @@
 # Exit:
 #   0 — all assertions passed
 #   1 — at least one assertion failed
-#   2 — runner-level error (missing test file, etc.)
+#   2 — runner-level error (missing test file, missing prerequisites, cd failed)
+#
+# Notes on flag choice: `set -uo pipefail` is used WITHOUT `-e` on purpose —
+# the runner must keep iterating across test files even if one of them fails
+# its assertions. Per-step exit codes are checked explicitly where they matter.
 
 set -uo pipefail
 
@@ -24,13 +28,24 @@ if [ ! -f "$LIB" ]; then
   exit 2
 fi
 
+# Prerequisite check: surface a single clear message at the runner level
+# rather than letting individual tests produce cryptic per-tool errors.
+for tool in awk grep sed mktemp; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "run.sh: missing prerequisite: $tool" >&2
+    exit 2
+  fi
+done
+
 # repo root is two levels up from tests/ (plugins/flow/tests -> plugins/flow -> repo).
 REPO_ROOT="$(cd "$TESTS_DIR/../../.." && pwd)"
 
 # Tests run from REPO_ROOT so relative paths in commands/ (e.g.,
 # `.claude/settings.flow.local.json`) resolve against the same directory the
-# actual command bash blocks would resolve them in.
-cd "$REPO_ROOT"
+# actual command bash blocks would resolve them in. Fail loudly if the cd
+# fails — silently running from the caller's cwd would make every test that
+# uses a relative path report misleading results.
+cd "$REPO_ROOT" || { echo "run.sh: cannot cd to $REPO_ROOT" >&2; exit 2; }
 
 if [ $# -gt 0 ]; then
   TEST_FILES=("$@")
@@ -49,6 +64,10 @@ fi
 TOTAL_PASS=0
 TOTAL_FAIL=0
 FAILED_FILES=()
+# Tracked separately from assertion failures: a runner-level error (missing
+# test file, malformed SUMMARY) is NOT the same as a test failure. The exit
+# code distinguishes 1 (assertions failed) from 2 (runner error).
+RUNNER_ERR=0
 
 for TEST_FILE in "${TEST_FILES[@]}"; do
   # Resolve relative arg against TESTS_DIR.
@@ -57,14 +76,18 @@ for TEST_FILE in "${TEST_FILES[@]}"; do
   fi
   if [ ! -f "$TEST_FILE" ]; then
     echo "run.sh: $TEST_FILE not found" >&2
-    TOTAL_FAIL=$((TOTAL_FAIL + 1))
+    RUNNER_ERR=1
     FAILED_FILES+=("$TEST_FILE")
     continue
   fi
 
   echo "=== $(basename "$TEST_FILE") ==="
-  # Capture each file's output AND its summary line so the runner can
-  # extract counts. Run in a subshell so counter state doesn't leak.
+  # Capture stdout AND stderr together: stderr from awk/grep/jq inside test
+  # bodies otherwise interleaves out-of-order with the SUMMARY extraction
+  # below and is invisible to CI artifact capture (T4/EV2). Also capture the
+  # subshell's exit code so a `set -u` unbound-var abort or explicit `exit`
+  # inside a test body surfaces with diagnostic context rather than just a
+  # bare "no SUMMARY line".
   OUTPUT=$(
     set +e
     # shellcheck source=lib/assert.sh
@@ -72,19 +95,38 @@ for TEST_FILE in "${TEST_FILES[@]}"; do
     # shellcheck disable=SC1090
     source "$TEST_FILE"
     _flow_test_summary
-  )
+  2>&1)
+  RC=$?
   printf '%s\n' "$OUTPUT"
-  # Extract last SUMMARY line — robust against tests that themselves print
-  # the word "SUMMARY" in PASS messages.
-  SUMMARY=$(printf '%s\n' "$OUTPUT" | grep -E '^SUMMARY pass=[0-9]+ fail=[0-9]+$' | tail -1)
+  # Extract last SUMMARY line — tolerate trailing whitespace and CR (a stray
+  # CRLF in a test file used to make the anchored regex reject the line).
+  SUMMARY=$(printf '%s\n' "$OUTPUT" | tr -d '\r' | grep -E '^SUMMARY pass=[0-9]+ fail=[0-9]+[[:space:]]*$' | tail -1)
   if [ -z "$SUMMARY" ]; then
-    echo "run.sh: WARN no SUMMARY line from $(basename "$TEST_FILE"); counting as 1 failure" >&2
+    echo "run.sh: WARN no SUMMARY line from $(basename "$TEST_FILE") (subshell exit=$RC); last lines:" >&2
+    printf '%s\n' "$OUTPUT" | tail -10 >&2
     TOTAL_FAIL=$((TOTAL_FAIL + 1))
     FAILED_FILES+=("$(basename "$TEST_FILE")")
     continue
   fi
   FILE_PASS=$(printf '%s' "$SUMMARY" | sed -E 's/.*pass=([0-9]+).*/\1/')
   FILE_FAIL=$(printf '%s' "$SUMMARY" | sed -E 's/.*fail=([0-9]+).*/\1/')
+  # Defensive: a future SUMMARY format that emits non-numeric values would
+  # break the arithmetic that follows. Catch and route to a clear error.
+  if ! [[ "$FILE_PASS" =~ ^[0-9]+$ ]] || ! [[ "$FILE_FAIL" =~ ^[0-9]+$ ]]; then
+    echo "run.sh: WARN malformed SUMMARY from $(basename "$TEST_FILE"): '$SUMMARY'" >&2
+    TOTAL_FAIL=$((TOTAL_FAIL + 1))
+    FAILED_FILES+=("$(basename "$TEST_FILE")")
+    continue
+  fi
+  # Zero-assertion files are a hazard, not a clean PASS: a future test that
+  # accidentally comments out every assertion would otherwise silently
+  # report green. Treat as a runner-level error.
+  if [ "$FILE_PASS" = "0" ] && [ "$FILE_FAIL" = "0" ]; then
+    echo "run.sh: WARN $(basename "$TEST_FILE") executed no assertions; counting as failure" >&2
+    RUNNER_ERR=1
+    FAILED_FILES+=("$(basename "$TEST_FILE")")
+    continue
+  fi
   TOTAL_PASS=$((TOTAL_PASS + FILE_PASS))
   TOTAL_FAIL=$((TOTAL_FAIL + FILE_FAIL))
   if [ "$FILE_FAIL" != "0" ]; then
@@ -95,8 +137,16 @@ done
 
 echo "=== overall ==="
 echo "TOTAL pass=$TOTAL_PASS fail=$TOTAL_FAIL"
-if [ "$TOTAL_FAIL" != "0" ]; then
+if [ "${#FAILED_FILES[@]}" -gt 0 ]; then
   echo "FAILED files: ${FAILED_FILES[*]}"
+fi
+# Exit code precedence: runner errors (exit 2) beat assertion failures
+# (exit 1) beat success (exit 0). The two are reported separately above so
+# CI can tell "you broke the harness" apart from "a real test failed".
+if [ "$RUNNER_ERR" != "0" ]; then
+  exit 2
+fi
+if [ "$TOTAL_FAIL" != "0" ]; then
   exit 1
 fi
 exit 0

--- a/plugins/flow/tests/run.sh
+++ b/plugins/flow/tests/run.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# plugins/flow/tests/run.sh — flow plugin test runner.
+#
+# Discovers *.test.sh files in this directory, runs each in a fresh subshell
+# with assert.sh sourced, aggregates pass/fail counts, and exits non-zero if
+# any assertion failed. No external test framework — pure bash + POSIX utils.
+#
+# Usage:
+#   plugins/flow/tests/run.sh              # run all tests
+#   plugins/flow/tests/run.sh <file.test.sh>  # run one file
+#
+# Exit:
+#   0 — all assertions passed
+#   1 — at least one assertion failed
+#   2 — runner-level error (missing test file, etc.)
+
+set -uo pipefail
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$TESTS_DIR/lib/assert.sh"
+
+if [ ! -f "$LIB" ]; then
+  echo "run.sh: missing $LIB" >&2
+  exit 2
+fi
+
+# repo root is two levels up from tests/ (plugins/flow/tests -> plugins/flow -> repo).
+REPO_ROOT="$(cd "$TESTS_DIR/../../.." && pwd)"
+
+# Tests run from REPO_ROOT so relative paths in commands/ (e.g.,
+# `.claude/settings.flow.local.json`) resolve against the same directory the
+# actual command bash blocks would resolve them in.
+cd "$REPO_ROOT"
+
+if [ $# -gt 0 ]; then
+  TEST_FILES=("$@")
+else
+  # Glob in TESTS_DIR; sort for deterministic order.
+  shopt -s nullglob
+  TEST_FILES=("$TESTS_DIR"/*.test.sh)
+  shopt -u nullglob
+fi
+
+if [ "${#TEST_FILES[@]}" -eq 0 ]; then
+  echo "run.sh: no *.test.sh files found in $TESTS_DIR" >&2
+  exit 2
+fi
+
+TOTAL_PASS=0
+TOTAL_FAIL=0
+FAILED_FILES=()
+
+for TEST_FILE in "${TEST_FILES[@]}"; do
+  # Resolve relative arg against TESTS_DIR.
+  if [ ! -f "$TEST_FILE" ] && [ -f "$TESTS_DIR/$TEST_FILE" ]; then
+    TEST_FILE="$TESTS_DIR/$TEST_FILE"
+  fi
+  if [ ! -f "$TEST_FILE" ]; then
+    echo "run.sh: $TEST_FILE not found" >&2
+    TOTAL_FAIL=$((TOTAL_FAIL + 1))
+    FAILED_FILES+=("$TEST_FILE")
+    continue
+  fi
+
+  echo "=== $(basename "$TEST_FILE") ==="
+  # Capture each file's output AND its summary line so the runner can
+  # extract counts. Run in a subshell so counter state doesn't leak.
+  OUTPUT=$(
+    set +e
+    # shellcheck source=lib/assert.sh
+    source "$LIB"
+    # shellcheck disable=SC1090
+    source "$TEST_FILE"
+    _flow_test_summary
+  )
+  printf '%s\n' "$OUTPUT"
+  # Extract last SUMMARY line — robust against tests that themselves print
+  # the word "SUMMARY" in PASS messages.
+  SUMMARY=$(printf '%s\n' "$OUTPUT" | grep -E '^SUMMARY pass=[0-9]+ fail=[0-9]+$' | tail -1)
+  if [ -z "$SUMMARY" ]; then
+    echo "run.sh: WARN no SUMMARY line from $(basename "$TEST_FILE"); counting as 1 failure" >&2
+    TOTAL_FAIL=$((TOTAL_FAIL + 1))
+    FAILED_FILES+=("$(basename "$TEST_FILE")")
+    continue
+  fi
+  FILE_PASS=$(printf '%s' "$SUMMARY" | sed -E 's/.*pass=([0-9]+).*/\1/')
+  FILE_FAIL=$(printf '%s' "$SUMMARY" | sed -E 's/.*fail=([0-9]+).*/\1/')
+  TOTAL_PASS=$((TOTAL_PASS + FILE_PASS))
+  TOTAL_FAIL=$((TOTAL_FAIL + FILE_FAIL))
+  if [ "$FILE_FAIL" != "0" ]; then
+    FAILED_FILES+=("$(basename "$TEST_FILE")")
+  fi
+  echo ""
+done
+
+echo "=== overall ==="
+echo "TOTAL pass=$TOTAL_PASS fail=$TOTAL_FAIL"
+if [ "$TOTAL_FAIL" != "0" ]; then
+  echo "FAILED files: ${FAILED_FILES[*]}"
+  exit 1
+fi
+exit 0

--- a/plugins/flow/tests/validate-skill-input.test.sh
+++ b/plugins/flow/tests/validate-skill-input.test.sh
@@ -87,12 +87,83 @@ assert_exit 1 "$EXIT" "exit 1 on minLength violation"
 assert_contains "validation failed" "$ERR" "stderr surfaces validation failure"
 
 # --- Test 8: PYTHONSAFEPATH=1 is exported (defense against attacker-controlled
-# CWD modules from `gh pr checkout` of a hostile fork). Static check on the
-# helper source — the runtime effect is implicit and hard to assert directly,
-# but a future maintainer removing the line in a refactor would silently
-# weaken the threat-model. The defensive sys.path filter inside the Python
-# heredoc provides the Python-<3.11 fallback.
-_flow_test_begin "PYTHONSAFEPATH=1 export preserved in helper source"
+# CWD modules from `gh pr checkout` of a hostile fork). Defense-in-depth:
+# the static-source checks below catch a refactor that removes the line,
+# AND a runtime check below proves the defense actually works.
+_flow_test_begin "PYTHONSAFEPATH=1 defense present in helper source"
 SOURCE=$(cat "$HELPER")
 assert_contains "export PYTHONSAFEPATH=1" "$SOURCE" "PYTHONSAFEPATH=1 export is present"
-assert_contains 'sys.path[:] = [p for p in sys.path if p not in ("", ".")]' "$SOURCE" "Python <3.11 sys.path filter fallback is present"
+# Use a structurally lenient grep (matches `if p not in` regardless of the
+# quote style or whitespace inside the comprehension) so reformatting the
+# helper doesn't silently weaken the source-text check.
+assert_match 'if p not in' "$SOURCE" "Python <3.11 sys.path filter fallback is present"
+
+# --- Test 9: PYTHONSAFEPATH defense — runtime verification with a hostile
+# CWD-poisoned module. Plant a `./jsonschema.py` that would exit 77 if
+# imported instead of the real jsonschema package, then run the helper from
+# that directory. If the defense works (PYTHONSAFEPATH=1 + sys.path filter),
+# the helper imports the real jsonschema (or falls back to shape-check) and
+# exits normally — never 77. The source-text check (Test 8) catches removal;
+# this runtime check catches functional breakage.
+_flow_test_begin "PYTHONSAFEPATH defense: hostile ./jsonschema.py is not imported"
+POISON_DIR=$(mktemp -d -t vsi.poison.XXXXXX)
+trap "rm -rf '$POISON_DIR'" RETURN 2>/dev/null || true
+cat > "$POISON_DIR/jsonschema.py" <<'POISON'
+# If this is imported instead of the real package, exit with a sentinel.
+import sys
+sys.exit(77)
+POISON
+cat > "$POISON_DIR/yaml.py" <<'POISON'
+# Belt-and-suspenders: helper doesn't import yaml but we don't want to risk
+# a future refactor importing it from CWD either.
+import sys
+sys.exit(78)
+POISON
+VALID_JSON='{"acceptanceCriteria":[{"text":"User can log in successfully"}]}'
+# Run from inside the poisoned directory so a vulnerable Python would
+# resolve `./jsonschema.py` first on sys.path.
+EXIT=0
+(cd "$POISON_DIR" && CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/flow" "$HELPER" "$EXISTING_SKILL" "$VALID_JSON" >/dev/null 2>&1) || EXIT=$?
+rm -rf "$POISON_DIR"
+# Exit must NOT be 77 (real jsonschema or fallback used) or 78 (yaml.py
+# bypass). Anything else means the defense held.
+case "$EXIT" in
+  77) _flow_assert_fail "PYTHONSAFEPATH defense breached — hostile ./jsonschema.py was imported (exit=77)" ;;
+  78) _flow_assert_fail "PYTHONSAFEPATH defense breached — hostile ./yaml.py was imported (exit=78)" ;;
+  *)  _flow_assert_pass "hostile CWD modules not imported (exit=$EXIT, !=77, !=78)" ;;
+esac
+
+# --- Test 10: jsonschema-fallback path coverage
+# The helper falls back to an in-house shape-check when `import jsonschema`
+# fails (bin/validate-skill-input.sh:112-220). In CI jsonschema IS installed
+# so Tests 5/6/7 only hit the jsonschema branch. Force the fallback by
+# running the helper under a shadow PATH that has `python3` but where
+# jsonschema is unreachable — we shadow with PYTHONPATH=/dev/null which
+# blocks all third-party imports without affecting stdlib.
+_flow_test_begin "jsonschema-fallback path: shape-check produces 'fallback' NOTE"
+# Force jsonschema ImportError by emptying sys.path of site-packages.
+# `python3 -I` (isolated mode) disables user site-packages and PYTHONPATH;
+# combined with `-S` (no `site.py`) it never finds installed jsonschema, so
+# the helper falls through to its shape-checker. We can't easily inject
+# `-I -S` into the helper, but we can stage a shadow PATH where the wrapped
+# `python3` invokes the real interpreter with `-I -S`.
+SHADOW_PY=$(mktemp -d -t vsi.shadow.XXXXXX)
+trap "rm -rf '$SHADOW_PY'" RETURN 2>/dev/null || true
+cat > "$SHADOW_PY/python3" <<SHADOW_EOF
+#!/bin/sh
+# Disable user-site and PYTHONPATH so jsonschema (always installed via pip
+# or system) is not reachable. Stdlib (json, sys, re) stays reachable.
+exec "$(command -v python3)" -I -S "\$@"
+SHADOW_EOF
+chmod +x "$SHADOW_PY/python3"
+VALID_JSON='{"acceptanceCriteria":[{"text":"User can log in successfully"}]}'
+# Use the shadow python by prepending to PATH. Capture stderr for the NOTE.
+STDERR_TMP=$(mktemp -t vsi.fallback.se.XXXXXX)
+EXIT=0
+PATH="$SHADOW_PY:$PATH" CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/flow" \
+  "$HELPER" "$EXISTING_SKILL" "$VALID_JSON" >/dev/null 2>"$STDERR_TMP" || EXIT=$?
+ERR=$(cat "$STDERR_TMP")
+rm -f "$STDERR_TMP"; rm -rf "$SHADOW_PY"
+assert_exit 0 "$EXIT" "fallback path returns 0 on valid input"
+assert_contains "jsonschema package not installed" "$ERR" "fallback path emits the NOTE on stderr"
+assert_contains "shape-check fallback" "$ERR" "NOTE names the fallback validator"

--- a/plugins/flow/tests/validate-skill-input.test.sh
+++ b/plugins/flow/tests/validate-skill-input.test.sh
@@ -51,9 +51,14 @@ assert_exit 2 "$EXIT" "exit 2"
 assert_contains "schema not found" "$ERR" "stderr names the missing schema"
 
 # --- Test 4: input is not valid JSON → exit 2
+# Note: `CLAUDE_PLUGIN_ROOT=...` MUST be inside the `$(...)` so it scopes to
+# the helper invocation. Putting it on a line preceding `ERR=$(...)` makes
+# it a parallel parent-shell assignment instead of a one-shot exec-env
+# (because `ERR=$(...)` is itself an assignment, not a command), and the
+# helper would only find the schema via the git-rev-parse fallback — testing
+# the wrong code path.
 _flow_test_begin "non-JSON input → exit 2"
-CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/flow" \
-  ERR=$("$HELPER" "$EXISTING_SKILL" 'not json at all' 2>&1 >/dev/null)
+ERR=$(CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/flow" "$HELPER" "$EXISTING_SKILL" 'not json at all' 2>&1 >/dev/null)
 EXIT=$?
 assert_exit 2 "$EXIT" "exit 2"
 assert_contains "not valid JSON" "$ERR" "stderr names the JSON parse failure"

--- a/plugins/flow/tests/validate-skill-input.test.sh
+++ b/plugins/flow/tests/validate-skill-input.test.sh
@@ -1,0 +1,93 @@
+# Tests for plugins/flow/bin/validate-skill-input.sh.
+#
+# Contract (from the helper's header):
+#   Usage: validate-skill-input.sh <skill-name> '<json-input>'
+#
+#   Exit 0: input validates against the schema.
+#   Exit 1: input fails validation (rationale on stderr).
+#   Exit 2: schema not found, input not valid JSON, kebab-case violation,
+#           or other infrastructure error.
+#
+#   Schema lookup: ${CLAUDE_PLUGIN_ROOT}/schemas/<skill>/input-schema.json,
+#   falling back to <repo>/plugins/flow/schemas/<skill>/ for in-repo callers.
+#
+# Prerequisites: python3. The jsonschema package is optional — the helper
+# falls back to an in-house shape-checker for the JSON Schema subset flow
+# actually uses. Tests cover both paths where feasible.
+
+HELPER="$REPO_ROOT/plugins/flow/bin/validate-skill-input.sh"
+
+# An always-present skill schema in this repo. criterion-verification-map
+# declares `acceptanceCriteria` (array, minItems=1) as required.
+EXISTING_SKILL="criterion-verification-map"
+
+# Skip the suite if python3 is unavailable.
+if ! command -v python3 >/dev/null 2>&1; then
+  _flow_test_begin "python3 prerequisite"
+  _flow_assert_pass "SKIP: python3 not installed"
+  return 0
+fi
+
+# --- Test 1: too few args → exit 2 with usage
+_flow_test_begin "no args → exit 2 with usage"
+ERR=$("$HELPER" 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 2 "$EXIT" "exit 2"
+assert_contains "Usage:" "$ERR" "usage text on stderr"
+
+# --- Test 2: invalid skill name (path traversal attempt) → exit 2
+_flow_test_begin "path-traversal skill name → exit 2 (charset guard)"
+ERR=$("$HELPER" "../../../etc/passwd" '{}' 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 2 "$EXIT" "exit 2"
+assert_contains "invalid skill name" "$ERR" "stderr names the charset rejection"
+assert_contains "kebab-case" "$ERR" "stderr explains the expected form"
+
+# --- Test 3: schema not found for a well-formed but unknown skill name
+_flow_test_begin "schema not found → exit 2"
+ERR=$("$HELPER" "no-such-skill-anywhere" '{}' 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 2 "$EXIT" "exit 2"
+assert_contains "schema not found" "$ERR" "stderr names the missing schema"
+
+# --- Test 4: input is not valid JSON → exit 2
+_flow_test_begin "non-JSON input → exit 2"
+CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/flow" \
+  ERR=$("$HELPER" "$EXISTING_SKILL" 'not json at all' 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 2 "$EXIT" "exit 2"
+assert_contains "not valid JSON" "$ERR" "stderr names the JSON parse failure"
+
+# --- Test 5: input validates → exit 0
+_flow_test_begin "valid input → exit 0"
+VALID_JSON='{"acceptanceCriteria":[{"text":"User can log in successfully"}]}'
+OUT=$(CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/flow" "$HELPER" "$EXISTING_SKILL" "$VALID_JSON" 2>&1)
+EXIT=$?
+assert_exit 0 "$EXIT" "exit 0 on valid input"
+
+# --- Test 6: input violates schema (missing required field) → exit 1
+_flow_test_begin "missing required field → exit 1"
+INVALID_JSON='{"someOtherField": "x"}'
+ERR=$(CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/flow" "$HELPER" "$EXISTING_SKILL" "$INVALID_JSON" 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 1 "$EXIT" "exit 1 on schema violation"
+assert_contains "validation failed" "$ERR" "stderr surfaces validation failure"
+
+# --- Test 7: input violates schema (minLength on string) → exit 1
+_flow_test_begin "string under minLength → exit 1"
+INVALID_JSON='{"acceptanceCriteria":[{"text":"hi"}]}'  # minLength=5
+ERR=$(CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/flow" "$HELPER" "$EXISTING_SKILL" "$INVALID_JSON" 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 1 "$EXIT" "exit 1 on minLength violation"
+assert_contains "validation failed" "$ERR" "stderr surfaces validation failure"
+
+# --- Test 8: PYTHONSAFEPATH=1 is exported (defense against attacker-controlled
+# CWD modules from `gh pr checkout` of a hostile fork). Static check on the
+# helper source — the runtime effect is implicit and hard to assert directly,
+# but a future maintainer removing the line in a refactor would silently
+# weaken the threat-model. The defensive sys.path filter inside the Python
+# heredoc provides the Python-<3.11 fallback.
+_flow_test_begin "PYTHONSAFEPATH=1 export preserved in helper source"
+SOURCE=$(cat "$HELPER")
+assert_contains "export PYTHONSAFEPATH=1" "$SOURCE" "PYTHONSAFEPATH=1 export is present"
+assert_contains 'sys.path[:] = [p for p in sys.path if p not in ("", ".")]' "$SOURCE" "Python <3.11 sys.path filter fallback is present"


### PR DESCRIPTION
## Summary

Adds a pure-bash test harness under `plugins/flow/tests/` that catches the two regression categories manual review repeatedly missed during PRs #103 and #104:

- **`cascade-resolve.test.sh`** — 9 tests for `bin/cascade-resolve.sh` (precedence cascade, `--default`, `--compact`, missing-expression, unknown-flag, per-source parse error WARN+skip, jq-missing graceful degrade).
- **`command-frontmatter.test.sh`** — 5 static lints across all 17 commands: every `!` block ends with `true` (F3-class); no destructive verbs inside `!` blocks; `$ARGUMENTS` always quoted/extracted (F2/F6-class); Required Skills resolve to skills dirs; `allowed-tools` `Bash()` prefixes have matching body invocations (C1-class).

Current run: **29/29 PASS**.

CI workflow (`.github/workflows/flow-tests.yml`) gates PRs touching `plugins/flow/{bin,commands,skills,tests}/`. Ubuntu latest, no setup — bash + jq + awk are preinstalled.

## Regression-of-record verification

Each lint was verified by temporarily injecting the regression and confirming the test catches it:

| Regression flavor | Injection | Caught by |
|---|---|---|
| F3 — `!` block exits non-zero | replace `true` → `false` in status.md | `FAIL status.md ! block #1 last line is 'false'` |
| Destructive verb in `!` block | insert `gh pr merge 999 --squash` in status.md | `FAIL status.md contains destructive verb inside ! block` |
| F2 — bare `$ARGUMENTS` | insert `RAW=$ARGUMENTS` in resolve.md | `FAIL resolve.md has bare $ARGUMENTS in ! block` |

## Scope deviation from misty-roaming-garden plan

- `aggregate-findings-ledger.test.sh` **dropped** — that helper was scoped to PR #103 (closed) and never landed on main. Ledger logic still lives inline in `status.md` and `merge.md`, and is exercised indirectly via `command-frontmatter.test.sh`.
- `mock-gh.sh` **dropped** — no test currently needs it (would only be needed for the dropped ledger unit tests).

The plan's Item 2 (best-practice audit + `command-patterns.md`) is **not in this PR**; per the evaluation, most of that doc was absorbed by `references/command-output-format.md` shipped in PR #104, and the residual gaps (`disable-model-invocation` decision, allowed-tools cross-check) are deferred or partially covered by the static lint here.

## Test plan

- [x] `plugins/flow/tests/run.sh` runs locally and reports 29/29 PASS
- [x] Each lint category caught by temporarily injecting a regression
- [x] No external test framework dependency (bash + POSIX utils + jq only)
- [x] Mock `jq` removal proves the jq-missing path on both macOS (jq in /usr/bin) and CI (jq in /usr/bin) via a shadow-symlink PATH
- [ ] CI run completes green on this PR