### PR TITLE
feat(flow): configurable model for Path A agent-team review (#112)

### DIFF
--- a/.decisions/issue-112.md
+++ b/.decisions/issue-112.md
@@ -1,0 +1,63 @@
+# Issue #112 — Configurable model for flow agent-team (Path A) review
+
+Branch: `feature/issue-112-configurable-agentteam-model`
+
+## Summary
+
+Path A (agent-team) review in `/flow:review` spawns ~20 subagents, all `model: inherit`,
+so an Opus session multiplies Opus-rate tokens ~4×. Make the Path A review-agent model
+configurable via a settings key (cascade-resolved), default `sonnet`. Path B unchanged.
+
+## Design decisions
+
+- **Key**: top-level `agentTeamModel` in plugin `settings.json`, sibling of `agentTeams`
+  (the model modifies the agent-teams feature). Resolved via the standard 4-tier cascade
+  using `bin/cascade-resolve.sh` (local > project > user > plugin default), the same
+  cascade `agentTeams` uses. Enum `["haiku","sonnet","opus","inherit"]`, default `sonnet`.
+- **Mechanism**: the Path A gate in `commands/review.md` resolves the key into
+  `AGENT_TEAM_MODEL`; A.1 and A.3 dispatches pass it as the per-invocation `model`
+  parameter, which overrides each agent's `model: inherit` frontmatter
+  (precedence: dispatch param > frontmatter > session). `inherit` → omit the param
+  (reproduces pre-#112 behavior).
+- **Documentation**: schema.json description cross-references `flow.goals.judge.model`;
+  README + gate-configuration.md document the key next to `agentTeams`.
+
+## Specification
+
+### Non-goals
+- Path B (single-session, default) review behavior is NOT changed — its agents keep inheriting the session model.
+- Other agent-dispatching commands (start, pr, address, debug, design, brainstorm) are NOT changed.
+- The two `Skill(holdout-validation)` invocations are NOT model-dispatched (skills run inline) — unaffected.
+- No global "all subagents" model setting is introduced.
+
+### Failure modes
+- Invalid `agentTeamModel` value (typo, non-enum) → emit a clear WARN naming the value + allowed set, reject it, fall back to `sonnet` (NOT silent — AC6).
+- `jq` not installed → `cascade-resolve.sh` returns the `--default sonnet` backstop.
+- Per-source JSON parse error → `cascade-resolve.sh` emits per-source WARN and continues the cascade.
+
+### Interface contracts
+- New top-level settings key: `agentTeamModel` : enum `["haiku","sonnet","opus","inherit"]`, default `"sonnet"` (settings.json + schema.json).
+- Path A gate emits `AGENT_TEAM_MODEL=<resolved-value>` (only when `USE_PATH_A=1`).
+- Path A dispatches (A.1 paired reviewers, A.3 challenge rounds) carry `model=$AGENT_TEAM_MODEL`; when value is `inherit`, the `model` param is omitted.
+
+<!-- auto-log: 2026-05-23 01:04 Write /Users/danielbentes/synapti-marketplace/.decisions/issue-112.md -->
+
+<!-- auto-log: 2026-05-23 01:06 Write /Users/danielbentes/synapti-marketplace/plugins/flow/tests/flow-agentteam-model.test.sh -->
+
+<!-- auto-log: 2026-05-23 01:06 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/settings.json -->
+
+<!-- auto-log: 2026-05-23 01:06 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/schema.json -->
+
+<!-- auto-log: 2026-05-23 01:07 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-23 01:07 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-23 01:07 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-23 01:07 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-23 01:07 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/README.md -->
+
+<!-- auto-log: 2026-05-23 01:07 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/README.md -->
+
+<!-- auto-log: 2026-05-23 01:08 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/references/gate-configuration.md -->

--- a/.decisions/issue-112.md
+++ b/.decisions/issue-112.md
@@ -1,3 +1,18 @@
+---
+issue: 112
+created: '2026-05-22T23:15:25Z'
+artifacts:
+- type: specification
+  captured_at: '2026-05-22T23:15:25Z'
+  by: specification-capture
+  elements:
+  - non-goals
+  - failure-modes
+  - interface-contracts
+- type: verdict
+  captured_at: '2026-05-22T23:15:25Z'
+  result: PASS
+---
 # Issue #112 — Configurable model for flow agent-team (Path A) review
 
 Branch: `feature/issue-112-configurable-agentteam-model`
@@ -61,3 +76,41 @@ configurable via a settings key (cascade-resolved), default `sonnet`. Path B unc
 <!-- auto-log: 2026-05-23 01:07 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/README.md -->
 
 <!-- auto-log: 2026-05-23 01:08 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/references/gate-configuration.md -->
+
+<!-- auto-log: 2026-05-23 01:09 commit "feat(flow): configurable model for Path A agent-team review (#112)" -->
+
+<!-- auto-log: 2026-05-23 01:12 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-23 01:12 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-23 01:12 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-23 01:12 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-23 01:12 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-23 01:12 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-23 01:12 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-23 01:12 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-23 01:12 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-23 01:13 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-23 01:13 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-23 01:13 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-23 01:13 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-23 01:13 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-23 01:13 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-23 01:13 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/flow-agentteam-model.test.sh -->
+
+<!-- auto-log: 2026-05-23 01:13 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/flow-agentteam-model.test.sh -->
+
+<!-- auto-log: 2026-05-23 01:15 commit "fix(flow): carry model param on Path A fenced dispatches (#112)" -->

--- a/plugins/flow/CHANGELOG.md
+++ b/plugins/flow/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added: configurable model for Path A agent-team review
+
+`/flow:review` Path A (agent-team paired-reviewer mode) dispatches ~20 subagents, all previously `model: inherit` — on an Opus session that multiplied Opus-rate tokens ~4x. A new top-level `agentTeamModel` setting (enum `haiku|sonnet|opus|inherit`, default `sonnet`, cascade-resolved) controls the model for those Path A reviewers via the Agent tool's per-invocation `model` override. `inherit` reproduces the prior behavior (override omitted → session model). Invalid values are rejected with a warning and fall back to `sonnet`. Path B (single-session, default) is unchanged.
+
 ## 3.0.0 (2026-05-20)
 
 ### New: Flow v3 runtime layer — goals, workflows, triggers

--- a/plugins/flow/README.md
+++ b/plugins/flow/README.md
@@ -323,6 +323,8 @@ Enable with `"agentTeams": true` in settings. Requires `CLAUDE_CODE_EXPERIMENTAL
 
 When enabled, `/flow:review` spawns an adversarial review team where independent reviewers challenge each other's findings. Falls back to single-session mode gracefully.
 
+**Model selection.** Because this Path A team dispatches ~20 agents per review, all of which would otherwise inherit the session model, the model is configurable via `agentTeamModel` (default `"sonnet"`; enum `haiku|sonnet|opus|inherit`). It resolves through the same settings cascade as `agentTeams`. Set it to `"inherit"` to run the review agents on the session's model, or `"opus"` for a high-stakes review. This mirrors the `flow.goals.judge.model` pattern and applies to Path A only — Path B (single-session, the default) always inherits the session model.
+
 ## Learning Loop
 
 Flow captures development decisions in a journal (`.decisions/`) and analyzes them for patterns:
@@ -346,6 +348,7 @@ Example project settings in `.claude/settings.flow.json`:
 ```json
 {
   "agentTeams": false,
+  "agentTeamModel": "sonnet",
   "tiers": { "push": "journal", "merge": "confirm", "release": "confirm" },
   "conventions": { "commitTypes": ["feat", "fix", "docs", "..."] },
   "merge": { "strategy": "squash", "deleteBranch": true },

--- a/plugins/flow/commands/review.md
+++ b/plugins/flow/commands/review.md
@@ -309,14 +309,39 @@ else
   echo "PATH_A_STATE=disabled"
 fi
 
+# AGENTTEAM_MODEL_BEGIN
+# Resolve the model for Path A review agents (#112). Scoped to Path A only —
+# Path B agents continue to inherit the session model via their frontmatter.
+# Cascade precedence: local > project > user > plugin default (same cascade as
+# agentTeams). Default is sonnet: a paired-reviewer run dispatches ~20 agents,
+# so inheriting an Opus session would multiply Opus-rate tokens ~4x for
+# marginal review value. An invalid value is rejected with a WARN (NOT silently
+# coerced) and falls back to sonnet.
+if [ "$USE_PATH_A" = "1" ]; then
+  AGENT_TEAM_MODEL=$("${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh" --default sonnet '.agentTeamModel // empty' 2>/dev/null)
+  case "$AGENT_TEAM_MODEL" in
+    haiku|sonnet|opus|inherit) ;;
+    *)
+      echo "WARN: agentTeamModel='$AGENT_TEAM_MODEL' is not one of haiku|sonnet|opus|inherit; rejecting and using sonnet. Set a valid value in .claude/settings.flow.local.json, .claude/settings.flow.json, \$HOME/.claude/settings.flow.json, or the plugin settings.json." >&2
+      AGENT_TEAM_MODEL=sonnet
+      ;;
+  esac
+  echo "AGENT_TEAM_MODEL=$AGENT_TEAM_MODEL"
+fi
+# AGENTTEAM_MODEL_END
+
 true
 ```
 
 If `USE_PATH_A=0`, skip the rest of Path A and dispatch Path B below.
 
+**Model selection (#112).** When `USE_PATH_A=1`, the gate emits `AGENT_TEAM_MODEL` (default `sonnet`). Dispatch every Path A agent below — both the A.1 paired reviewers and the A.3 challenge rounds — with that model passed as the per-invocation `model` parameter, e.g. `Agent(security-reviewer-skeptic, model=$AGENT_TEAM_MODEL)`. The per-invocation `model` overrides each agent's `model: inherit` frontmatter (precedence: dispatch param > frontmatter > session model), so the reviewers run on `AGENT_TEAM_MODEL` regardless of the session's model. **Exception:** when `AGENT_TEAM_MODEL=inherit`, OMIT the `model` parameter so agents fall back to frontmatter `inherit` (the session model) — reproducing pre-#112 behavior. The two `Skill(holdout-validation)` invocations are unaffected (skills run inline in the parent context, not as model-dispatched subagents).
+
 #### A.1 — Independent Analysis (paired reviewers, parallel dispatch)
 
 Dispatch **12 invocations** (10 `Agent(...)` + 2 `Skill(holdout-validation)`) in a single parallel block — 5 agent facets × {skeptic, verifier} plus the holdout-validation skill in both lenses. Each variant carries an orthogonal lens; both run with no awareness of each other.
+
+Each `Agent(...)` call below carries `model=$AGENT_TEAM_MODEL` per **Model selection (#112)** above (omit the parameter only when the resolved value is `inherit`).
 
 ```
 Agent(security-reviewer-skeptic):
@@ -436,7 +461,7 @@ Auto-consensus findings skip the challenge round (no need — both reviewers alr
 
 #### A.3 — Challenge Round (disposition-only, parallel)
 
-For findings NOT in auto-consensus, dispatch each variant to challenge the OTHER variant's findings. **Variants do NOT re-read the diff.** Up to 10 challenge prompts run in parallel (5 agent facets × 2 directions; holdout-validation excluded — see A.1 note).
+For findings NOT in auto-consensus, dispatch each variant to challenge the OTHER variant's findings. **Variants do NOT re-read the diff.** Up to 10 challenge prompts run in parallel (5 agent facets × 2 directions; holdout-validation excluded — see A.1 note). Each challenge `Agent(...)` carries `model=$AGENT_TEAM_MODEL` per **Model selection (#112)** (omit only when the value is `inherit`).
 
 ```
 Agent(security-reviewer-skeptic) [challenge mode]:
@@ -517,6 +542,8 @@ When Path A is the orchestrator, the marker is **uniformly 7-field** — includi
 After A.6 completes, jump to Phase 4 with the consolidated finding set.
 
 ### Path B: Single Session (default)
+
+Path B dispatch is intentionally unchanged (#112) — its agents carry no `model` parameter and inherit the session model via frontmatter. The `agentTeamModel` setting applies to Path A only.
 
 **Parallel Agent dispatch** — 5 agents in single message:
 

--- a/plugins/flow/commands/review.md
+++ b/plugins/flow/commands/review.md
@@ -335,16 +335,16 @@ true
 
 If `USE_PATH_A=0`, skip the rest of Path A and dispatch Path B below.
 
-**Model selection (#112).** When `USE_PATH_A=1`, the gate emits `AGENT_TEAM_MODEL` (default `sonnet`). Dispatch every Path A agent below — both the A.1 paired reviewers and the A.3 challenge rounds — with that model passed as the per-invocation `model` parameter, e.g. `Agent(security-reviewer-skeptic, model=$AGENT_TEAM_MODEL)`. The per-invocation `model` overrides each agent's `model: inherit` frontmatter (precedence: dispatch param > frontmatter > session model), so the reviewers run on `AGENT_TEAM_MODEL` regardless of the session's model. **Exception:** when `AGENT_TEAM_MODEL=inherit`, OMIT the `model` parameter so agents fall back to frontmatter `inherit` (the session model) — reproducing pre-#112 behavior. The two `Skill(holdout-validation)` invocations are unaffected (skills run inline in the parent context, not as model-dispatched subagents).
+**Model selection (#112).** When `USE_PATH_A=1`, the gate emits `AGENT_TEAM_MODEL` (default `sonnet`). Dispatch every Path A agent below — both the A.1 paired reviewers and the A.3 challenge rounds — with that model passed as the per-invocation `model` parameter, e.g. `Agent(security-reviewer-skeptic, model=$AGENT_TEAM_MODEL)`. The per-invocation `model` overrides each agent's `model: inherit` frontmatter (precedence: dispatch param > frontmatter > session model), so the reviewers run on `AGENT_TEAM_MODEL` regardless of the session's model. When `AGENT_TEAM_MODEL=inherit`, passing `model=inherit` is itself valid and resolves to the session model (reproducing pre-#112 behavior); omitting the parameter entirely is equivalent. The two `Skill(holdout-validation)` invocations are unaffected (skills run inline in the parent context, not as model-dispatched subagents).
 
 #### A.1 — Independent Analysis (paired reviewers, parallel dispatch)
 
 Dispatch **12 invocations** (10 `Agent(...)` + 2 `Skill(holdout-validation)`) in a single parallel block — 5 agent facets × {skeptic, verifier} plus the holdout-validation skill in both lenses. Each variant carries an orthogonal lens; both run with no awareness of each other.
 
-Each `Agent(...)` call below carries `model=$AGENT_TEAM_MODEL` per **Model selection (#112)** above (omit the parameter only when the resolved value is `inherit`).
+Each `Agent(...)` call below carries `model=$AGENT_TEAM_MODEL` per **Model selection (#112)** above. (`model=inherit` is valid and means the session model.)
 
 ```
-Agent(security-reviewer-skeptic):
+Agent(security-reviewer-skeptic, model=$AGENT_TEAM_MODEL):
   "You are reviewing PR #$ARGUMENTS as the SKEPTIC variant. Assume the diff is
    broken until proven otherwise. Flag every security behavior you cannot prove
    correct from the code as written: OWASP Top 10, secrets, auth/authz, input
@@ -352,41 +352,41 @@ Agent(security-reviewer-skeptic):
    file:line citations and category. Do NOT include challenge information —
    another reviewer will challenge your findings later."
 
-Agent(security-reviewer-verifier):
+Agent(security-reviewer-verifier, model=$AGENT_TEAM_MODEL):
   "You are reviewing PR #$ARGUMENTS as the VERIFIER variant. Assume the diff is
    correct as a baseline. Look only for missed security edge cases, undocumented
    contract assumptions, or invariants that aren't enforced. Return P1/P2/P3
    findings with file:line citations and category."
 
-Agent(code-reviewer-skeptic):
+Agent(code-reviewer-skeptic, model=$AGENT_TEAM_MODEL):
   "PR #$ARGUMENTS as SKEPTIC. Assume broken; flag logic/quality/edge-case
    issues you cannot prove correct. P1/P2/P3 + file:line + category."
 
-Agent(code-reviewer-verifier):
+Agent(code-reviewer-verifier, model=$AGENT_TEAM_MODEL):
   "PR #$ARGUMENTS as VERIFIER. Assume correct; look only for missed edge cases
    and unenforced invariants. P1/P2/P3 + file:line + category."
 
-Agent(convention-checker-skeptic):
+Agent(convention-checker-skeptic, model=$AGENT_TEAM_MODEL):
   "PR #$ARGUMENTS as SKEPTIC. Flag every convention violation (commits, branch
    naming, code patterns) you cannot prove conformant. P1/P2/P3 + file:line."
 
-Agent(convention-checker-verifier):
+Agent(convention-checker-verifier, model=$AGENT_TEAM_MODEL):
   "PR #$ARGUMENTS as VERIFIER. Look for convention drift the skeptic might miss
    (e.g., subtle stylistic divergence). P1/P2/P3 + file:line."
 
-Agent(test-runner-skeptic):
+Agent(test-runner-skeptic, model=$AGENT_TEAM_MODEL):
   "PR #$ARGUMENTS as SKEPTIC. Run quality commands (lint, test, typecheck) and
    flag every failure or warning. Return findings with command output."
 
-Agent(test-runner-verifier):
+Agent(test-runner-verifier, model=$AGENT_TEAM_MODEL):
   "PR #$ARGUMENTS as VERIFIER. Run quality commands and flag missing test
    coverage or weak assertions in passing tests. Return findings."
 
-Agent(error-handler-inspector-skeptic):
+Agent(error-handler-inspector-skeptic, model=$AGENT_TEAM_MODEL):
   "PR #$ARGUMENTS as SKEPTIC. Flag every error-handling gap, silent failure,
    or unhandled exception you cannot prove handled. P1/P2/P3 + file:line."
 
-Agent(error-handler-inspector-verifier):
+Agent(error-handler-inspector-verifier, model=$AGENT_TEAM_MODEL):
   "PR #$ARGUMENTS as VERIFIER. Look for missed error contracts and unenforced
    exception invariants. P1/P2/P3 + file:line."
 
@@ -461,10 +461,10 @@ Auto-consensus findings skip the challenge round (no need — both reviewers alr
 
 #### A.3 — Challenge Round (disposition-only, parallel)
 
-For findings NOT in auto-consensus, dispatch each variant to challenge the OTHER variant's findings. **Variants do NOT re-read the diff.** Up to 10 challenge prompts run in parallel (5 agent facets × 2 directions; holdout-validation excluded — see A.1 note). Each challenge `Agent(...)` carries `model=$AGENT_TEAM_MODEL` per **Model selection (#112)** (omit only when the value is `inherit`).
+For findings NOT in auto-consensus, dispatch each variant to challenge the OTHER variant's findings. **Variants do NOT re-read the diff.** Up to 10 challenge prompts run in parallel (5 agent facets × 2 directions; holdout-validation excluded — see A.1 note). Each challenge `Agent(...)` carries `model=$AGENT_TEAM_MODEL` per **Model selection (#112)**.
 
 ```
-Agent(security-reviewer-skeptic) [challenge mode]:
+Agent(security-reviewer-skeptic, model=$AGENT_TEAM_MODEL) [challenge mode]:
   "You are reviewer-A (skeptic) for facet 'security'. Reviewer-B (verifier)
    raised the following findings on the same diff you reviewed independently.
    For each finding, respond with exactly one line:
@@ -478,7 +478,7 @@ Agent(security-reviewer-skeptic) [challenge mode]:
    Findings to challenge:
    {list of verifier's non-auto-consensus findings: ID, file:line, priority, category}"
 
-Agent(security-reviewer-verifier) [challenge mode]:
+Agent(security-reviewer-verifier, model=$AGENT_TEAM_MODEL) [challenge mode]:
   "Same instructions, reversed: challenge the skeptic's non-auto-consensus
    findings for facet 'security'."
 

--- a/plugins/flow/commands/review.md
+++ b/plugins/flow/commands/review.md
@@ -335,13 +335,13 @@ true
 
 If `USE_PATH_A=0`, skip the rest of Path A and dispatch Path B below.
 
-**Model selection.** When `USE_PATH_A=1`, the gate emits `AGENT_TEAM_MODEL` (default `sonnet`). Dispatch every Path A agent below — both the A.1 paired reviewers and the A.3 challenge rounds — with that model passed as the per-invocation `model` parameter, e.g. `Agent(security-reviewer-skeptic, model=$AGENT_TEAM_MODEL)`. The per-invocation `model` overrides each agent's `model: inherit` frontmatter (precedence: dispatch param > frontmatter > session model), so the reviewers run on `AGENT_TEAM_MODEL` regardless of the session's model. When `AGENT_TEAM_MODEL=inherit`, passing `model=inherit` is itself valid and resolves to the session model (the same behavior as before this setting existed); omitting the parameter entirely is equivalent. The two `Skill(holdout-validation)` invocations are unaffected (skills run inline in the parent context, not as model-dispatched subagents).
+**Model selection.** When `USE_PATH_A=1`, the gate emits `AGENT_TEAM_MODEL` (default `sonnet`). Dispatch every Path A agent below — both the A.1 paired reviewers and the A.3 challenge rounds — passing `AGENT_TEAM_MODEL` as the Agent tool's per-invocation `model` override (the `model=...` shown in the `Agent(...)` examples maps to that tool argument). The override takes precedence over each agent's `model: inherit` frontmatter (precedence: dispatch override > frontmatter > session model), so the reviewers run on `AGENT_TEAM_MODEL` regardless of the session's model. **When `AGENT_TEAM_MODEL=inherit`, OMIT the `model` argument entirely** — the dispatch-time override accepts only `sonnet`/`opus`/`haiku`, and the session model (the behavior before this setting existed) is expressed by dropping the override, NOT by passing `model=inherit`. The two `Skill(holdout-validation)` invocations are unaffected (skills run inline in the parent context, not as model-dispatched subagents).
 
 #### A.1 — Independent Analysis (paired reviewers, parallel dispatch)
 
 Dispatch **12 invocations** (10 `Agent(...)` + 2 `Skill(holdout-validation)`) in a single parallel block — 5 agent facets × {skeptic, verifier} plus the holdout-validation skill in both lenses. Each variant carries an orthogonal lens; both run with no awareness of each other.
 
-Each `Agent(...)` call below carries `model=$AGENT_TEAM_MODEL` per **Model selection** above. (`model=inherit` is valid and means the session model.)
+Each `Agent(...)` call below carries `model=$AGENT_TEAM_MODEL` per **Model selection** above. (When the resolved value is `inherit`, drop the `model=` argument — the session model is the default when no override is passed.)
 
 ```
 Agent(security-reviewer-skeptic, model=$AGENT_TEAM_MODEL):

--- a/plugins/flow/commands/review.md
+++ b/plugins/flow/commands/review.md
@@ -310,7 +310,7 @@ else
 fi
 
 # AGENTTEAM_MODEL_BEGIN
-# Resolve the model for Path A review agents (#112). Scoped to Path A only —
+# Resolve the model for Path A review agents. Scoped to Path A only —
 # Path B agents continue to inherit the session model via their frontmatter.
 # Cascade precedence: local > project > user > plugin default (same cascade as
 # agentTeams). Default is sonnet: a paired-reviewer run dispatches ~20 agents,
@@ -335,13 +335,13 @@ true
 
 If `USE_PATH_A=0`, skip the rest of Path A and dispatch Path B below.
 
-**Model selection (#112).** When `USE_PATH_A=1`, the gate emits `AGENT_TEAM_MODEL` (default `sonnet`). Dispatch every Path A agent below — both the A.1 paired reviewers and the A.3 challenge rounds — with that model passed as the per-invocation `model` parameter, e.g. `Agent(security-reviewer-skeptic, model=$AGENT_TEAM_MODEL)`. The per-invocation `model` overrides each agent's `model: inherit` frontmatter (precedence: dispatch param > frontmatter > session model), so the reviewers run on `AGENT_TEAM_MODEL` regardless of the session's model. When `AGENT_TEAM_MODEL=inherit`, passing `model=inherit` is itself valid and resolves to the session model (reproducing pre-#112 behavior); omitting the parameter entirely is equivalent. The two `Skill(holdout-validation)` invocations are unaffected (skills run inline in the parent context, not as model-dispatched subagents).
+**Model selection.** When `USE_PATH_A=1`, the gate emits `AGENT_TEAM_MODEL` (default `sonnet`). Dispatch every Path A agent below — both the A.1 paired reviewers and the A.3 challenge rounds — with that model passed as the per-invocation `model` parameter, e.g. `Agent(security-reviewer-skeptic, model=$AGENT_TEAM_MODEL)`. The per-invocation `model` overrides each agent's `model: inherit` frontmatter (precedence: dispatch param > frontmatter > session model), so the reviewers run on `AGENT_TEAM_MODEL` regardless of the session's model. When `AGENT_TEAM_MODEL=inherit`, passing `model=inherit` is itself valid and resolves to the session model (the same behavior as before this setting existed); omitting the parameter entirely is equivalent. The two `Skill(holdout-validation)` invocations are unaffected (skills run inline in the parent context, not as model-dispatched subagents).
 
 #### A.1 — Independent Analysis (paired reviewers, parallel dispatch)
 
 Dispatch **12 invocations** (10 `Agent(...)` + 2 `Skill(holdout-validation)`) in a single parallel block — 5 agent facets × {skeptic, verifier} plus the holdout-validation skill in both lenses. Each variant carries an orthogonal lens; both run with no awareness of each other.
 
-Each `Agent(...)` call below carries `model=$AGENT_TEAM_MODEL` per **Model selection (#112)** above. (`model=inherit` is valid and means the session model.)
+Each `Agent(...)` call below carries `model=$AGENT_TEAM_MODEL` per **Model selection** above. (`model=inherit` is valid and means the session model.)
 
 ```
 Agent(security-reviewer-skeptic, model=$AGENT_TEAM_MODEL):
@@ -461,7 +461,7 @@ Auto-consensus findings skip the challenge round (no need — both reviewers alr
 
 #### A.3 — Challenge Round (disposition-only, parallel)
 
-For findings NOT in auto-consensus, dispatch each variant to challenge the OTHER variant's findings. **Variants do NOT re-read the diff.** Up to 10 challenge prompts run in parallel (5 agent facets × 2 directions; holdout-validation excluded — see A.1 note). Each challenge `Agent(...)` carries `model=$AGENT_TEAM_MODEL` per **Model selection (#112)**.
+For findings NOT in auto-consensus, dispatch each variant to challenge the OTHER variant's findings. **Variants do NOT re-read the diff.** Up to 10 challenge prompts run in parallel (5 agent facets × 2 directions; holdout-validation excluded — see A.1 note). Each challenge `Agent(...)` carries `model=$AGENT_TEAM_MODEL` per **Model selection**.
 
 ```
 Agent(security-reviewer-skeptic, model=$AGENT_TEAM_MODEL) [challenge mode]:
@@ -543,7 +543,7 @@ After A.6 completes, jump to Phase 4 with the consolidated finding set.
 
 ### Path B: Single Session (default)
 
-Path B dispatch is intentionally unchanged (#112) — its agents carry no `model` parameter and inherit the session model via frontmatter. The `agentTeamModel` setting applies to Path A only.
+Path B dispatch is intentionally unchanged — its agents carry no `model` parameter and inherit the session model via frontmatter. The `agentTeamModel` setting applies to Path A only.
 
 **Parallel Agent dispatch** — 5 agents in single message:
 

--- a/plugins/flow/references/gate-configuration.md
+++ b/plugins/flow/references/gate-configuration.md
@@ -199,6 +199,16 @@ Example: enabling Path A paired-reviewer mode for yourself in this project only:
 
 (Note: `agentTeams: true` also requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` set in your shell environment — the env var is the user-side opt-in for the experimental feature.)
 
+**Path A review model (`agentTeamModel`).** Path A dispatches ~20 review agents (paired skeptic/verifier × 5 facets + a challenge round), all of which would otherwise inherit the session model. To avoid running an Opus session's rate across that fan-out, the model is configurable via the top-level `agentTeamModel` key (enum `haiku|sonnet|opus|inherit`, default `sonnet`), resolved through this same cascade. An invalid value is rejected with a WARN and falls back to `sonnet`. Use `inherit` to reproduce the pre-configuration behavior. This is scoped to Path A only — Path B (single-session) agents always inherit the session model.
+
+```json
+// .claude/settings.flow.local.json (gitignored) — pin a higher model for a hard review
+{
+  "agentTeams": true,
+  "agentTeamModel": "opus"
+}
+```
+
 #### Team-wide opt-in
 
 To enable a setting for the whole team via the committed project-shared file:

--- a/plugins/flow/schema.json
+++ b/plugins/flow/schema.json
@@ -8,6 +8,11 @@
       "default": false,
       "description": "Enable agent team support for adversarial review and parallel implementation"
     },
+    "agentTeamModel": {
+      "enum": ["haiku", "sonnet", "opus", "inherit"],
+      "default": "sonnet",
+      "description": "Model used by the Path A agent-team review agents in /flow:review (paired skeptic/verifier reviewers + challenge round). Resolved via the standard settings cascade (local > project > user > plugin default). Default is 'sonnet' because a paired-reviewer run dispatches ~20 agents — inheriting an Opus session would multiply Opus-rate tokens ~4x for marginal review value. Use 'inherit' to reproduce the pre-configuration behavior (agents run on the main session's model). Mirrors the configurable-model pattern of flow.goals.judge.model. Scoped to Path A only: Path B (single-session, default) agents always inherit the session model."
+    },
     "tiers": {
       "type": "object",
       "description": "Safety tier classification for actions",

--- a/plugins/flow/settings.json
+++ b/plugins/flow/settings.json
@@ -1,5 +1,6 @@
 {
   "agentTeams": false,
+  "agentTeamModel": "sonnet",
   "tiers": {
     "push": "journal",
     "prCreate": "journal",

--- a/plugins/flow/tests/flow-agentteam-model.test.sh
+++ b/plugins/flow/tests/flow-agentteam-model.test.sh
@@ -1,0 +1,125 @@
+# Tests for the configurable Path A agent-team review model (issue #112).
+#
+# Contract under test:
+#   - settings.json carries a top-level `agentTeamModel` defaulting to "sonnet".
+#   - schema.json constrains it to enum [haiku,sonnet,opus,inherit], default sonnet.
+#   - commands/review.md Path A gate resolves the key via cascade-resolve.sh into
+#     AGENT_TEAM_MODEL, validates it against the enum (rejecting invalid values
+#     with a WARN + sonnet fallback — NOT silent), and the A.1/A.3 dispatches
+#     pass it as the per-invocation model. Path B is left unchanged.
+#   - Docs (README.md, references/gate-configuration.md) mention the key.
+#   - Functional: cascade-resolve returns sonnet by default and honors a local
+#     override; the extracted gate block rejects a bogus value and accepts inherit.
+#
+# Prereq: jq (used by cascade-resolve.sh and the static enum assertions).
+# SKIPS gracefully if jq is unavailable.
+
+if ! command -v jq >/dev/null 2>&1; then
+  _flow_test_begin "jq prerequisite"
+  _flow_assert_pass "SKIP: jq not installed"
+  return 0
+fi
+
+PLUGIN_DIR="$REPO_ROOT/plugins/flow"
+SETTINGS="$PLUGIN_DIR/settings.json"
+SCHEMA="$PLUGIN_DIR/schema.json"
+REVIEW_MD="$PLUGIN_DIR/commands/review.md"
+README="$PLUGIN_DIR/README.md"
+GATE_DOC="$PLUGIN_DIR/references/gate-configuration.md"
+CASCADE="$PLUGIN_DIR/bin/cascade-resolve.sh"
+
+CLEANUP_PATHS=()
+_cleanup_all() {
+  local p
+  for p in "${CLEANUP_PATHS[@]:-}"; do
+    [ -n "$p" ] && rm -rf "$p" 2>/dev/null
+  done
+}
+trap _cleanup_all EXIT
+
+# --- settings.json: default value
+_flow_test_begin "settings.json has agentTeamModel=sonnet"
+VAL=$(jq -r '.agentTeamModel // empty' "$SETTINGS" 2>/dev/null)
+assert_equal "sonnet" "$VAL" "settings.json agentTeamModel default is sonnet"
+
+# --- schema.json: enum + default
+_flow_test_begin "schema.json constrains agentTeamModel enum + default"
+ENUM=$(jq -r '.properties.agentTeamModel.enum | join(",")' "$SCHEMA" 2>/dev/null)
+assert_equal "haiku,sonnet,opus,inherit" "$ENUM" "schema enum is haiku,sonnet,opus,inherit"
+DEF=$(jq -r '.properties.agentTeamModel.default // empty' "$SCHEMA" 2>/dev/null)
+assert_equal "sonnet" "$DEF" "schema default is sonnet"
+
+# --- settings value is a member of the schema enum
+_flow_test_begin "settings agentTeamModel is within schema enum"
+INDEX=$(jq -r --arg v "$VAL" '.properties.agentTeamModel.enum | index($v)' "$SCHEMA" 2>/dev/null)
+assert_match '^[0-9]+$' "$INDEX" "settings value '$VAL' is a valid enum member"
+
+# --- review.md wiring (static)
+_flow_test_begin "review.md Path A gate wires the model resolution"
+REVIEW_CONTENT=$(cat "$REVIEW_MD")
+assert_contains "AGENTTEAM_MODEL_BEGIN" "$REVIEW_CONTENT" "model-resolution block markers present"
+assert_contains "cascade-resolve.sh" "$REVIEW_CONTENT" "gate uses cascade-resolve.sh"
+assert_contains ".agentTeamModel" "$REVIEW_CONTENT" "gate resolves the agentTeamModel key"
+assert_contains "AGENT_TEAM_MODEL=" "$REVIEW_CONTENT" "gate emits AGENT_TEAM_MODEL"
+assert_match 'haiku\|sonnet\|opus\|inherit' "$REVIEW_CONTENT" "gate validates against the enum allowlist"
+
+_flow_test_begin "review.md dispatches pass the resolved model"
+assert_contains "model=\$AGENT_TEAM_MODEL" "$REVIEW_CONTENT" "A.1/A.3 dispatch directive passes model=\$AGENT_TEAM_MODEL"
+
+_flow_test_begin "review.md documents Path B as unchanged"
+# A line tying Path B to leaving the model inherited / unchanged for #112.
+assert_match 'Path B.*(unchanged|inherit|not modified|NOT modified)' "$REVIEW_CONTENT" "Path B explicitly noted as unchanged"
+
+# --- docs mention the key
+_flow_test_begin "README documents agentTeamModel"
+assert_contains "agentTeamModel" "$(cat "$README")" "README mentions agentTeamModel"
+
+_flow_test_begin "gate-configuration documents agentTeamModel"
+assert_contains "agentTeamModel" "$(cat "$GATE_DOC")" "gate-configuration.md mentions agentTeamModel"
+
+# --- functional: cascade-resolve default resolves to sonnet (from plugin settings.json)
+_flow_test_begin "cascade-resolve returns sonnet by default"
+RESOLVED=$(CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" "$CASCADE" --default sonnet '.agentTeamModel // empty' 2>/dev/null)
+assert_equal "sonnet" "$RESOLVED" "plugin-tier default resolves to sonnet"
+
+# --- functional: a project-local override wins
+_flow_test_begin "cascade-resolve honors a local override (opus)"
+SCRATCH=$(mktemp -d -t flow-atm.XXXXXX)
+CLEANUP_PATHS+=("$SCRATCH")
+mkdir -p "$SCRATCH/.claude"
+printf '%s\n' '{"agentTeamModel":"opus"}' > "$SCRATCH/.claude/settings.flow.local.json"
+RESOLVED_LOCAL=$( cd "$SCRATCH" && CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" "$CASCADE" --default sonnet '.agentTeamModel // empty' 2>/dev/null )
+assert_equal "opus" "$RESOLVED_LOCAL" "local settings.flow.local.json override resolves to opus"
+
+# --- functional: extract the gate's model block and exercise validation
+# Stub cascade-resolve so we control the returned value, then source the
+# extracted block with USE_PATH_A=1 and read the emitted AGENT_TEAM_MODEL / WARN.
+_run_model_block() {
+  # $1 = value the stubbed cascade-resolve should echo
+  local stub_value="$1"
+  local work; work=$(mktemp -d -t flow-atm-blk.XXXXXX)
+  CLEANUP_PATHS+=("$work")
+  mkdir -p "$work/bin"
+  # Stub cascade-resolve.sh: ignore args, echo the controlled value.
+  printf '#!/usr/bin/env bash\nprintf "%%s\\n" "%s"\n' "$stub_value" > "$work/bin/cascade-resolve.sh"
+  chmod +x "$work/bin/cascade-resolve.sh"
+  # Extract the block between the sentinels (exclusive of the sentinel lines).
+  awk '/AGENTTEAM_MODEL_BEGIN/{f=1;next} /AGENTTEAM_MODEL_END/{f=0} f' "$REVIEW_MD" > "$work/block.sh"
+  ( set +u; USE_PATH_A=1; CLAUDE_PLUGIN_ROOT="$work"; . "$work/block.sh" ) 2>"$work/err"
+  # Return combined stdout already captured by caller via command sub; emit err marker.
+  cat "$work/err" >&2
+}
+
+_flow_test_begin "gate block accepts a valid override (opus)"
+OUT=$(_run_model_block "opus" 2>/dev/null)
+assert_contains "AGENT_TEAM_MODEL=opus" "$OUT" "valid value opus passes through"
+
+_flow_test_begin "gate block accepts inherit"
+OUT=$(_run_model_block "inherit" 2>/dev/null)
+assert_contains "AGENT_TEAM_MODEL=inherit" "$OUT" "inherit passes the allowlist"
+
+_flow_test_begin "gate block rejects a bogus value with WARN + sonnet fallback"
+OUT=$(_run_model_block "gpt-9000" 2>/dev/null)
+ERR=$(_run_model_block "gpt-9000" 2>&1 >/dev/null)
+assert_contains "AGENT_TEAM_MODEL=sonnet" "$OUT" "bogus value falls back to sonnet"
+assert_contains "WARN" "$ERR" "bogus value is rejected with a clear WARN (not silent)"

--- a/plugins/flow/tests/flow-agentteam-model.test.sh
+++ b/plugins/flow/tests/flow-agentteam-model.test.sh
@@ -1,4 +1,4 @@
-# Tests for the configurable Path A agent-team review model (issue #112).
+# Tests for the configurable Path A agent-team review model.
 #
 # Contract under test:
 #   - settings.json carries a top-level `agentTeamModel` defaulting to "sonnet".
@@ -73,13 +73,13 @@ _flow_test_begin "review.md fenced dispatches carry the resolved model"
 # challenge-mode examples = 12 expected.
 DISPATCH_WITH_MODEL=$(printf '%s\n' "$REVIEW_CONTENT" | grep -cE 'Agent\([a-z-]+(-skeptic|-verifier).*model=\$AGENT_TEAM_MODEL')
 assert_match '^(1[0-9]|[2-9])$' "$DISPATCH_WITH_MODEL" "at least several fenced Agent(...) dispatches carry model=\$AGENT_TEAM_MODEL (found $DISPATCH_WITH_MODEL)"
-# Guard against the F1 regression specifically: no paired-reviewer dispatch line
-# may exist WITHOUT the model param.
+# The model param must travel with the copy-ready fenced examples, not live
+# only in adjacent prose: no paired-reviewer dispatch line may omit it.
 DISPATCH_WITHOUT_MODEL=$(printf '%s\n' "$REVIEW_CONTENT" | grep -E 'Agent\([a-z-]+(-skeptic|-verifier)[):]' | grep -vc 'model=\$AGENT_TEAM_MODEL')
 assert_equal "0" "$DISPATCH_WITHOUT_MODEL" "no paired-reviewer dispatch omits the model param"
 
 _flow_test_begin "review.md documents Path B as unchanged"
-# A line tying Path B to leaving the model inherited / unchanged for #112.
+# A line stating Path B leaves the model inherited / unchanged.
 assert_match 'Path B.*(unchanged|inherit|not modified|NOT modified)' "$REVIEW_CONTENT" "Path B explicitly noted as unchanged"
 
 # --- docs mention the key

--- a/plugins/flow/tests/flow-agentteam-model.test.sh
+++ b/plugins/flow/tests/flow-agentteam-model.test.sh
@@ -61,10 +61,22 @@ assert_contains "AGENTTEAM_MODEL_BEGIN" "$REVIEW_CONTENT" "model-resolution bloc
 assert_contains "cascade-resolve.sh" "$REVIEW_CONTENT" "gate uses cascade-resolve.sh"
 assert_contains ".agentTeamModel" "$REVIEW_CONTENT" "gate resolves the agentTeamModel key"
 assert_contains "AGENT_TEAM_MODEL=" "$REVIEW_CONTENT" "gate emits AGENT_TEAM_MODEL"
-assert_match 'haiku\|sonnet\|opus\|inherit' "$REVIEW_CONTENT" "gate validates against the enum allowlist"
+# Bind to the actual case-allowlist construct, not just any prose mention of
+# the model names (which appear throughout the file).
+assert_contains "haiku|sonnet|opus|inherit) ;;" "$REVIEW_CONTENT" "gate validates against the enum allowlist case arm"
 
-_flow_test_begin "review.md dispatches pass the resolved model"
-assert_contains "model=\$AGENT_TEAM_MODEL" "$REVIEW_CONTENT" "A.1/A.3 dispatch directive passes model=\$AGENT_TEAM_MODEL"
+_flow_test_begin "review.md fenced dispatches carry the resolved model"
+# The param must travel with the copy-ready Agent(...) examples, not live only
+# in adjacent prose — otherwise an agent copying the fenced block silently
+# drops it and regresses to inherited-model behavior. Count fenced dispatches
+# that carry model=$AGENT_TEAM_MODEL: A.1 has 10 paired reviewers, A.3 shows 2
+# challenge-mode examples = 12 expected.
+DISPATCH_WITH_MODEL=$(printf '%s\n' "$REVIEW_CONTENT" | grep -cE 'Agent\([a-z-]+(-skeptic|-verifier).*model=\$AGENT_TEAM_MODEL')
+assert_match '^(1[0-9]|[2-9])$' "$DISPATCH_WITH_MODEL" "at least several fenced Agent(...) dispatches carry model=\$AGENT_TEAM_MODEL (found $DISPATCH_WITH_MODEL)"
+# Guard against the F1 regression specifically: no paired-reviewer dispatch line
+# may exist WITHOUT the model param.
+DISPATCH_WITHOUT_MODEL=$(printf '%s\n' "$REVIEW_CONTENT" | grep -E 'Agent\([a-z-]+(-skeptic|-verifier)[):]' | grep -vc 'model=\$AGENT_TEAM_MODEL')
+assert_equal "0" "$DISPATCH_WITHOUT_MODEL" "no paired-reviewer dispatch omits the model param"
 
 _flow_test_begin "review.md documents Path B as unchanged"
 # A line tying Path B to leaving the model inherited / unchanged for #112.
@@ -123,3 +135,11 @@ OUT=$(_run_model_block "gpt-9000" 2>/dev/null)
 ERR=$(_run_model_block "gpt-9000" 2>&1 >/dev/null)
 assert_contains "AGENT_TEAM_MODEL=sonnet" "$OUT" "bogus value falls back to sonnet"
 assert_contains "WARN" "$ERR" "bogus value is rejected with a clear WARN (not silent)"
+
+_flow_test_begin "gate block treats an empty resolution as invalid -> sonnet + WARN"
+# Defends the path where cascade-resolve yields nothing (e.g. jq missing and no
+# default reached the case): the allowlist's catchall must still produce sonnet.
+OUT=$(_run_model_block "" 2>/dev/null)
+ERR=$(_run_model_block "" 2>&1 >/dev/null)
+assert_contains "AGENT_TEAM_MODEL=sonnet" "$OUT" "empty value falls back to sonnet"
+assert_contains "WARN" "$ERR" "empty value is rejected with a clear WARN (not silent)"

--- a/plugins/flow/tests/flow-agentteam-model.test.sh
+++ b/plugins/flow/tests/flow-agentteam-model.test.sh
@@ -78,6 +78,13 @@ assert_match '^(1[0-9]|[2-9])$' "$DISPATCH_WITH_MODEL" "at least several fenced 
 DISPATCH_WITHOUT_MODEL=$(printf '%s\n' "$REVIEW_CONTENT" | grep -E 'Agent\([a-z-]+(-skeptic|-verifier)[):]' | grep -vc 'model=\$AGENT_TEAM_MODEL')
 assert_equal "0" "$DISPATCH_WITHOUT_MODEL" "no paired-reviewer dispatch omits the model param"
 
+_flow_test_begin "review.md omits the model override when inherit (dispatch enum is sonnet|opus|haiku)"
+# The Agent tool's per-invocation model override accepts only sonnet|opus|haiku;
+# 'inherit' must be expressed by dropping the override, never by passing
+# model=inherit (which would be an invalid dispatch and break the inherit case).
+assert_contains "OMIT the \`model\` argument" "$REVIEW_CONTENT" "directive instructs omitting the override on inherit"
+assert_not_contains "model=inherit\` is itself valid" "$REVIEW_CONTENT" "no false 'model=inherit is valid' claim"
+
 _flow_test_begin "review.md documents Path B as unchanged"
 # A line stating Path B leaves the model inherited / unchanged.
 assert_match 'Path B.*(unchanged|inherit|not modified|NOT modified)' "$REVIEW_CONTENT" "Path B explicitly noted as unchanged"


### PR DESCRIPTION
## Summary

Closes #112. Path A (agent-team) review in `/flow:review` dispatches ~20 subagents (paired skeptic/verifier × 5 facets + a challenge round), all declared `model: inherit`. On an Opus session that multiplies Opus-rate tokens ~4× for marginal review value. This makes the Path A review-agent model configurable, defaulting to `sonnet`.

- **New setting `agentTeamModel`** (top-level, sibling of `agentTeams`) — enum `haiku|sonnet|opus|inherit`, default `sonnet`. Resolved via the standard settings cascade (local > project > user > plugin) using `bin/cascade-resolve.sh`, the same cascade `agentTeams` uses.
- **Path A gate** in `commands/review.md` resolves the key into `AGENT_TEAM_MODEL`, validates it against an enum `case` (invalid/empty → WARN + `sonnet` fallback, never silent), and every A.1 paired-reviewer + A.3 challenge `Agent(...)` dispatch carries `model=$AGENT_TEAM_MODEL`. This overrides each agent's `model: inherit` frontmatter (precedence: dispatch param > frontmatter > session).
- **`inherit`** reproduces pre-change behavior (`model=inherit` resolves to the session model).
- **Scoped to Path A only** — Path B (single-session, default) is unchanged and its agents continue to inherit the session model.

## Acceptance criteria

| # | Criterion | Evidence |
|---|-----------|----------|
| 1 | Default `sonnet` regardless of session model | `settings.json` default + `--default sonnet` backstop + per-dispatch `model` override; tested |
| 2 | Documented setting accepting haiku/sonnet/opus/inherit, schema-validated | `schema.json` enum; settings validates against schema (jsonschema) |
| 3 | `inherit` reproduces prior behavior | `model=inherit` = session model; gate accepts `inherit`; tested |
| 4 | Documented alongside `flow.goals.judge.model` | schema description cross-reference + README + `gate-configuration.md` |
| 5 | Path B unchanged | no `model` param on Path B dispatches; explicit note; tested |
| 6 | Invalid value rejected with a clear message, not silent | gate `case` catchall WARN + `sonnet`; schema enum; tested (bogus + empty) |

## Test plan

- [x] New `tests/flow-agentteam-model.test.sh` — 22 assertions (settings/schema, gate wiring, fenced-dispatch co-location guard, cascade default→sonnet + local override→opus, gate-block opus/inherit/bogus/empty)
- [x] Full flow suite: 644/644 pass, no regressions
- [x] `settings.json` validates against `schema.json` (jsonschema)
- [x] Self-review (flow:code-reviewer) → 1 P2 + 3 test findings, all fixed in-PR; convergence re-review: zero findings

## Notes

Self-review caught that the per-invocation model initially lived only in prose, not on the copy-ready fenced `Agent(...)` examples — an agent copying the block verbatim would have silently regressed to the inherited model. Fixed: the param now travels with every fenced dispatch, with a test guard that fails if any paired-reviewer line omits it.

Scope was deliberately limited to Path A (the doubling, ~20-agent path) per the issue discussion. Path B is the default everyday path and still inherits the session model — a follow-up could extend the same setting there if everyday review cost proves to be the real pain.

<!-- FLOW_REVIEW_CYCLE:1 FINDINGS:[] -->