### PR TITLE
feat(flow): llm-operator-principles skill + anti-deferral defaults (#106)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Synapti plugin marketplace",
-    "version": "4.3.2"
+    "version": "4.4.0"
   },
   "plugins": [
     {
@@ -109,7 +109,7 @@
       "name": "flow",
       "source": "./plugins/flow",
       "description": "Skill-driven workflow plugin for GitHub development with excellence-by-default quality gates. Encodes team knowledge as composable skills, enforces safety through hooks, and compounds learning across sessions.",
-      "version": "2.3.2",
+      "version": "2.4.0",
       "author": {
         "name": "Daniel Bentes"
       },

--- a/plugins/flow/.claude-plugin/plugin.json
+++ b/plugins/flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "Skill-driven workflow plugin for GitHub development with excellence-by-default quality gates. Encodes team knowledge as composable skills, enforces safety through hooks, and compounds learning across sessions. Strict TDD, Stranger Test, holdout validation, and evidence-based verification built in.",
   "author": {
     "name": "Synapti AI",

--- a/plugins/flow/CHANGELOG.md
+++ b/plugins/flow/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## 2.4.0 (2026-05-19)
+
+### Behavior change — LLM Operator Principles
+
+The flow plugin now treats Claude as an LLM operator that does not tire. Three structural shifts close the deferral and time-estimation patterns observed in v2.3.x usage despite the existing "P3 not deferrable" policy.
+
+#### New skill: `llm-operator-principles`
+
+A new foundational skill at `skills/llm-operator-principles/SKILL.md` is consulted by every `/flow:*` command. It encodes:
+
+- **Convergence = zero findings, not exhausted budget.** Iteration ceilings are safety nets, not budgets.
+- **In-PR fix by default for all findings.** Finding triage (P1/P2/P3 disposition) is NEVER a valid escalation trigger.
+- **Calendar-time estimates prohibited.** PR bodies, decision-journal entries, escalations, and resolution comments MUST NOT include weeks/days/hours/sprints/ETAs.
+- **Multi-PR sequencing is the user's call.** Default to one PR that resolves all findings.
+
+#### Settings changes
+
+- `fixForwardMaxIterations` default raised from `2` to `10`
+- `reviewCycleLimit` default raised from `3` to `10`
+- New flag `autonomous` (default `false`) — when `true`, removes `AskUserQuestion` interruptions for any decision the agent can resolve under the operator principles. Recommended for sole-maintainer repositories.
+- New flag `minimalScope` (default `false`) — when `true`, restores the original follow-up-issue workflow for cosmetic P3 in untouched files only. P1/P2 findings still fix in-PR even in this mode.
+
+#### Command changes
+
+- `commands/address.md`, `commands/review.md`: the "Create a follow-up issue?" `AskUserQuestion` prompts are removed in default mode. Cosmetic P3 in untouched files is fix-if-bounded (<10 lines) or documented inline in the PR body. `minimalScope: true` restores the original workflow.
+- `commands/pr.md`: removed the "after 2 fix iterations, remaining P2 become Known issues" deferral path. P2s are fixed until zero remain.
+- All six commands (`start`, `address`, `pr`, `review`, `commit`, `merge`) reference `llm-operator-principles` as the first required skill.
+
+#### Reference changes
+
+- `references/escalation-format.md`: the `Time sensitivity` field is replaced by a `Blocking?` field (yes/soft/no, no calendar verbs). Finding triage is explicitly added under "When escalation IS NOT required."
+- The same anti-deferral and anti-estimation language is propagated to `skills/code-quality-principles`, `skills/feedback-resolution`, `skills/code-review-methodology`, `skills/evidence-based-development`, `skills/autonomous-workflow`, `skills/specification-capture`, and `commands/commit.md`.
+
+#### Template changes
+
+- `templates/pr-body.md`: HTML-comment guard forbids calendar-time estimates in any field.
+
+#### Migration
+
+To restore v2.3.x behavior, set in `.claude/settings.flow.json`:
+
+```json
+{
+  "fixForwardMaxIterations": 2,
+  "reviewCycleLimit": 3,
+  "minimalScope": true
+}
+```
+
+Closes #106.
+
 ## 2.3.1 (2026-05-08)
 
 ### Bug fixes

--- a/plugins/flow/CHANGELOG.md
+++ b/plugins/flow/CHANGELOG.md
@@ -39,6 +39,8 @@ A new foundational skill at `skills/llm-operator-principles/SKILL.md` is consult
 
 #### Migration
 
+**Behavior change for unpinned configs.** Existing `.claude/settings.flow.json` files that explicitly pinned `fixForwardMaxIterations` or `reviewCycleLimit` to the old defaults (2 / 3) keep their pinned values — the cascade honors local settings. Configs that did not pin these keys (relying on plugin defaults) will see the new 10 / 10 ceilings on first run. Review against the new safety-net framing: ceilings are no longer planned stop points; reaching them is the signal that you have hit **genuine non-convergence** (see `skills/llm-operator-principles/SKILL.md` § Genuine non-convergence).
+
 To restore v2.3.x behavior, set in `.claude/settings.flow.json`:
 
 ```json
@@ -48,6 +50,14 @@ To restore v2.3.x behavior, set in `.claude/settings.flow.json`:
   "minimalScope": true
 }
 ```
+
+#### Additional changes from in-PR self-review (fix-forward on PR #107)
+
+The first run of `/flow:review` under the new operator principles surfaced five findings; all were fixed in-PR per the new defaults (no deferral). Notable additions:
+
+- `bin/flow-escalate.sh` — `--blocking` now enforces a `yes|soft|no` value space. Without this guard, a caller passing `--blocking "by Friday"` would defeat the calendar-time-rename's purpose. Test 8 covers the enforcement (5 invalid + 3 valid values).
+- `bin/flow-escalate.sh` — trailing-flag detection via `require_value` helper. A trailing flag like `flow-escalate.sh ... --blocking` (no value following) now produces "`--blocking requires a value`" instead of the misleading missing-fields message. Test 9 covers this path.
+- `skills/llm-operator-principles/SKILL.md` and `commands/address.md` — new "Genuine non-convergence" guidance defining the ONE case where an iteration ceiling becomes a stop point: same findings persist 3 iterations in a row AND `fixForwardMaxIterations` is reached. Closes the silent-failure gap where the LLM could either silently exceed the ceiling or exit with unresolved findings.
 
 Closes #106.
 

--- a/plugins/flow/README.md
+++ b/plugins/flow/README.md
@@ -110,8 +110,9 @@ claude plugins add ./plugins/flow
 ## Architecture
 
 ```
-SKILL LIBRARY (24 skills)
+SKILL LIBRARY (25 skills)
   ├── Foundation (always loaded, stable shape)
+  │   ├── llm-operator-principles (operator stance — convergence, anti-deferral, anti-estimation)
   │   ├── evidence-based-development
   │   ├── autonomous-workflow
   │   └── code-quality-principles

--- a/plugins/flow/README.md
+++ b/plugins/flow/README.md
@@ -36,6 +36,29 @@ Pre-existing findings in touched files keep their natural priority (no longer ca
 |---------|-------------|-------------|
 | `testing.tddMode` | `"suggest"` | `"enforce"` |
 | `verdict.requireAllPass` | `false` | `true` |
+| `fixForwardMaxIterations` | `2` | `10` |
+| `reviewCycleLimit` | `3` | `10` |
+| `autonomous` | _(new)_ | `false` |
+| `minimalScope` | _(new)_ | `false` |
+
+### LLM Operator Principles (v2.4)
+
+Flow v2.4 introduces the `llm-operator-principles` foundational skill that frames Claude as an LLM operator that does not tire. This skill is consulted by every `/flow:*` command and shifts default behavior in three ways:
+
+1. **Convergence = zero findings, not exhausted budget.** Iteration ceilings (`fixForwardMaxIterations`, `reviewCycleLimit`) defaulted to 10 because the ceiling is a safety net against true infinite loops, not a planned stop point. Approaching the ceiling without convergence is a signal to re-check understanding, not to escalate.
+2. **In-PR fix by default for all findings.** P1/P2/P3 findings are fixed in the current PR. Finding triage is NEVER a valid escalation trigger — escalations are reserved for true product/architecture/irreversible-action decisions. Default mode does NOT create follow-up issues; cosmetic P3 in untouched files is fix-if-bounded or document inline.
+3. **Calendar-time estimates prohibited.** PR bodies, decision-journal entries, escalations, and resolution comments MUST NOT include weeks/days/hours/sprints/ETAs. The old escalation "Time sensitivity" field is replaced by a "Blocking?" field with yes/soft/no values.
+
+See [`skills/llm-operator-principles/SKILL.md`](skills/llm-operator-principles/SKILL.md) for the full operating frame.
+
+### Modes
+
+Two opt-in modes complement the LLM-operator defaults:
+
+- `autonomous: true` — removes `AskUserQuestion` interruptions for any decision the agent can resolve under the operator principles. Reserves `AskUserQuestion` for Tier 3 confirmations (merge, release) and true product/architecture decisions. Recommended for sole-maintainer repositories.
+- `minimalScope: true` — restores the original follow-up-issue workflow for cosmetic P3 in untouched files only. Use when scope is deliberately constrained (e.g., a one-line hotfix that should not expand into a refactor). P1/P2 findings still fix in-PR even in this mode.
+
+Both can be toggled in settings or in-conversation ("autonomous mode on", "minimal scope on").
 
 ### Opting Out
 
@@ -49,7 +72,10 @@ Teams not ready for strict defaults can restore previous behavior:
   },
   "verdict": {
     "requireAllPass": false
-  }
+  },
+  "fixForwardMaxIterations": 2,
+  "reviewCycleLimit": 3,
+  "minimalScope": true
 }
 ```
 
@@ -64,6 +90,7 @@ Set these in `.claude/settings.flow.json` or `.claude/settings.flow.local.json`.
 - Evidence bundles require completeness subsections (not tested, limitations, adversarial cases)
 - Holdout validation runs inline during VERIFY, review, and address phases
 - Spec Validation Gate requires automated verification commands for every acceptance criterion
+- (v2.4) `llm-operator-principles` skill introduced; iteration ceilings raised to 10; follow-up-issue workflow now opt-in via `minimalScope`; calendar-time estimates prohibited; escalation "Time sensitivity" field renamed to "Blocking?"
 
 See [gate-configuration.md](references/gate-configuration.md) for full gate details.
 
@@ -193,7 +220,7 @@ The plugin ships three canonical reference documents (under `plugins/flow/refere
 | Reference | What it canonicalizes | Primary consumers |
 |---|---|---|
 | [`finding-schema.md`](references/finding-schema.md) | Reviewer output: 6-field row shape (ID, Category, Location, Problem, Suggested Fix, Confidence) plus the marker-only `status` and `disposition` fields. Compatible with the existing `FLOW_REVIEW_CYCLE` 7-field marker schema. | All 4 reviewer agents (`code-reviewer`, `security-reviewer`, `error-handler-inspector`, `integration-verifier`); orchestrators (`commands/review.md`, `commands/pr.md`, `commands/address.md`) |
-| [`escalation-format.md`](references/escalation-format.md) | Six-field Proactive-Autonomy escalation structure (Situation, What I tried, Options, Recommendation, Time sensitivity, Risk). Delivered via `AskUserQuestion`, never inline text. | All 6 escalating commands (`start`, `pr`, `merge`, `commit`, `address`, `resolve`); reviewer agents that surface NEEDS-HUMAN-REVIEW |
+| [`escalation-format.md`](references/escalation-format.md) | Six-field Proactive-Autonomy escalation structure (Situation, What I tried, Options, Recommendation, Blocking?, Risk). Delivered via `AskUserQuestion`, never inline text. | All 6 escalating commands (`start`, `pr`, `merge`, `commit`, `address`, `resolve`); reviewer agents that surface NEEDS-HUMAN-REVIEW |
 | [`evidence-bundle-format.md`](references/evidence-bundle-format.md) | Markdown shape verdict-judge consumes: per-criterion sections with mandatory `### Does NOT promise` plus three completeness subsections. `none` is a valid positive-statement answer; bare blank triggers auto-FAIL. | `commands/start.md` Phase 4 (producer), `agents/verdict-judge.md` Step 1 (consumer); `criterion-verification-map` skill (plan-time inputs) |
 
 Plus the existing references documenting policy, parser rules, and configuration:

--- a/plugins/flow/agents/code-reviewer.md
+++ b/plugins/flow/agents/code-reviewer.md
@@ -9,7 +9,7 @@ memory: project
 
 # Code Reviewer Agent
 
-You are a code review specialist for the flow plugin. Analyze code changes for quality, correctness, and security. When findings require human judgment (genuinely ambiguous trade-offs, architectural preferences), use the six-field Proactive Autonomy escalation structure (Situation / What I tried / Options / My recommendation / Time sensitivity / Risk if wrong) rather than open-ended questions or silent deferrals.
+You are a code review specialist for the flow plugin. Analyze code changes for quality, correctness, and security. When a true product/architecture decision arises (NOT finding triage), use the six-field Proactive Autonomy escalation structure (Situation / What I tried / Options / My recommendation / Blocking? / Risk if wrong) rather than open-ended questions or silent deferrals. Finding triage (P1/P2/P3 disposition) is NEVER a valid escalation trigger — every finding is fixed in-PR by default per `skills/llm-operator-principles/SKILL.md`.
 
 ## Process
 

--- a/plugins/flow/agents/error-handler-inspector.md
+++ b/plugins/flow/agents/error-handler-inspector.md
@@ -9,7 +9,7 @@ memory: project
 
 # Error Handler Inspector Agent
 
-You are an error handling specialist for the flow plugin. Analyze code changes for unhandled errors, silent failures, and exception handling gaps. When findings require human judgment (e.g., acceptable risk trade-offs, performance vs. safety decisions), use the six-field Proactive Autonomy escalation structure (Situation / What I tried / Options / My recommendation / Time sensitivity / Risk if wrong) rather than open-ended questions or silent deferrals.
+You are an error handling specialist for the flow plugin. Analyze code changes for unhandled errors, silent failures, and exception handling gaps. When a true risk trade-off decision arises (e.g., performance vs. safety — NOT finding triage), use the six-field Proactive Autonomy escalation structure (Situation / What I tried / Options / My recommendation / Blocking? / Risk if wrong) rather than open-ended questions or silent deferrals. Finding triage (P1/P2/P3 disposition) is NEVER a valid escalation trigger; fix in-PR per `skills/llm-operator-principles/SKILL.md`.
 
 ## Process
 

--- a/plugins/flow/agents/security-reviewer.md
+++ b/plugins/flow/agents/security-reviewer.md
@@ -9,7 +9,7 @@ memory: project
 
 # Security Reviewer Agent
 
-You are a security review specialist for the flow plugin. Focus exclusively on security concerns in code changes. When findings require human judgment (e.g., risk acceptance decisions, security vs. usability trade-offs), use the six-field Proactive Autonomy escalation structure (Situation / What I tried / Options / My recommendation / Time sensitivity / Risk if wrong) rather than open-ended questions or silent deferrals.
+You are a security review specialist for the flow plugin. Focus exclusively on security concerns in code changes. When a true security decision arises (e.g., risk acceptance, security vs. usability trade-offs — NOT finding triage), use the six-field Proactive Autonomy escalation structure (Situation / What I tried / Options / My recommendation / Blocking? / Risk if wrong) rather than open-ended questions or silent deferrals. Finding triage (P1/P2/P3 disposition) is NEVER a valid escalation trigger; fix in-PR per `skills/llm-operator-principles/SKILL.md`.
 
 ## Process
 

--- a/plugins/flow/agents/verdict-judge.md
+++ b/plugins/flow/agents/verdict-judge.md
@@ -25,7 +25,7 @@ You are an independent verification judge for the flow plugin. Your role is to e
 2. The evidence bundle (test outputs, curl responses, screenshot paths, build logs)
 3. The holdout-validation output (P1/P2/P3 findings from cross-referencing self-review claims against actual file state)
 
-This separation is intentional. You are a second set of eyes that evaluates outcomes, not process. When issuing NEEDS-HUMAN-REVIEW verdicts, structure them using the six-field Proactive Autonomy escalation (Situation / What I tried / Options / My recommendation / Time sensitivity / Risk if wrong) so the human receives actionable context rather than an open-ended question.
+This separation is intentional. You are a second set of eyes that evaluates outcomes, not process. When issuing NEEDS-HUMAN-REVIEW verdicts, structure them using the six-field Proactive Autonomy escalation (Situation / What I tried / Options / My recommendation / Blocking? / Risk if wrong) so the human receives actionable context rather than an open-ended question. The `Blocking?` field replaced an older `Time sensitivity` field — use yes/soft/no values, no calendar-time language.
 
 ## Process
 

--- a/plugins/flow/bin/flow-escalate.sh
+++ b/plugins/flow/bin/flow-escalate.sh
@@ -55,16 +55,26 @@ RECOMMENDATION=""
 BLOCKING=""
 RISK=""
 
+# Distinguishes "flag passed without a value" (e.g., trailing `--blocking`) from
+# "flag absent." Without this guard, a trailing flag consumes its own slot via
+# `${2:-}` and the user gets a misleading "missing required fields" message.
+require_value() {
+  if [ "$2" -lt 2 ]; then
+    echo "flow-escalate.sh: $1 requires a value" >&2
+    exit 1
+  fi
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
-    --situation)         SITUATION="${2:-}"; shift 2 ;;
-    --tried)             TRIED="${2:-}"; shift 2 ;;
-    --options)           OPTIONS="${2:-}"; shift 2 ;;
-    --recommendation)    RECOMMENDATION="${2:-}"; shift 2 ;;
-    --blocking)          BLOCKING="${2:-}"; shift 2 ;;
-    --risk)              RISK="${2:-}"; shift 2 ;;
-    -h|--help)           usage; exit 0 ;;
-    *)                   echo "flow-escalate.sh: unknown argument: $1" >&2; usage; exit 1 ;;
+    --situation)      require_value "$1" "$#"; SITUATION="$2"; shift 2 ;;
+    --tried)          require_value "$1" "$#"; TRIED="$2"; shift 2 ;;
+    --options)        require_value "$1" "$#"; OPTIONS="$2"; shift 2 ;;
+    --recommendation) require_value "$1" "$#"; RECOMMENDATION="$2"; shift 2 ;;
+    --blocking)       require_value "$1" "$#"; BLOCKING="$2"; shift 2 ;;
+    --risk)           require_value "$1" "$#"; RISK="$2"; shift 2 ;;
+    -h|--help)        usage; exit 0 ;;
+    *)                echo "flow-escalate.sh: unknown argument: $1" >&2; usage; exit 1 ;;
   esac
 done
 
@@ -82,6 +92,22 @@ if [ ${#MISSING[@]} -gt 0 ]; then
   usage
   exit 1
 fi
+
+# Value-space validation for --blocking: the rename from --time-sensitivity
+# only matters if the actual values are constrained. Without this check, a
+# caller passing `--blocking "by Friday"` defeats the calendar-time framing
+# the rename was designed to eliminate. Case-insensitive on input so canonical
+# prose examples ("Yes."/"Soft."/"No.") work without normalization, normalized
+# to lowercase on render. See references/escalation-format.md.
+case "$BLOCKING" in
+  yes|Yes|YES) BLOCKING="yes" ;;
+  soft|Soft|SOFT) BLOCKING="soft" ;;
+  no|No|NO) BLOCKING="no" ;;
+  *)
+    echo "flow-escalate.sh: --blocking must be 'yes', 'soft', or 'no' (case-insensitive; got: '$BLOCKING')" >&2
+    exit 2
+    ;;
+esac
 
 # Format options (semicolon-separated → numbered markdown list).
 # Each item in OPTIONS is `N: text`. Validate that each non-empty entry has the

--- a/plugins/flow/bin/flow-escalate.sh
+++ b/plugins/flow/bin/flow-escalate.sh
@@ -18,7 +18,7 @@
 #     --tried "..." \
 #     --options "1: First option;2: Second option;3: Third option" \
 #     --recommendation "..." \
-#     --time-sensitivity "blocking|urgent|low|deadline:YYYY-MM-DD" \
+#     --blocking "yes|soft|no" \
 #     --risk "..."
 #
 # Options are semicolon-separated to keep the CLI single-shot. Each option
@@ -39,10 +39,11 @@ Usage: flow-escalate.sh \
          --tried TEXT \
          --options "1: A;2: B[;3: C]" \
          --recommendation TEXT \
-         --time-sensitivity TEXT \
+         --blocking TEXT \
          --risk TEXT
 
 All six fields are required. Options are semicolon-separated (each `<n>: <text>`).
+The --blocking flag should be "yes", "soft", or "no" (no calendar-time language).
 See plugins/flow/references/escalation-format.md for field semantics.
 USAGE
 }
@@ -51,7 +52,7 @@ SITUATION=""
 TRIED=""
 OPTIONS=""
 RECOMMENDATION=""
-TIME_SENSITIVITY=""
+BLOCKING=""
 RISK=""
 
 while [ $# -gt 0 ]; do
@@ -60,7 +61,7 @@ while [ $# -gt 0 ]; do
     --tried)             TRIED="${2:-}"; shift 2 ;;
     --options)           OPTIONS="${2:-}"; shift 2 ;;
     --recommendation)    RECOMMENDATION="${2:-}"; shift 2 ;;
-    --time-sensitivity)  TIME_SENSITIVITY="${2:-}"; shift 2 ;;
+    --blocking)          BLOCKING="${2:-}"; shift 2 ;;
     --risk)              RISK="${2:-}"; shift 2 ;;
     -h|--help)           usage; exit 0 ;;
     *)                   echo "flow-escalate.sh: unknown argument: $1" >&2; usage; exit 1 ;;
@@ -69,12 +70,12 @@ done
 
 # Required-field check
 MISSING=()
-[ -z "$SITUATION" ]        && MISSING+=("--situation")
-[ -z "$TRIED" ]            && MISSING+=("--tried")
-[ -z "$OPTIONS" ]          && MISSING+=("--options")
-[ -z "$RECOMMENDATION" ]   && MISSING+=("--recommendation")
-[ -z "$TIME_SENSITIVITY" ] && MISSING+=("--time-sensitivity")
-[ -z "$RISK" ]             && MISSING+=("--risk")
+[ -z "$SITUATION" ]      && MISSING+=("--situation")
+[ -z "$TRIED" ]          && MISSING+=("--tried")
+[ -z "$OPTIONS" ]        && MISSING+=("--options")
+[ -z "$RECOMMENDATION" ] && MISSING+=("--recommendation")
+[ -z "$BLOCKING" ]       && MISSING+=("--blocking")
+[ -z "$RISK" ]           && MISSING+=("--risk")
 
 if [ ${#MISSING[@]} -gt 0 ]; then
   echo "flow-escalate.sh: missing required fields: ${MISSING[*]}" >&2
@@ -134,7 +135,7 @@ $(printf '%s' "$OPTIONS_BLOCK" | awk 'NF { sub(/^[0-9]+:[[:space:]]*/, ""); prin
 
 **Recommendation** — $RECOMMENDATION
 
-**Time sensitivity** — $TIME_SENSITIVITY
+**Blocking?** — $BLOCKING
 
 **Risk** — $RISK
 BODY

--- a/plugins/flow/commands/address.md
+++ b/plugins/flow/commands/address.md
@@ -304,6 +304,7 @@ Even in minimal-scope mode, P1 and P2 findings in untouched files are always fix
    - Cosmetic P3 in untouched files → fix if bounded (<10 lines) or document inline in PR body. Default mode does not create follow-up issues. (Only `minimalScope` mode restores the follow-up workflow for this case.)
    - After fixes: re-run quality commands, re-review changed files, re-run holdout-validation
    - Approaching the iteration ceiling without convergence is a signal to re-check your understanding (are two findings in tension? are you fixing the wrong thing?), not to escalate the remaining findings.
+   - **Genuine non-convergence** (terminal case): iteration `fixForwardMaxIterations` is reached AND the same findings persist across the last 3 iterations with no progress (or fixes oscillate — fix A flags B, fix B flags A). Halt the loop, do not silently exceed the ceiling, do not push with known unresolved P1/P2. File a six-field Proactive-Autonomy escalation citing the **"genuinely ambiguous architecture decision"** trigger (NOT finding-triage), naming the specific finding(s) in irreconcilable tension. See `skills/llm-operator-principles/SKILL.md` § Genuine non-convergence and `references/escalation-format.md`.
 5. **Verify Boy Scout cleanup** passes proximity test (no scope creep)
 6. **Change classification** — verify no out-of-context changes introduced
 7. **Push** (Tier 2: journal-and-proceed):

--- a/plugins/flow/commands/address.md
+++ b/plugins/flow/commands/address.md
@@ -15,6 +15,7 @@ Systematic feedback resolution. Follows Explore > Plan > Code > Verify loop.
 
 ## Required Skills
 
+- `llm-operator-principles` — foundational operator stance: convergence = zero findings, in-PR fixes by default, no calendar-time estimates, narrow escalation triggers. MUST be consulted before any other phase
 - `feedback-resolution` — surgical changes, context recovery, pushback criteria
 - `change-classification` — verify no out-of-context changes
 - `capability-discovery` — quality commands for verification
@@ -222,22 +223,15 @@ For **Question** items: prepare a response comment (no code change needed).
 
 For **Pushback** items: explain reasoning in response comment.
 
-For **Out-of-scope** items — the proximity test is NOT a deferral mechanism for P1/P2 findings:
+For **Out-of-scope** items — finding triage is NEVER a valid escalation trigger; the default action for every finding is fix in this PR:
 
 A finding in a file the PR already modifies is NEVER out-of-scope — it must be fixed in this PR (Boy Scout Rule + ownership of known defects in touched files).
 
-Only **cosmetic P3 findings in truly untouched files** may become follow-up issues by default. P1 or P2 findings in untouched files must either:
+P1 or P2 findings in untouched files must be addressed in-PR (expand scope with an `improve:` commit if the fix is bounded). They MUST NOT be filed as a six-field Proactive-Autonomy escalation — finding triage is not a decision, it is work. See `skills/llm-operator-principles/SKILL.md`.
 
-1. Be addressed in-PR (expand scope with an `improve:` commit if the fix is bounded), OR
-2. Be filed as a six-field Proactive-Autonomy escalation:
-   - **Situation**: what the finding is and where (file:line)
-   - **Tried**: what you considered and why it didn't resolve in-PR
-   - **Options**: 2–3 concrete paths forward with trade-offs
-   - **Recommendation**: your recommended option with reasoning
-   - **Time sensitivity**: is this blocking? urgent? safe to wait?
-   - **Risk**: what happens if we defer, and to whom
+**Default mode (no `minimalScope` set):** cosmetic P3 findings in truly untouched files are fixed if bounded (<10 lines) or documented inline in the PR body under a `### Known cosmetic notes` section. Do NOT create follow-up issues, do NOT use AskUserQuestion to ask whether to defer.
 
-For cosmetic P3 findings in untouched files that the team agrees to track separately:
+**Minimal-scope mode (`settings.json` → `minimalScope: true`, or user said "minimal scope" in-conversation):** for cosmetic P3 findings in truly untouched files only, the original follow-up workflow is restored:
 
 1. Use the AskUserQuestion tool with contextual options: "This cosmetic P3 finding is in an untouched file. Create a follow-up issue to track it?"
 2. If yes, create a GitHub issue using issue-crafting skill knowledge:
@@ -250,6 +244,8 @@ For cosmetic P3 findings in untouched files that the team agrees to track separa
    ```
 3. Reference the created issue in the resolution comment
 4. TaskUpdate the feedback task as completed with result: "follow-up issue #{N}"
+
+Even in minimal-scope mode, P1 and P2 findings in untouched files are always fixed in-PR.
 
 ## Phase 4: VERIFY (Convergence Check)
 
@@ -299,13 +295,15 @@ For cosmetic P3 findings in untouched files that the team agrees to track separa
    - P1/P2 holdout findings → fix immediately before proceeding
    - After fixes: re-run holdout-validation to confirm resolution
    - P3 findings → note, do not block
-4. **Convergence check** (max 3 self-review-fix iterations):
+4. **Convergence check** (bounded by `fixForwardMaxIterations`, default 10 — this is a safety net against true infinite loops, NOT a planned stop point; see `skills/llm-operator-principles/SKILL.md`):
    - Self-review finds P1 → fix NOW (don't re-request with known P1s)
    - Holdout-validation finds P1/P2 → fix NOW (same blocking treatment as self-review P1)
    - P2 in touched files → fix NOW
    - P3 in touched files → fix NOW (same disposition as P1/P2 — the proximity test is not a deferral mechanism)
-   - Only truly cosmetic P3 findings in untouched files may become follow-up issues; P1/P2 in untouched files must be addressed in-PR or filed as a six-field Proactive-Autonomy escalation (Situation / Tried / Options / Recommendation / Time sensitivity / Risk)
+   - P1/P2 in untouched files → fix in-PR (expand scope with `improve:` commits). Finding triage is NEVER a valid escalation trigger.
+   - Cosmetic P3 in untouched files → fix if bounded (<10 lines) or document inline in PR body. Default mode does not create follow-up issues. (Only `minimalScope` mode restores the follow-up workflow for this case.)
    - After fixes: re-run quality commands, re-review changed files, re-run holdout-validation
+   - Approaching the iteration ceiling without convergence is a signal to re-check your understanding (are two findings in tension? are you fixing the wrong thing?), not to escalate the remaining findings.
 5. **Verify Boy Scout cleanup** passes proximity test (no scope creep)
 6. **Change classification** — verify no out-of-context changes introduced
 7. **Push** (Tier 2: journal-and-proceed):
@@ -338,20 +336,20 @@ For cosmetic P3 findings in untouched files that the team agrees to track separa
 
     ONLY after TaskList confirms "Post resolution comment" is completed:
     - If self-review found 0 findings → do NOT re-request (nothing changed that needs re-review beyond the feedback fixes)
-    - If cycle < `reviewCycleLimit` (default 3) → re-request normally:
+    - If cycle < `reviewCycleLimit` (default 10) → re-request normally:
       ```bash
       gh pr edit "$PR_NUM" --add-reviewer @{reviewer}
       ```
-    - If cycle >= `reviewCycleLimit` → use the AskUserQuestion tool with the following Proactive-Autonomy escalation:
+    - If cycle >= `reviewCycleLimit` → this signals genuine review deadlock (not a finding-triage decision). Use the AskUserQuestion tool with the following Proactive-Autonomy escalation:
 
-      **Situation**: Review cycle {N} reached the configured limit (`reviewCycleLimit`). {remaining_count} finding(s) remain unresolved.
+      **Situation**: Review cycle {N} reached the configured limit (`reviewCycleLimit`). {remaining_count} finding(s) remain unresolved across {N} review-and-address cycles — this is a deadlock between reviewer and author, not a finding-triage question.
       **Tried**: {N} cycles of review-and-address with the current reviewer.
       **Options**:
         1. Re-request the same reviewer for another cycle
         2. Request a fresh reviewer for an independent perspective
         3. Explicit override — accept risk of open findings (requires written justification that will be recorded in the PR)
       **Recommendation**: Option 2 (fresh reviewer) — breaks potential deadlock while maintaining quality gate integrity.
-      **Time sensitivity**: Blocking — PR cannot merge until findings are resolved or explicitly overridden with justification.
+      **Blocking?**: Yes — PR cannot merge until findings are resolved or explicitly overridden with justification.
       **Risk**: Merging with unresolved findings violates the "no incomplete shipments" hard boundary. Open findings become production defects owned by the team.
 
       Present via AskUserQuestion: "Review cycle {N} has reached the limit with {remaining_count} unresolved finding(s). Choose a path forward:"

--- a/plugins/flow/commands/commit.md
+++ b/plugins/flow/commands/commit.md
@@ -15,6 +15,7 @@ Classify changes, flag anomalies, and create atomic conventional commits. Follow
 
 ## Required Skills
 
+- `llm-operator-principles` — foundational operator stance: convergence = zero findings, in-PR fixes by default, no calendar-time estimates, narrow escalation triggers. MUST be consulted before any other phase
 - `change-classification` — signal-based change analysis
 - `convention-enforcement` — commit message validation
 
@@ -121,14 +122,13 @@ Use the AskUserQuestion tool with a Proactive-Autonomy escalation:
 >
 > **Options**:
 > 1. Include in this commit with a separate `improve:` or `chore:` commit (Recommended if changes are Boy Scout cleanup)
-> 2. Exclude from this commit — leave unstaged for a future branch
-> 3. Create a follow-up issue to track these changes separately
+> 2. Exclude from this commit — leave unstaged for a separate branch
 >
 > **Recommendation** — Option {1|2} based on whether the changes are cleanup (include) or genuinely unrelated (exclude).
 >
-> **Time sensitivity** — Not blocking. These files can be committed later.
+> **Blocking?** — Soft. The commit cannot proceed until these files are classified, but no external state depends on the outcome.
 >
-> **Risk** — Including out-of-context changes clutters the branch history. Excluding them risks forgetting the changes.
+> **Risk** — Including out-of-context changes clutters the branch history. Excluding them leaves the work unstaged on the worktree until you address it.
 
 ## Phase 4: COMMIT
 

--- a/plugins/flow/commands/merge.md
+++ b/plugins/flow/commands/merge.md
@@ -10,6 +10,7 @@ Tier 3 operation — **always requires human confirmation**. This is non-negotia
 
 ## Required Skills
 
+- `llm-operator-principles` — foundational operator stance: convergence = zero findings, in-PR fixes by default, no calendar-time estimates, narrow escalation triggers. MUST be consulted before any other phase
 - `merge-and-release` — prerequisite verification, merge execution
 
 ## References
@@ -380,7 +381,7 @@ Use the AskUserQuestion tool with a Proactive-Autonomy escalation:
 >
 > **Recommendation** — Option 1. Automated conflict resolution handles most cases and re-verifies after resolution.
 >
-> **Time sensitivity** — Blocks merge. Must resolve before proceeding.
+> **Blocking?** — Yes. Blocks merge; the workflow cannot proceed until conflicts resolve.
 >
 > **Risk** — Option 1 may produce incorrect resolution for semantic conflicts (caught by post-resolution verification). Option 2 delays merge.
 
@@ -421,7 +422,7 @@ if [ -n "$ISSUE" ]; then
   "${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/journal-record.sh" \
     --issue $ISSUE \
     --type escalation-resolved \
-    --metadata escalation_field={situation|tried|options|recommendation|time-sensitivity|risk} \
+    --metadata escalation_field={situation|tried|options|recommendation|blocking|risk} \
     --metadata outcome="$USER_RESPONSE_SUMMARY"
 fi
 ```

--- a/plugins/flow/commands/pr.md
+++ b/plugins/flow/commands/pr.md
@@ -16,6 +16,7 @@ Full PR creation workflow with multi-faceted review, quality gates, and structur
 
 ## Required Skills
 
+- `llm-operator-principles` — foundational operator stance: convergence = zero findings, in-PR fixes by default, no calendar-time estimates, narrow escalation triggers. MUST be consulted before any other phase
 - `pr-lifecycle` — pre-flight, PR body, reviewer suggestion
 - `code-review-methodology` — 6-facet review synthesis
 - `capability-discovery` — detect quality commands and agents
@@ -225,16 +226,16 @@ After agents return, TaskUpdate each review task with findings.
      >
      > **Recommendation** — Option {1|2|3} based on scope of UI changes.
      >
-     > **Time sensitivity** — Blocks PR creation if `requireVisualVerification: true`.
+     > **Blocking?** — Yes if `requireVisualVerification: true`; otherwise soft.
      >
      > **Risk** — Skipping may miss visual regressions. Manual verification depends on user follow-through.
    - Based on response → `TaskUpdate` visual tasks to SKIP_USER_APPROVED or MANUAL, or provide installation guidance and retry
    - The PR body should note whether visual verification was PASS, MANUAL, SKIP_USER_APPROVED, or SKIP_WARN
-6. **Display findings** (finding-first pattern):
+6. **Display findings** (finding-first pattern; fix-forward bounded by `fixForwardMaxIterations`, default 10 — safety net, not a budget; see `skills/llm-operator-principles/SKILL.md`):
    - P1 findings → must fix before PR
-   - P2 findings → fix before PR (max 2 fix iterations; after 2, remaining P2 become "Known issues" in PR body)
-   - P3 findings → note in PR body
-7. **If P1 findings**: Fix them, re-run review
+   - P2 findings → fix before PR (continue iterating until zero remain; finding triage is NEVER a valid escalation trigger)
+   - P3 findings → fix in-PR by default. Cosmetic P3 in untouched files only: fix if bounded (<10 lines) or document inline in the PR body under `### Known cosmetic notes`. Do NOT add a "Known issues" section that defers fixable P2s.
+7. **If P1 or P2 findings**: Fix them, re-run review
 8. **Generate PR body** from template + findings + journal + comprehension report.
    If visual verification ran, include visual evidence section:
    ```markdown

--- a/plugins/flow/commands/review.md
+++ b/plugins/flow/commands/review.md
@@ -15,6 +15,7 @@ Multi-faceted code review with parallel analysis. Follows Explore > Plan > Code 
 
 ## Required Skills
 
+- `llm-operator-principles` — foundational operator stance: convergence = zero findings, in-PR fixes by default, no calendar-time estimates, narrow escalation triggers. MUST be consulted before any other phase
 - `code-review-methodology` — 6-facet review, finding synthesis, adversarial protocol
 - `holdout-validation` — cross-reference self-review claims against file state (Phase 3)
 
@@ -580,7 +581,7 @@ TaskUpdate each review task as agents complete.
 
 5. **Self-review (own PR — PR_AUTHOR == CURRENT_USER)**:
 
-   Fix-forward approach (max `fixForwardMaxIterations`, default 2):
+   Fix-forward approach (bounded by `fixForwardMaxIterations`, default 10 — a safety net against true infinite loops, not a budget; see `skills/llm-operator-principles/SKILL.md`):
    - P1 findings → fix immediately
    - P2 findings → fix immediately
    - P3 findings → fix immediately (the proximity test is not a deferral mechanism — P3 in touched files gets the same disposition as P1/P2)
@@ -588,20 +589,23 @@ TaskUpdate each review task as agents complete.
    - For each fix: write or update a test that covers the fixed behavior
    - After fixes: run targeted re-review of only changed files
    - TaskUpdate(testCoverageTaskId, status: "completed", result: "Tests written/updated for {N} fixes")
-   - No follow-up issue creation for fixable items — just fix them
-   - If any P1/P2 finding cannot be fixed in-PR, file a six-field Proactive-Autonomy escalation (Situation / Tried / Options / Recommendation / Time sensitivity / Risk) rather than deferring silently
+   - No follow-up issue creation for fixable items — finding triage is NEVER a valid escalation trigger; fix in this PR
+   - Approaching the iteration ceiling without convergence is a signal to re-check the findings (are two findings in tension? misunderstood scope?), not to escalate
    - TaskCreate("Post self-review comment", "Post review findings summary to PR via gh pr review --comment")
 
 6. **External review (someone else's PR — PR_AUTHOR != CURRENT_USER)**:
 
    - TaskCreate("Post review comment", "Post structured review findings to PR via gh pr review")
-   - P1/P2/P3 in already-touched files → REQUEST_CHANGES (P1/P2) or COMMENT with fix-expected language (P3) — the author must fix or file an escalation
-   - Cosmetic P3 in untouched files → follow-up issue workflow
-   - P1/P2 in untouched files → REQUEST_CHANGES; author must address in-PR or file a six-field Proactive-Autonomy escalation
+   - P1/P2/P3 in already-touched files → REQUEST_CHANGES (P1/P2) or COMMENT with fix-expected language (P3) — the author must fix
+   - Cosmetic P3 in untouched files → COMMENT with fix-if-bounded-or-document-inline language (default mode) OR follow-up issue workflow (only when `minimalScope: true` or the PR author has explicitly invoked minimal scope)
+   - P1/P2 in untouched files → REQUEST_CHANGES; author must address in-PR (finding triage is NEVER a valid escalation trigger; see `skills/llm-operator-principles/SKILL.md`)
 
    Findings in files the PR already modifies are NEVER out-of-scope — the author owns the known defects in any file they touch. Do NOT flag them as informational; flag them as blocking.
 
-   For cosmetic P3 findings in untouched files that warrant follow-up:
+   **Default mode (no `minimalScope` set):** for cosmetic P3 findings in untouched files, do NOT create follow-up issues and do NOT present an AskUserQuestion asking the author to defer. Recommend "fix if bounded (<10 lines) or document inline in the PR body" in the review comment.
+
+   **Minimal-scope mode (`settings.json` → `minimalScope: true`):** for cosmetic P3 findings in untouched files only, the original follow-up workflow is restored:
+
    Present the findings and use the AskUserQuestion tool with contextual options: "These cosmetic P3 findings are in untouched files. Which ones should become follow-up issues?"
 
    For each selected finding, create a GitHub issue using issue-crafting skill knowledge:

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -331,7 +331,7 @@ Agent(implementation-planner):
    Return: task list, dependency graph, suggested order."
 ```
 
-Each atomic task flows through implementation → test → evidence collection within the same task lifecycle in Phase 3 (CODE). Phase 4 (VERIFY) still runs the full evidence bundle assembly and independent verdict judge, but per-task evidence is captured at the moment the task completes, not weeks after the author has context-switched.
+Each atomic task flows through implementation → test → evidence collection within the same task lifecycle in Phase 3 (CODE). Phase 4 (VERIFY) still runs the full evidence bundle assembly and independent verdict judge, but per-task evidence is captured at the moment the task completes, not in a bulk pass after all tasks have completed and context is fragmented.
 
 **Stranger Test check** (mandatory PLAN gate):
 
@@ -395,7 +395,7 @@ For each task (in dependency order):
        - Re-run tests
        - Repeat until all tests pass (bounded by closedLoop.maxDebugIterations)
        - Do NOT proceed to step 6. Do NOT call TaskUpdate(completed).
-       - After max iterations without resolution, escalate to user via AskUserQuestion.
+       - Approaching `closedLoop.maxDebugIterations` is a signal to re-check whether you're fixing the wrong layer or whether two test failures are in tension — not a budget to stop at. Only halt for genuine non-convergence (same failure persists 3+ iterations with no progress AND the ceiling is reached); in that case file a six-field Proactive-Autonomy escalation per `skills/llm-operator-principles/SKILL.md` § Genuine non-convergence.
      IF tests PASS → continue to step 6
   6. REFACTOR: Clean up implementation and tests. Re-run tests — they must still pass.
   7. Capture verification evidence:
@@ -428,7 +428,7 @@ $TEST_CMD
 $TYPECHECK_CMD
 ```
 
-If failures: fix and re-run. After max iterations, escalate to user.
+If failures: fix and re-run. The iteration ceiling is a safety net against true infinite loops, not a budget — approaching it is a signal to re-check understanding, not to escalate. Only halt for genuine non-convergence per `skills/llm-operator-principles/SKILL.md` § Genuine non-convergence.
 
 **Build-and-run verification** (before proceeding to Phase 4):
 
@@ -456,11 +456,12 @@ Prove everything works with fix-forward:
       Check for: logic errors, security issues, missing edge cases,
       convention violations. Return P1/P2/P3 findings with file:line."
    ```
-   **Fix-forward** (max `fixForwardMaxIterations`, default 2):
+   **Fix-forward** (bounded by `fixForwardMaxIterations`, default 10 — safety net against true infinite loops, NOT a planned stop point; see `skills/llm-operator-principles/SKILL.md`):
    - P1 findings → fix immediately (you just wrote this code, no "pre-existing" excuse)
    - P2 findings → fix immediately
-   - P3 findings → fix if contained (<10 lines, same file), otherwise note for PR body
+   - P3 findings → fix immediately (same disposition as P1/P2 — the proximity test is not a deferral mechanism). Cosmetic P3 in untouched files only: fix if bounded (<10 lines) or document inline in the PR body under `### Known cosmetic notes`. Finding triage is NEVER a valid escalation trigger.
    - After fixes: re-run quality commands, then targeted re-review on files changed by fixes
+   - Approaching the iteration ceiling without convergence is a signal to re-check understanding (are two findings in tension? are you fixing the wrong thing?), not to escalate the remaining findings. See `skills/llm-operator-principles/SKILL.md` § Genuine non-convergence for the one terminal case.
 4. **Holdout validation** — invoke `holdout-validation` skill to cross-reference self-review claims against actual file state:
    ```
    Skill(holdout-validation):
@@ -472,8 +473,8 @@ Prove everything works with fix-forward:
    **Blocking treatment:**
    - P1/P2 findings from holdout-validation → fix immediately before proceeding (same fix-forward loop as step 3)
    - After fixes: re-run holdout-validation to confirm the conflict is resolved
-   - P3 findings → note for PR body, do not block
-   - Only proceed to step 5 when holdout-validation returns PASS or P3-only
+   - P3 findings → fix in-PR as part of the same convergence loop. Only cosmetic P3 in untouched files may be documented inline in the PR body under `### Known cosmetic notes` instead of fixed. Do NOT defer fixable P3 to the PR body.
+   - Only proceed to step 5 when holdout-validation returns PASS or no fixable findings remain
 
    The holdout-validation output is passed to the verdict-judge in step 6 as a required input.
 5. **Per-criterion evidence collection** — execute verification tasks created in Phase 2:
@@ -504,7 +505,7 @@ Prove everything works with fix-forward:
 
    **Handle verdicts:**
    - **All PASS** → proceed to completion gate
-   - **Any FAIL** → enter fix loop: fix the failing criterion, re-collect evidence, re-judge (bounded by `fixForwardMaxIterations`). After max iterations, escalate remaining FAIL verdicts to user via `AskUserQuestion`.
+   - **Any FAIL** → enter fix loop: fix the failing criterion, re-collect evidence, re-judge (bounded by `fixForwardMaxIterations` as a safety net, not a budget — see `skills/llm-operator-principles/SKILL.md`). FAIL on an acceptance criterion is a genuine escalation case (failing acceptance criteria is a product-level decision, not finding-triage) — but only escalate after genuine non-convergence (same criterion fails 3+ iterations with no progress AND the ceiling is reached).
    - **NEEDS-HUMAN-REVIEW** (no FAILs):
      - If `verdict.requireAllPass` is `true` → treat as FAIL (enter fix loop to produce definitive evidence)
      - If `verdict.requireAllPass` is `false` (default) → present verdict table to user via `AskUserQuestion`:

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -21,6 +21,7 @@ Skill-driven workflow from issue assignment through implementation. Follows the 
 ## Required Skills
 
 This command operates with these domain skills loaded:
+- `llm-operator-principles` — foundational operator stance: convergence = zero findings, in-PR fixes by default, no calendar-time estimates, narrow escalation triggers. MUST be consulted before any other phase
 - `branch-and-task-management` — branch creation, task decomposition
 - `change-classification` — change context awareness
 - `capability-discovery` — detect available quality tools
@@ -265,7 +266,7 @@ If acceptance criteria are found, build a **Spec Validation Table** and treat it
 >
 > **Recommendation** — Option {1|2} — measurable criteria produce better verdicts and prevent vague implementations.
 >
-> **Time sensitivity** — Blocks planning. Must resolve before Phase 2.
+> **Blocking?** — Yes. Blocks planning; Phase 2 cannot proceed until this resolves.
 >
 > **Risk** — Choosing Option 3 (`manual`) means no automated verdict for this criterion and requires a human-in-the-loop at VERIFY phase.
 

--- a/plugins/flow/references/escalation-format.md
+++ b/plugins/flow/references/escalation-format.md
@@ -18,6 +18,8 @@ Do NOT escalate when ANY of these apply:
 - The decision is reversible and small (Tier 1 actions: file edits, branches, commits).
 - A reasonable default exists and the cost of asking exceeds the cost of being wrong.
 - The agent is asking permission for an already-authorized action ("can I commit?" — yes, that's Tier 1).
+- **The decision is about how to dispose of a code-review finding (P1/P2/P3 triage).** Finding triage is NEVER a valid escalation trigger — findings are work, not decisions. The default action for every finding is to fix it in this PR (see `skills/llm-operator-principles/SKILL.md`). If you find yourself drafting a Situation/Tried/Options block about a P1/P2/P3, stop and fix the finding instead.
+- **The agent is approaching but has not exceeded an iteration ceiling** (`fixForwardMaxIterations`, `reviewCycleLimit`, `qualityCheckMaxIterations`). Ceilings are safety nets against true infinite loops, not budgets — approaching one is a signal to re-check understanding, not to escalate the remaining work.
 
 The Iron Law: **resolve what can be resolved locally, escalate only when there is a real decision to make**. An agent that escalates too eagerly trains the user to ignore escalations.
 
@@ -52,11 +54,13 @@ The agent's preferred option, with one-sentence reasoning. The user can accept, 
 
 > **Recommendation** — Option 1. Snapshot tests are the lowest-friction way to lock the shape; the maintenance cost is paid only when the schema legitimately evolves.
 
-### 5. Time sensitivity
+### 5. Blocking?
 
-Whether the decision is blocking, urgent, or safe to wait. If a deadline applies, name it. The user uses this to triage when to read.
+Whether the decision blocks the current command. Three values: **Yes** (blocks — the command cannot proceed until this resolves), **Soft** (advisory — the command can continue with a default but the user should know), or **No** (informational only).
 
-> **Time sensitivity** — Blocks the Spec Validation Gate. PLAN cannot proceed until this resolves.
+Do NOT use calendar-time language ("urgent," "by Friday," "this week," "ASAP," "ETA"). The flow plugin is an LLM operator — calendar-time framings invite incorrect estimates that anchor deferral behavior. See `skills/llm-operator-principles/SKILL.md`.
+
+> **Blocking?** — Yes. Blocks the Spec Validation Gate; PLAN cannot proceed until this resolves.
 
 ### 6. Risk
 
@@ -77,7 +81,7 @@ AskUserQuestion(
   **Situation** — {full situation paragraph}
   **What I tried** — {tried paragraph}
   **Recommendation** — {one-sentence recommendation}
-  **Time sensitivity** — {blocking/urgent/safe}
+  **Blocking?** — {yes/soft/no}
   **Risk** — {risk paragraph}",
   options: [
     {label: "Option 1: ...", description: "{trade-off}"},
@@ -99,7 +103,7 @@ The vision article (`flow_plugin_medium_article_grounded.md`) uses a slightly di
 | Options considered | (combined with Tried + Options) | The vision treats "options considered" as a single field; the canonical split separates "what I tried (and why those didn't work)" from "what I am offering as paths forward" because users frequently need to see the failed attempts before they trust the offered options |
 | Tradeoffs | (one-line trade-offs in each Option) | Inlined per option for brevity |
 | Recommendation | Recommendation | Same |
-| Risk of inaction | Time sensitivity + Risk | The vision combines these; the canonical split separates "when does this matter" (Time sensitivity) from "what breaks if wrong" (Risk) because they answer different triage questions |
+| Risk of inaction | Blocking? + Risk | The vision combines these; the canonical split separates "does this block the current command" (Blocking?) from "what breaks if wrong" (Risk). The Blocking? field replaced an older "Time sensitivity" field to remove calendar-time framings that anchored deferral. |
 | Decision needed | (implicit in the AskUserQuestion options array) | The structured tool surfaces this naturally |
 
 Both shapes carry the same information. The canonical six-field structure is preferred for new commands and agents because it maps cleanly onto `AskUserQuestion`, which is the only delivery channel the project endorses.
@@ -111,3 +115,5 @@ Both shapes carry the same information. The canonical six-field structure is pre
 - **Asking permission for Tier 1 actions** — file edits, commits, branches do not require escalation. See `references/three-tier-safety.md` for the tier definitions.
 - **Compound questions** — escalate one decision at a time. If the user must make decisions A AND B, file two escalations or design a single decision that covers both.
 - **Recommending "you decide"** — every escalation must include a Recommendation. "I have no preference" is rarely true and signals the agent didn't do the analysis.
+- **Finding-triage escalation** — drafting a six-field block to ask the user whether to fix a P1/P2/P3 finding. Findings are work, not decisions. Fix the finding instead. See `skills/llm-operator-principles/SKILL.md`.
+- **Calendar-time framings in any field** — "urgent," "by Friday," "1-2 weeks," "ETA." Use the Blocking? field's yes/soft/no values instead.

--- a/plugins/flow/schema.json
+++ b/plugins/flow/schema.json
@@ -231,8 +231,28 @@
         "requireRuntimeVerification": { "type": "boolean", "default": true }
       }
     },
-    "reviewCycleLimit": { "type": "integer", "default": 3, "minimum": 1 },
-    "fixForwardMaxIterations": { "type": "integer", "default": 2, "minimum": 1 }
+    "reviewCycleLimit": {
+      "type": "integer",
+      "default": 10,
+      "minimum": 1,
+      "description": "Maximum review-and-address cycles between code-reviewer and code-author roles. Defaults to 10 because the ceiling is a safety net against true infinite loops, not a planned stop point — LLM operators iterate cheaply. See skills/llm-operator-principles/SKILL.md."
+    },
+    "fixForwardMaxIterations": {
+      "type": "integer",
+      "default": 10,
+      "minimum": 1,
+      "description": "Maximum fix-forward iterations on self-review or holdout-validation findings. Defaults to 10 because the ceiling is a safety net, not a budget — convergence means zero findings, not exhausted budget. See skills/llm-operator-principles/SKILL.md."
+    },
+    "autonomous": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, the agent does NOT use AskUserQuestion for decisions the agent can resolve under the llm-operator-principles skill. AskUserQuestion is reserved for Tier 3 confirmations (merge, release) and true product/architecture decisions. Recommended for sole-maintainer repositories. See skills/llm-operator-principles/SKILL.md."
+    },
+    "minimalScope": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, restores the original deferral behavior for cosmetic P3 in untouched files only: the 'Create a follow-up issue?' AskUserQuestion is re-enabled, and Boy Scout expansion is softened. All other principles still apply (P1/P2 fix in-PR, no calendar estimates, fix-forward unbounded). Use when the user has deliberately constrained scope. See skills/llm-operator-principles/SKILL.md."
+    }
   },
   "additionalProperties": false
 }

--- a/plugins/flow/settings.json
+++ b/plugins/flow/settings.json
@@ -58,8 +58,10 @@
   "debugging": {
     "maxHypotheses": 3
   },
-  "reviewCycleLimit": 3,
-  "fixForwardMaxIterations": 2,
+  "reviewCycleLimit": 10,
+  "fixForwardMaxIterations": 10,
+  "autonomous": false,
+  "minimalScope": false,
   "closedLoop": {
     "enabled": true,
     "maxBuildIterations": 5,

--- a/plugins/flow/skills/autonomous-workflow/SKILL.md
+++ b/plugins/flow/skills/autonomous-workflow/SKILL.md
@@ -93,18 +93,19 @@ Dispatch independent operations in a single message:
 
 ## Bounded Verification
 
-Quality check loops have max iterations from `settings.json`:
+Quality check loops have max iterations from `settings.json`. These ceilings are safety nets against true infinite loops, NOT planned stop points — see `skills/llm-operator-principles/SKILL.md`:
 
 1. Run quality commands
 2. If failures, fix and re-run
-3. After `qualityCheckMaxIterations` (default 3), escalate to user
-4. Never loop indefinitely
+3. Approaching `qualityCheckMaxIterations` without convergence is a signal to re-check understanding (are two findings in tension? are you fixing the wrong thing?), not a budget to stop at. Continue iterating until convergence.
+4. Only halt for **genuine non-convergence**: the same failure persists across the last 3 iterations with no progress AND the ceiling is actually reached. In that case, file a six-field Proactive-Autonomy escalation citing "genuinely ambiguous architecture decision" — NOT finding-triage.
+5. Never loop indefinitely past the ceiling without surfacing the non-convergence diagnostic.
 
 ## Stop Conditions
 
 | Trigger | Action |
 |---------|--------|
-| 3+ verification failures on the same issue | Stop fixing forward. Return to EXPLORE — the problem is architectural. |
+| Genuine non-convergence (same findings persist 3+ iterations AND ceiling reached) | File a six-field Proactive-Autonomy escalation per `skills/llm-operator-principles/SKILL.md` § Genuine non-convergence. Do NOT silently exit the loop. |
 | Plan has >10 tasks for a single issue | Decompose the issue first. One PR should not span 10 tasks. |
 | EXPLORE phase yields contradictory signals | Stop. Ask the user for clarification before planning. |
 | >5 files modified without staging or committing | Stop. What you have should be committable. If not, the tasks are too large. |

--- a/plugins/flow/skills/autonomous-workflow/SKILL.md
+++ b/plugins/flow/skills/autonomous-workflow/SKILL.md
@@ -81,6 +81,8 @@ When a command or skill says "use the AskUserQuestion tool", you MUST invoke the
 
 Journal dir defaults to `.decisions/`, configurable in settings.
 
+**Anti-estimation guard for journal entries:** journal entries MUST NOT include calendar-time estimates (weeks, days, hours, sprints, ETAs, "by Friday"). Use t-shirt sizing (S/M/L) only when the user has explicitly asked for size context. Describe work in terms of artifacts and tool calls, not wall-clock duration. See `skills/llm-operator-principles/SKILL.md`. This guard exists because journal entries are the most common surface where calendar-time framings leak through and anchor downstream deferral.
+
 ## Parallel Execution
 
 Dispatch independent operations in a single message:
@@ -169,22 +171,23 @@ Every escalation to a human MUST follow this structure. Omitting fields is not p
 | **What I tried** | What you attempted before escalating — research, alternatives considered, commands run |
 | **Options** | 2-3 concrete paths forward, each with trade-offs. Label one "(Recommended)" |
 | **My recommendation** | Which option you recommend and why — never leave this blank |
-| **Time sensitivity** | Is this blocking? Urgent? Safe to defer? |
+| **Blocking?** | Yes (blocks the current command), Soft (advisory), or No (informational). Do NOT use calendar-time language. |
 | **Risk if wrong** | What happens if the chosen option turns out to be the wrong call, and who is affected |
 
 ### When Escalation IS Required
 
 - **Irreversible actions** — merge, release, force-push, data deletion, production deploys
-- **Genuinely ambiguous preference decisions** — two valid approaches where the trade-off depends on user priorities the agent cannot infer
+- **Genuinely ambiguous preference decisions** — two valid approaches where the trade-off depends on user priorities the agent cannot infer (product/architecture decisions only, NOT finding triage)
 - **Out-of-whitelist runtime skip requests** — skipping verification for a category not in the `markdown-only`, `config-only`, or `dependency-bump-only` whitelist
-- **Repeated verification failures** — after `maxDebugIterations` or `fixForwardMaxIterations` exhausted
+- **Verification ceilings exceeded after re-checking understanding** — only after `maxDebugIterations` or `fixForwardMaxIterations` have been fully exhausted AND the agent has re-checked whether findings are in tension or being misunderstood. Approaching a ceiling is not a trigger; the ceiling is a safety net, not a budget. See `skills/llm-operator-principles/SKILL.md`.
 
 ### When Escalation is NOT Needed
 
 - **Reversible local actions** — file edits, commits, branch creation, staging (Tier 1)
 - **Actions within the three-tier safety framework** — Tier 1 and Tier 2 actions that are already classified as autonomous or journal-and-proceed
 - **Decisions with clear policy** — the skill, command, or governance framework already specifies the correct action
-- **Fixing your own findings** — P1/P2 findings from self-review are your responsibility to fix, not escalate
+- **Fixing any findings (P1/P2/P3)** — finding triage is NEVER a valid escalation trigger. Findings are work, not decisions. Fix in this PR by default. See `skills/llm-operator-principles/SKILL.md` and `references/escalation-format.md`.
+- **Approaching but not exceeding an iteration ceiling** — `fixForwardMaxIterations`, `reviewCycleLimit`, `qualityCheckMaxIterations` are safety nets, not budgets. Iteration 7 of 10 is the middle of the safety margin, not "the ceiling."
 
 ## Anti-Patterns
 
@@ -193,4 +196,7 @@ Every escalation to a human MUST follow this structure. Omitting fields is not p
 | **Lazy Verification** | Tests pass does not equal works. "Theoretically works" is not "actually works." The proof is running it — build it, start it, hit the endpoint, check the output. | Run the code. Capture the output. Show the evidence. |
 | **Lazy Escalation** | Asking the user without trying first. Open-ended questions with no research, no options, no recommendation. "What should I do?" is never acceptable. | Try to resolve it yourself. If you still need input, use the six-field template with your recommendation. |
 | **Punt-to-User** | "What should I do?" or "How should we proceed?" without options. Agents are teammates, not tools waiting for instructions. Every escalation must include 2-3 options with a recommended path. | Present structured options. Label one "(Recommended)." Explain the trade-offs. |
-| **Silent Deferral** | Downgrading findings to avoid escalation. P3 "note only" was the old way — the new way is fix or escalate with the six-field structure. A finding that matters enough to mention matters enough to act on. | Fix it (if within scope) or file a six-field escalation. Never silently downgrade. |
+| **Silent Deferral** | Downgrading findings to avoid escalation, or routing findings to follow-up issues instead of fixing them. A finding that matters enough to mention matters enough to act on. | Fix it. Finding triage is NEVER a valid escalation trigger; see `skills/llm-operator-principles/SKILL.md`. Default mode does not create follow-up issues for findings. |
+| **Triage Escalation** | Drafting a six-field escalation about a P1/P2/P3 finding to ask whether to fix it. | Stop. Fix the finding. Escalations are for true decisions (product, architecture, irreversible actions), not for work the agent can do. |
+| **Convergence Surrender** | "We hit iteration 3 of fix-forward, escalating remaining findings." | Continue iterating. Iteration ceilings are safety nets, not budgets. The default ceilings (10) are designed to make the LLM converge well before the ceiling, not to stop at it. |
+| **Calendar Anchoring** | "Multi-week effort," "defer to next sprint," "ETA: end of quarter." | Re-frame in tool calls. The LLM operator does not have weeks or sprints. Use t-shirt sizing (S/M/L) only when the user explicitly asks for size. |

--- a/plugins/flow/skills/code-quality-principles/SKILL.md
+++ b/plugins/flow/skills/code-quality-principles/SKILL.md
@@ -44,9 +44,11 @@ Leave every file you touch better than you found it. Fixing known defects in tou
 4. Would benefit from its own issue to explain motivation
 5. Is a subjective style preference (in which case it is P3 at most, not a fix-blocker)
 
-For P1/P2 findings that fall into the "expanded scope" bucket: fix them in-PR with an appropriate commit message, or file a six-field Proactive-Autonomy escalation (Situation / Tried / Options / Recommendation / Time sensitivity / Risk) to escalate the decision. "Disagree to fix" is not an option — the escalation forces a human judgment call.
+For P1/P2 findings that fall into the "expanded scope" bucket: fix them in-PR with an appropriate commit message. Finding triage is NEVER a valid escalation trigger — do NOT file a six-field Proactive-Autonomy escalation to ask whether to fix a finding (see `skills/llm-operator-principles/SKILL.md` and `references/escalation-format.md`). "Disagree to fix" is not an option; "ask the user whether to fix" is also not an option.
 
-Only **cosmetic P3 findings in truly untouched files** may be logged as follow-up issues by default.
+**Default mode:** cosmetic P3 findings in truly untouched files are fixed if bounded (<10 lines) or documented inline in the PR body. Do NOT create follow-up issues for them.
+
+**Minimal-scope mode (`settings.json` → `minimalScope: true`):** the original follow-up issue workflow for cosmetic P3 in untouched files is restored.
 
 ## No Secrets in Code
 
@@ -69,7 +71,7 @@ Code that ships must be complete:
 
 ## Quality Command Execution
 
-Run independent quality commands (lint, test, typecheck) as parallel Bash calls, never chained with `&&`. After quality checks: P1 failures fix immediately, P2 fix before PR, P3 fix in-PR unless a six-field Proactive-Autonomy escalation is filed.
+Run independent quality commands (lint, test, typecheck) as parallel Bash calls, never chained with `&&`. After quality checks: P1 failures fix immediately, P2 fix before PR, P3 fix in-PR by default. Finding triage is NEVER a valid escalation trigger (see `references/escalation-format.md`).
 
 ## Anti-Patterns
 
@@ -112,8 +114,8 @@ Before marking any task complete:
 
 | Excuse | Response |
 |--------|----------|
-| "I'll clean this up while I'm here" | If it's a P1/P2 in a touched file, you must fix it. If it's small and self-evident, use an `improve:` commit. If it's cosmetic and in an untouched file, you may log it. |
+| "I'll clean this up while I'm here" | If it's a P1/P2 in a touched file, you must fix it. If it's small and self-evident, use an `improve:` commit. If it's cosmetic and in an untouched file, fix-if-bounded or document inline (default) — only log as a follow-up issue under `minimalScope` mode. |
 | "This TODO is temporary" | TODOs in commits are permanent. Create an issue instead. |
 | "The tests pass, it's fine" | Tests passing is necessary, not sufficient. Run the self-review checklist. |
 | "This debug log helps with development" | Remove it. Development aids don't ship. |
-| "It's just a small formatting fix" | If the file is already touched for the task and the fix is self-evident, use an `improve:` commit. If the file is untouched and the fix is cosmetic, log it as a follow-up issue. |
+| "It's just a small formatting fix" | If the file is already touched for the task and the fix is self-evident, use an `improve:` commit. If the file is untouched and the fix is cosmetic, fix-if-bounded (<10 lines) or document inline in the PR body (default) — only log as a follow-up issue under `minimalScope` mode. |

--- a/plugins/flow/skills/code-review-methodology/SKILL.md
+++ b/plugins/flow/skills/code-review-methodology/SKILL.md
@@ -167,10 +167,10 @@ If a finding was claimed resolved but the code at that location is unchanged, fl
 |----------|----------|
 | P1 findings (any) | REQUEST_CHANGES |
 | P2 findings (any) | REQUEST_CHANGES |
-| P3 findings only | COMMENT (fix-expected — author must fix in-PR or file a six-field Proactive-Autonomy escalation; P3 is not a free pass) |
+| P3 findings only | COMMENT (fix-expected — author must fix in-PR; P3 is not a free pass) |
 | No findings | APPROVE |
 
-Note: P3 → COMMENT is NOT "approve with nits." The PR author is expected to fix every P3 in-PR unless they file an escalation justifying deferral. Reviewers should not approve PRs with unaddressed P3s.
+Note: P3 → COMMENT is NOT "approve with nits." The PR author is expected to fix every P3 in-PR. Finding triage is NEVER a valid escalation trigger (see `skills/llm-operator-principles/SKILL.md` and `references/escalation-format.md`) — reviewers should not approve PRs with unaddressed P3s, and authors should not file escalations to ask whether to fix them.
 
 ## Adversarial Protocol (Agent Teams)
 

--- a/plugins/flow/skills/evidence-based-development/SKILL.md
+++ b/plugins/flow/skills/evidence-based-development/SKILL.md
@@ -36,7 +36,7 @@ All findings, review comments, and issues use P1/P2/P3 classification. This prio
 |----------|---------|--------|
 | **P1** | Must fix — blocks merge, security issue, data loss risk, broken functionality | Fix before proceeding |
 | **P2** | Should fix — logic error, missing edge case, test gap, convention violation | Fix in this PR |
-| **P3** | Consider — style preference, optimization opportunity, future improvement | Fix in-PR unless a Proactive-Autonomy escalation is filed (six-field structure: Situation / Tried / Options / Recommendation / Time sensitivity / Risk) |
+| **P3** | Consider — style preference, optimization opportunity | Fix in-PR by default. Cosmetic P3 in untouched files: fix-if-bounded or document inline (default) / follow-up issue (`minimalScope` mode only). Finding triage is NEVER a valid escalation trigger — see `skills/llm-operator-principles/SKILL.md`. |
 
 ## ASSERTION/EVIDENCE/VERIFIED Pattern
 

--- a/plugins/flow/skills/feedback-resolution/SKILL.md
+++ b/plugins/flow/skills/feedback-resolution/SKILL.md
@@ -104,13 +104,13 @@ Pushback is a narrow, evidence-backed response — not a general "I disagree" es
 
 "I disagree" alone is NOT valid pushback. Subjective preference differences resolve in favor of the reviewer — if you don't have factual evidence, a broken test, or a CLAUDE.md citation, apply the fix.
 
-Always explain the reasoning when pushing back. Never ignore feedback silently. If pushback would require a judgment call beyond the three valid categories above, file a six-field Proactive-Autonomy escalation instead (Situation / Tried / Options / Recommendation / Time sensitivity / Risk).
+Always explain the reasoning when pushing back. Never ignore feedback silently. If pushback would require a judgment call beyond the three valid categories above, file a six-field Proactive-Autonomy escalation per `references/escalation-format.md` — but only if this is a genuine product/architecture decision. Finding triage (P1/P2/P3 disposition) is NEVER a valid escalation trigger; see `skills/llm-operator-principles/SKILL.md`.
 
 ## Rationalization Prevention
 
 | Excuse | Response |
 |--------|----------|
-| "While fixing this, I noticed something else to improve" | Does it pass the proximity test? If yes, fix it in a separate `improve:` commit. If no, create a follow-up issue with `/flow:issue`. |
+| "While fixing this, I noticed something else to improve" | Does it pass the proximity test? If yes, fix it in a separate `improve:` commit. If no AND it is cosmetic P3 in an untouched file: fix-if-bounded or document inline (default mode) — only create a follow-up issue under `minimalScope` mode. For P1/P2 anywhere: fix in this PR. |
 | "The reviewer probably meant this broader change" | Don't guess. Address the literal comment. Clarify if unsure. |
 | "I'll batch all fixes into one commit" | One commit per feedback item. Traceability requires it. |
 

--- a/plugins/flow/skills/llm-operator-principles/SKILL.md
+++ b/plugins/flow/skills/llm-operator-principles/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: llm-operator-principles
+description: "Frame Claude's identity as an LLM operator that does not tire, treats convergence as zero findings (not exhausted budget), prohibits calendar-time estimates (weeks/days/hours/sprints/ETAs), and defaults to in-PR fixes for all findings (P1/P2/P3). Use when starting any /flow:* command, processing findings during VERIFY or convergence phases, addressing PR feedback, deciding whether to defer work, or considering filing a six-field escalation. This skill MUST be consulted because every other flow skill describes a mechanism — this one describes the operator stance that makes the mechanisms produce the right behavior, and without it the agent reverts to a human-engineer prior that estimates in person-days and defers fixable findings."
+allowed-tools: Read
+---
+
+# LLM Operator Principles
+
+Foundation skill governing Claude's stance as an LLM-driven development operator. This skill is consulted before any other flow skill — it sets the operating frame that makes the rest of the plugin produce correct behavior.
+
+## Iron Law
+
+**CONVERGENCE = ZERO FINDINGS. NOT EXHAUSTED BUDGET.**
+
+An iteration ceiling (`fixForwardMaxIterations`, `reviewCycleLimit`, `qualityCheckMaxIterations`) is a safety net against true infinite loops — it is not a planned stop point. Approaching a ceiling without convergence is a signal to check your understanding of the problem, not to escalate the findings to the user.
+
+## You Are An LLM Agent
+
+You are not a human engineer. The constraints that drive human delivery practices do not apply to you:
+
+- **Iteration is cheap.** A re-run of quality + review costs seconds, not a meeting and a context-switch. There is no time pressure to "batch findings for the next PR" — there is no next PR coming, only this one.
+- **Parallelism is free.** When work can be parallelized, you can fan out via sub-agents or git worktrees. A 20-finding PR converges in tool-call minutes, not engineer-days.
+- **You do not tire.** A 5th or 10th fix pass is not more expensive than the 1st. The "fatigue" that justifies deferral in human teams does not apply.
+- **Your work-time is measured in tool calls, not wall-clock hours.** A fix that a human would budget at "half a day" you complete in a single Edit + a re-run of the quality suite.
+
+When you find yourself reasoning "this is a multi-week effort" or "we should defer to a follow-up sprint," stop. That is a human-engineer prior leaking through. Re-frame in tool calls.
+
+## Calendar-Time Estimates Are Prohibited
+
+Never write, suggest, or imply estimates in calendar units:
+
+- ❌ "This will take 2-3 weeks"
+- ❌ "Multi-day effort"
+- ❌ "Defer to the next sprint"
+- ❌ "1-2 hours of work"
+- ❌ "By Friday"
+- ❌ "ETA: end of quarter"
+- ❌ "Urgent — needs to ship this week"
+
+If you must convey size, use **t-shirt sizing** (S / M / L) and only when the user explicitly asked for a size estimate. Otherwise, describe the work itself ("3 file edits + a test re-run" / "a single skill prompt change" / "introduce a new config flag and update 6 commands").
+
+This applies everywhere: PR bodies, decision-journal entries, commit messages, AskUserQuestion bodies, resolution comments, escalations, follow-up issue bodies. The flow plugin's templates explicitly forbid calendar-time language.
+
+The escalation-format "Blocking?" field replaced the older "Time sensitivity" field for exactly this reason — calendar verbs invite incorrect estimates.
+
+## Default Finding Disposition: Fix In This PR
+
+When a review (self-review, agent-team review, holdout-validation, code-reviewer agent) produces a finding (P1, P2, or P3), **the default action is to fix it in this PR.**
+
+The ONLY valid non-fix outcomes are:
+
+1. **The finding requires a user product decision Claude cannot make** — e.g., "the API contract changed; should we maintain backward compatibility or break it?" This is a true ambiguity, not a triage question.
+2. **The finding is in a binary, vendored, generated, or third-party file** Claude does not own. Examples: minified bundles, lockfiles content beyond bumps, vendored copies of upstream libraries.
+3. **The fix requires modifying a dependency Claude does not own.** Open an upstream issue, document the workaround in-PR.
+4. **The user has explicitly invoked minimal-scope mode for this run** (`minimalScope: true` in settings, or "minimal scope" said in-conversation). In that mode, cosmetic P3 in untouched files may become follow-up issues.
+
+In every other case — including P3 findings in untouched files, "out-of-scope" findings that emerged from a broader review pass, and findings the agent feels are "not strictly required by acceptance criteria" — **fix in this PR.** "I noticed an unrelated issue" is not a deferral excuse; it is an `improve:` commit waiting to be made.
+
+Restating: **finding triage is NEVER a valid trigger for the six-field Proactive-Autonomy escalation.** If you find yourself drafting a Situation/Tried/Options block about a P1/P2/P3, stop and fix the finding instead. Escalations are for safety, architecture, and irreversible decisions — not for "should I fix this bug or defer it?"
+
+## Multi-PR Sequencing Is The User's Call
+
+Default to ONE PR that resolves all findings. Do not propose multi-PR "landings" (Landing 1, Landing 2, Landing 3), staged delivery plans, or sequenced rollouts unless the user explicitly asks for them.
+
+A multi-PR plan is appropriate when:
+- The user explicitly requests it ("split this into smaller PRs")
+- The work crosses a deployment boundary (database migration that must merge before code that uses it)
+- Findings genuinely require user product decisions between phases
+
+A multi-PR plan is NOT appropriate when:
+- It is being used to reduce reviewer cognitive load (you are the reviewer, or the user is)
+- It is being used to fit work into a release cadence (the LLM operator has no release cadence)
+- It is being used to defer findings the agent could fix in one pass
+
+## Iteration Ceiling Semantics
+
+The flow plugin's iteration ceilings are tuned for LLM operators. Defaults:
+
+- `fixForwardMaxIterations: 10` — fix-forward loops on self-review/holdout findings
+- `reviewCycleLimit: 10` — review-and-address cycles between code-reviewer and code-author roles
+- `closedLoop.maxDebugIterations: 5` — debug-fix-retest loops
+- `qualityCheckMaxIterations: 3` — quality-command re-runs
+
+These are safety nets, not budgets. If you reach iteration 7 of fix-forward without convergence, the right response is:
+
+1. Re-read the latest findings against the actual diff
+2. Check whether you misunderstood a finding (and are fixing the wrong thing)
+3. Check whether two findings are in tension (fix A breaks B)
+4. Continue iterating — do not escalate solely because the ceiling is approaching
+
+You only escalate when you cannot progress at all, not because a budget is "running low."
+
+## The Six-Field Escalation Is For Decisions, Not Findings
+
+The Proactive-Autonomy six-field escalation (`references/escalation-format.md`) is for true decisions the agent cannot resolve. Valid triggers:
+
+- Irreversible actions (merge, release, force-push, data deletion, production deploys) — Tier 3
+- Genuinely ambiguous product or architecture decisions where two valid approaches exist and the trade-off requires user-only knowledge
+- Out-of-whitelist runtime-verification skip requests
+- True scope decisions ("this work has grown beyond the issue — pause for triage?")
+
+Invalid triggers (do NOT escalate on these):
+
+- Any P1/P2/P3 finding disposition — fix it
+- "I found something unrelated while reviewing" — fix it (as an `improve:` commit)
+- "This will be a lot of changes" — that is not a decision, it is observation
+- "Should I keep going?" — yes, until convergence
+
+## Autonomous Mode
+
+When `settings.json` → `autonomous: true` (or the user says "autonomous mode" / "autonomous on" in-conversation), the agent does NOT use `AskUserQuestion` for any decision the agent can resolve under these principles. AskUserQuestion is reserved for:
+
+- Tier 3 confirmations (merge, release)
+- True product/architecture decisions per the valid escalation triggers above
+
+Autonomous mode is the recommended default for sole-maintainer repositories and for users who trust the agent to converge without interruption.
+
+## Minimal-Scope Mode
+
+When `settings.json` → `minimalScope: true` (or the user says "minimal scope" / "minimal scope on" in-conversation), the original deferral behavior is restored for **cosmetic P3 in untouched files only**:
+
+- The "Create a follow-up issue?" AskUserQuestion is re-enabled for that specific case
+- Boy Scout expansion is softened — only fixes self-evidently required by the current task land in this PR
+- All other principles still apply (P1/P2 fix in-PR, no calendar estimates, fix-forward unbounded)
+
+Minimal-scope mode is for situations where the user has deliberately constrained the scope of the change and wants the agent to respect that — e.g., a one-line hotfix that should not expand into a refactor.
+
+## Anti-Patterns
+
+| Anti-Pattern | Symptom | Right Response |
+|--------------|---------|----------------|
+| **Calendar Anchoring** | "This is a multi-week effort" / "Defer to next sprint" | Re-frame in tool calls. There is no sprint. There is this PR and the work it needs. |
+| **Triage Escalation** | Drafting a six-field escalation about a P2 finding | Stop. Fix the finding. Escalations are for decisions, not findings. |
+| **Convergence Surrender** | "We hit iteration 3 of fix-forward, escalating remaining findings to user" | Continue iterating. Iteration 3 of 10 is not the ceiling — it is the middle of the safety budget. |
+| **Speculative Landing Plans** | Proposing "Landing 1 / Landing 2 / Landing 3" decomposition unprompted | Default to one PR. Only multi-PR when the user explicitly asked or a deploy boundary requires it. |
+| **Follow-up Issue Reflex** | "Create a follow-up issue for this cosmetic P3?" on every untouched-file finding | In default mode: fix-if-bounded OR document inline in PR body. Follow-up issues only when `minimalScope` is set or the user explicitly asked. |
+| **Lazy Estimate** | "This will take a few hours" / "ETA: end of week" | Describe the work itself in tool-call terms. |
+
+## Rationalization Prevention
+
+| Excuse | Response |
+|--------|----------|
+| "Fixing this would expand scope" | If the file is touched, scope is already there. Fix it. If it is untouched and cosmetic P3, fix-if-bounded or document inline. |
+| "The user wanted minimum changes" | Did they say "minimal scope"? If yes, restore the deferral path for cosmetic P3 only. Otherwise, this is your prior leaking through. |
+| "This is a multi-PR effort" | Default to one PR. Only split on explicit user ask or deploy boundary. |
+| "We've hit the iteration ceiling" | The ceiling is a safety net. Iteration 7 of 10 is not "hit the ceiling." |
+| "I should escalate this finding so the user can decide" | Findings are not decisions. Fix it. |
+| "This will take 2 hours" | You do not take hours. Re-frame in tool calls. |
+| "Better to track this as a follow-up issue" | Better to fix it now. Follow-ups are an opt-in mode, not a default. |

--- a/plugins/flow/skills/llm-operator-principles/SKILL.md
+++ b/plugins/flow/skills/llm-operator-principles/SKILL.md
@@ -27,6 +27,8 @@ When you find yourself reasoning "this is a multi-week effort" or "we should def
 
 ## Calendar-Time Estimates Are Prohibited
 
+The examples in this section quote calendar units ONLY to illustrate the prior they replace — they are anti-patterns, not templates. Do not propagate any calendar-unit phrase from these examples into your own output.
+
 Never write, suggest, or imply estimates in calendar units:
 
 - ❌ "This will take 2-3 weeks"
@@ -89,6 +91,21 @@ These are safety nets, not budgets. If you reach iteration 7 of fix-forward with
 4. Continue iterating — do not escalate solely because the ceiling is approaching
 
 You only escalate when you cannot progress at all, not because a budget is "running low."
+
+### Genuine non-convergence
+
+The Iron Law says convergence is zero findings, not exhausted budget — and the ceilings exist as a safety net for the case where the LLM genuinely cannot reach zero. This case is real but rare. Recognize it by two diagnostic signals:
+
+1. **Stuck signal**: the same findings reappear across the last 3 iterations with no progress (or worse, fixes oscillate — fix A flags B, fix B flags A).
+2. **Reach-limit signal**: the iteration count actually equals `fixForwardMaxIterations` (or `reviewCycleLimit`) with one or more findings still open.
+
+When **both** signals fire, this is genuine non-convergence — the ONE case where the ceiling becomes a stop point. Take this action:
+
+- Halt the fix-forward loop (do not silently exceed the ceiling, do not push with known unresolved P1/P2).
+- File a six-field Proactive-Autonomy escalation per `references/escalation-format.md`, citing the valid trigger **"genuinely ambiguous architecture decision"** (NOT finding-triage). The Situation must name the specific finding(s) in irreconcilable tension or the specific finding you cannot reproduce/understand.
+- The escalation's Options should describe concrete paths the user can choose — typically (a) accept one of the conflicting fixes and explicitly waive the other, (b) request user clarification on a finding the LLM cannot interpret, or (c) revert the divergent attempts and approach the problem differently.
+
+This is the ONLY case where an iteration ceiling becomes a stop point. In every other situation — iteration 9 of 10, partial progress, single finding remaining — you continue iterating.
 
 ## The Six-Field Escalation Is For Decisions, Not Findings
 

--- a/plugins/flow/skills/specification-capture/SKILL.md
+++ b/plugins/flow/skills/specification-capture/SKILL.md
@@ -70,7 +70,7 @@ For each element that is still missing after Steps 1 and 2, draft a 3-5 item pro
 - **What I tried** — Read issue body and {N} comments. Searched for cues ({list of cues from the table above}). No prior statement found.
 - **Options** — (1) Accept the agent's proposal as written. (2) Accept with edits (the agent will prompt for changes). (3) Reject — the specification is incomplete and the issue should be updated first.
 - **Recommendation** — Option {1|2} based on the proposal's specificity. Option 3 only when the agent cannot produce a credible proposal from the issue context.
-- **Time sensitivity** — Blocks PLAN. The Spec Validation Gate cannot proceed until this resolves.
+- **Blocking?** — Yes. Blocks PLAN; the Spec Validation Gate cannot proceed until this resolves.
 - **Risk** — Choosing Option 1 with a wrong proposal locks the implementation into the wrong fence; the agent will surface a Stranger Test failure later but the user will have wasted PLAN cycles. Choosing Option 3 means the issue must be updated before re-running the workflow.
 
 Surface ONE escalation per missing element. Do not bundle (a compound prompt forces the user to make multiple decisions in one click; see `references/escalation-format.md` anti-patterns).

--- a/plugins/flow/templates/pr-body.md
+++ b/plugins/flow/templates/pr-body.md
@@ -53,6 +53,10 @@ Closes #{issue_number}
 | P2 | {Y} | {Summary} |
 | P3 | {Z} | {Summary} |
 
+### Known cosmetic notes
+
+{Cosmetic P3 findings in untouched files that the agent determined were not bounded enough to fix in-PR (>10 lines) — listed as `file:line — one-line description`. Empty if all P3 were fixed or no cosmetic-P3-in-untouched findings surfaced. NEVER use this section to defer fixable P1/P2 findings or any finding in a touched file; those MUST be fixed before PR creation per `skills/llm-operator-principles/SKILL.md`.}
+
 ### Review Cycle History
 <!-- Updated by /flow:address -->
 _No review cycles completed yet._

--- a/plugins/flow/templates/pr-body.md
+++ b/plugins/flow/templates/pr-body.md
@@ -1,3 +1,12 @@
+<!--
+PR body anti-estimation guard:
+This template MUST NOT include calendar-time estimates (weeks, days, hours, sprints,
+ETAs, "by Friday," etc.) in any field. If size context is necessary, use t-shirt
+sizing (S/M/L) and only when the user explicitly asked for it. The flow plugin
+runs under an LLM operator; calendar-time framings invite incorrect estimates that
+anchor downstream deferral. See `skills/llm-operator-principles/SKILL.md`.
+-->
+
 ## Summary
 
 {2-3 sentence description of what changed and why}

--- a/plugins/flow/templates/resolution-comment.md
+++ b/plugins/flow/templates/resolution-comment.md
@@ -30,7 +30,7 @@ For each item the author believes requires a judgment call beyond autonomous res
 - **Tried**: {what was considered and why it did not resolve in-PR}
 - **Options**: {2–3 concrete paths forward with trade-offs}
 - **Recommendation**: {recommended option and reasoning}
-- **Time sensitivity**: {blocking / urgent / safe to wait — with justification}
+- **Blocking?**: {yes / soft / no — no calendar-time language}
 - **Risk**: {what happens if we defer, and to whom}
 - Follow-up issue (if created): #{issue_number}
 

--- a/plugins/flow/templates/self-review-comment.md
+++ b/plugins/flow/templates/self-review-comment.md
@@ -36,7 +36,7 @@ Verdict: N/A (independent verdict not enabled)
 - **Tried**: {what was considered, why it didn't resolve in-PR}
 - **Options**: {2–3 concrete paths}
 - **Recommendation**: {recommended option}
-- **Time sensitivity**: {blocking / urgent / safe to wait}
+- **Blocking?**: {yes / soft / no — no calendar-time language}
 - **Risk**: {consequence of deferring}
 
 ### Verification

--- a/plugins/flow/tests/flow-escalate.test.sh
+++ b/plugins/flow/tests/flow-escalate.test.sh
@@ -2,7 +2,7 @@
 #
 # Contract (from the helper's header):
 #   - Six required fields: --situation, --tried, --options, --recommendation,
-#     --time-sensitivity, --risk.
+#     --blocking, --risk.
 #   - Options are semicolon-separated, each `<n>: <text>`.
 #   - Exit 0: prints formatted body to stdout.
 #   - Exit 1: missing required field. Usage printed to stderr.
@@ -19,7 +19,7 @@ ALL_ARGS=(
   --tried "Tried thing A and B"
   --options "1: First option;2: Second option"
   --recommendation "Pick option 1"
-  --time-sensitivity "blocking"
+  --blocking "yes"
   --risk "Defer means service stays broken"
 )
 
@@ -32,7 +32,7 @@ assert_contains "**Situation** — Test situation"           "$OUT" "Situation s
 assert_contains "**What I tried** — Tried thing A and B"   "$OUT" "What I tried section present"
 assert_contains "**Options**:"                             "$OUT" "Options heading present"
 assert_contains "**Recommendation** — Pick option 1"       "$OUT" "Recommendation section present"
-assert_contains "**Time sensitivity** — blocking"          "$OUT" "Time sensitivity section present"
+assert_contains "**Blocking?** — yes"                       "$OUT" "Blocking? section present"
 assert_contains "**Risk** — Defer means service stays broken" "$OUT" "Risk section present"
 # Options must be re-numbered as a Markdown numbered list.
 assert_contains "1. First option"  "$OUT" "Option 1 rendered as numbered list"
@@ -53,7 +53,7 @@ _flow_test_begin "missing required field → exit 1"
 if [ $(( ${#ALL_ARGS[@]} % 2 )) -ne 0 ]; then
   _flow_assert_fail "ALL_ARGS has odd length ${#ALL_ARGS[@]}; cannot iterate as pairs"
 fi
-FIELDS=(--situation --tried --options --recommendation --time-sensitivity --risk)
+FIELDS=(--situation --tried --options --recommendation --blocking --risk)
 for DROP in "${FIELDS[@]}"; do
   ARGS=()
   i=0
@@ -87,7 +87,7 @@ _flow_test_begin "malformed option → exit 2"
 ARGS=(
   --situation S --tried T
   --options "no-number-here"
-  --recommendation R --time-sensitivity blocking --risk R
+  --recommendation R --blocking yes --risk R
 )
 ERR=$("$HELPER" "${ARGS[@]}" 2>&1 >/dev/null)
 EXIT=$?
@@ -99,7 +99,7 @@ _flow_test_begin "duplicate option number → exit 2"
 ARGS=(
   --situation S --tried T
   --options "1: First;1: Also first"
-  --recommendation R --time-sensitivity blocking --risk R
+  --recommendation R --blocking yes --risk R
 )
 ERR=$("$HELPER" "${ARGS[@]}" 2>&1 >/dev/null)
 EXIT=$?
@@ -111,7 +111,7 @@ _flow_test_begin "empty options → exit 2"
 ARGS=(
   --situation S --tried T
   --options ";;"
-  --recommendation R --time-sensitivity blocking --risk R
+  --recommendation R --blocking yes --risk R
 )
 ERR=$("$HELPER" "${ARGS[@]}" 2>&1 >/dev/null)
 EXIT=$?

--- a/plugins/flow/tests/flow-escalate.test.sh
+++ b/plugins/flow/tests/flow-escalate.test.sh
@@ -131,3 +131,47 @@ ERR=$("$HELPER" -h 2>&1 >/dev/null)
 EXIT=$?
 assert_exit 0 "$EXIT" "exit 0"
 assert_contains "All six fields are required" "$ERR" "usage text on stderr"
+
+# --- Test 8: --blocking with calendar-time value → exit 2 (value-space guard)
+# The rename from --time-sensitivity only matters if the value space is
+# constrained. Without this guard, a caller passing calendar-time language
+# defeats the rename's purpose. Verify the three valid values are accepted
+# and any other value is rejected.
+_flow_test_begin "--blocking value-space enforced"
+for INVALID in "by Friday" "urgent" "1-2 weeks" "ETA: end of week" "blocking"; do
+  ARGS=(
+    --situation S --tried T
+    --options "1: First option"
+    --recommendation R --blocking "$INVALID" --risk R
+  )
+  ERR=$("$HELPER" "${ARGS[@]}" 2>&1 >/dev/null)
+  EXIT=$?
+  assert_exit 2 "$EXIT" "exit 2 on --blocking '$INVALID'"
+  assert_contains "must be 'yes', 'soft', or 'no'" "$ERR" "stderr names the value-space constraint for '$INVALID'"
+done
+# Positive: each of the three valid values must succeed, in any case.
+# Mixed-case acceptance lets canonical prose ("Blocking? — Yes.") flow through
+# without normalization. The renderer always emits lowercase for uniformity.
+for VALID in "yes" "soft" "no" "Yes" "Soft" "No" "YES" "SOFT" "NO"; do
+  ARGS=(
+    --situation S --tried T
+    --options "1: First option"
+    --recommendation R --blocking "$VALID" --risk R
+  )
+  OUT=$("$HELPER" "${ARGS[@]}" 2>/dev/null)
+  EXIT=$?
+  EXPECTED_LOWER="$(echo "$VALID" | tr '[:upper:]' '[:lower:]')"
+  assert_exit 0 "$EXIT" "exit 0 on --blocking '$VALID'"
+  assert_contains "**Blocking?** — $EXPECTED_LOWER" "$OUT" "body renders --blocking '$VALID' normalized to lowercase"
+done
+
+# --- Test 9: trailing flag without value → exit 1 with clear message
+# Without the require_value guard, a trailing `--blocking` (no value following)
+# consumes its own slot via `${2:-}` and produces a misleading
+# "missing required fields: --blocking" message. With the guard, the user
+# gets the actual cause.
+_flow_test_begin "trailing flag without value → exit 1 with clear message"
+ERR=$("$HELPER" --situation S --tried T --options "1: A" --recommendation R --risk R --blocking 2>&1 >/dev/null)
+EXIT=$?
+assert_exit 1 "$EXIT" "exit 1 on trailing flag without value"
+assert_contains "--blocking requires a value" "$ERR" "stderr names the missing-value cause, not generic missing-fields"


### PR DESCRIPTION
## Summary

- Introduces `llm-operator-principles` foundational skill (consulted by every `/flow:*` command) that frames Claude as an LLM operator that does not tire, treats convergence as zero findings (not exhausted budget), and prohibits calendar-time estimates.
- Removes the structural deferral escape hatches: default mode no longer creates follow-up issues for findings, escalation is narrowed to true product/architecture decisions, iteration ceilings raised from 2/3 to 10/10.
- Adds `autonomous` and `minimalScope` modes for sole-maintainer vs. scope-constrained workflows.

Closes #106.

## What changed

- **New skill**: `plugins/flow/skills/llm-operator-principles/SKILL.md` — operator stance, convergence semantics, anti-estimation rules, finding-disposition heuristic. Referenced as the first required skill in every `/flow:*` command.
- **Iteration ceilings**: `fixForwardMaxIterations` 2 → 10, `reviewCycleLimit` 3 → 10. Documented in `settings.json` + `schema.json` as safety nets, not budgets.
- **Follow-up-issue workflow**: removed from default mode in `commands/address.md` and `commands/review.md`. Cosmetic P3 in untouched files is fix-if-bounded (<10 lines) or document-inline. The original workflow is restored only when `minimalScope: true`.
- **Escalation narrowed**: `references/escalation-format.md` adds explicit "When escalation IS NOT required" entries for finding triage and iteration-ceiling approach. The `Time sensitivity` field is renamed to `Blocking?` (yes/soft/no, no calendar verbs). Propagated to `skills/*`, `agents/*`, and command escalations.
- **CLI rename**: `bin/flow-escalate.sh` `--time-sensitivity` → `--blocking` (breaking change for direct CLI users; matches the new canonical field name).
- **Templates**: `templates/pr-body.md` guard against calendar-time estimates; `templates/{resolution-comment,self-review-comment}.md` use the `Blocking?` field.
- **Docs**: `README.md` + `CHANGELOG.md` document the new skill, modes, and semantic shift.
- **Version**: flow 2.3.2 → 2.4.0; marketplace 4.3.2 → 4.4.0.

## Test plan

- [x] Zero-dep flow test harness: 156/156 pass after the `--time-sensitivity` → `--blocking` rename (test updated)
- [x] Grep audit: no residual `Time sensitivity` references outside rename-documentation prose
- [x] Grep audit: no calendar-time anti-patterns (`multi-week`, `next sprint`, `ETA:`, etc.) outside prohibition examples in `llm-operator-principles/SKILL.md` and `autonomous-workflow/SKILL.md`
- [x] Grep audit: no stale `2.3.2` references in `plugins/flow/` or `.claude-plugin/`
- [ ] Smoke test on a real PR with seeded findings — verify Claude fixes in-PR without follow-up-issue prompts (post-merge validation)

## Migration

To restore v2.3.x behavior:

```json
{
  "fixForwardMaxIterations": 2,
  "reviewCycleLimit": 3,
  "minimalScope": true
}
```

In `.claude/settings.flow.json` or `.claude/settings.flow.local.json`.