### PR TITLE
feat(flow): v3 integration — wire FlowRun + FlowGoal into the commands

### DIFF
--- a/.decisions/issue-110.md
+++ b/.decisions/issue-110.md
@@ -1,0 +1,119 @@
+---
+issue: 110
+created: '2026-05-23T00:00:00Z'
+artifacts:
+- type: specification
+  captured_at: '2026-05-23T00:52:49Z'
+  by: flow-start
+  elements:
+  - non-goals
+  - failure-modes
+  - interface-contracts
+---
+# Issue #110 — v3 integration: wire FlowGoal + FlowRun into the 7 commands
+
+Branch: `feature/issue-110-v3-command-integration`
+
+## Summary
+
+#109 shipped the v3 runtime layer as pure infrastructure (helpers + skills + schemas +
+the `goal` command) but left the existing flow commands byte-identical to v2.4.0. This
+issue wires those primitives into start/debug/address/review/pr/merge/release so goals +
+runs are automatic. Amended by #111: review/address are FlowRun-only (no FlowGoal), and
+the goal-creation default (`goalCreation: auto`) is owned by #111 — this issue does NOT
+add a binary `requireGoalForStart` flip.
+
+## Verified pre-state (2026-05-23)
+
+- #109 merged (commit 34a8d75). All referenced helpers present: `flow-record-activity.sh`,
+  `flow-goal-record.sh`, `flow-active-goal.sh`, `flow-record-evidence.sh`,
+  `flow-record-verdict.sh`, `journal-record.sh`. All referenced skills present
+  (`run-state-management`, `goal-contract-capture`, `goal-evaluator`, `goal-evidence-ledger`,
+  `specification-capture`). `goal-evaluator-judge` is an **agent**, not a skill.
+- None of the 7 commands wire `.flow` yet (confirmed by grep).
+- **status.md + learn.md `.flow` mining already shipped with #109** (cycle-13): status has
+  `### FlowGoal State` + `### Recent Runs`; learn has `### FlowRun Events` + Goal Failure
+  Patterns. Passing tests: `flow-status-learn-v3.test.sh`, `flow-cycle14-behavioral.test.sh`.
+  → AC6 main + AC7 are already satisfied. Remaining AC6 sub-part: status has NO triggers section.
+- Settings: `workflows.enabled=false`, `triggers.enabled=false` (AC8 flips both → true);
+  `goals.enabled=true` already; `goalCreation` absent (owned by #111).
+- Test baseline: `bash plugins/flow/tests/run.sh` → TOTAL pass=646 fail=0.
+
+## Design decisions
+
+- **Skill-owned writes.** Commands do NOT inline FlowRun/FlowGoal YAML composition. They
+  invoke `Skill(run-state-management)` (run create + activity + state transition) and
+  `Skill(goal-contract-capture)` / `Skill(goal-evaluator)` (start/debug only). The skills own
+  the file layout; commands pass workflow id, run id, context, phase.
+- **Surgical insertion.** Add hook points at existing phase boundaries; do NOT restructure
+  command logic (non-goal). FlowRun create at entry; activity write at each phase boundary;
+  terminal transition + `workflow-run` artifact update at completion.
+- **Per-#111 split.** start/debug: FlowGoal + FlowRun. review/address/release: FlowRun only.
+  pr/merge: read the active goal and gate on `lifecycle.status: achieved`.
+- **Gating asymmetry (AC4 vs AC5).** `/flow:pr` gate has an override path (six-field
+  AskUserQuestion escalation → `escalation-resolved` artifact). `/flow:merge` gate is Tier 3,
+  NO override beyond the existing merge confirmation — refuse if goal not achieved or any
+  linked FlowRun still `active`.
+- **Test pattern.** Each new `tests/<cmd>-v3-integration.test.sh` is a source-presence +
+  behavioral test mirroring `flow-agentteam-model.test.sh`: assert the command markdown wires
+  the helper/skill, and (where feasible) extract+run the entry bash block against a scratch
+  repo to assert a valid `.flow/runs/<id>/run.yaml` (and `.flow/goals/*.goal.yaml` for
+  start/debug; NO goal file for review/address — #111 AC-3) is produced.
+
+## Specification
+
+### Non-goals
+- Path B / agent-team review behavior, model selection — unrelated (#112, shipped).
+- Restructuring command markdown beyond surgical hook-point additions — preserve phase structure.
+- The `goalCreation` 3-state default and any `requireGoalForStart` flip — owned by #111 AC-1.
+- FlowGoal creation for `/flow:review` and `/flow:address` — #111 AC-3 makes them FlowRun-only.
+- Re-implementing status/learn `.flow` mining — already shipped with #109 (only add the missing triggers section to status).
+- Polyglot Windows hook wrapper — separate pre-existing tech-debt PR.
+- New goal-creation default flip for review/address — out by construction (FlowRun-only).
+
+### Failure modes
+- `python3` / PyYAML missing → helpers exit 2 with a clear stderr message; command surfaces
+  it as a blocked activity rather than crashing (helpers already degrade gracefully).
+- No active goal when `/flow:pr` or `/flow:merge` runs → `flow-active-goal.sh` exits 1;
+  treat as "no goal to gate" only when `flow.goals.enabled` is false OR the workflow that
+  created the branch was review/address (FlowRun-only). Otherwise (start/debug-derived branch
+  with goals enabled) a missing goal is itself a gate failure → escalate.
+- `>1` active goal → `flow-active-goal.sh` exits 3 (degenerate); pr/merge refuse and point to
+  `/flow:goal history`.
+- Run dir already exists for the computed run id → run-state-management uses an ISO-timestamp
+  id so collisions are implausible; if it occurs, the create is race-safe (dir-absent invariant).
+- `flow.goals.enabled=false` → goal creation + gates are no-ops; FlowRun wiring still runs
+  (runs are gated by `flow.runtime.enabled`, default true).
+
+### Interface contracts
+- FlowRun create: `Skill(run-state-management)` writes `.flow/runs/<ISO-id>/run.yaml`
+  conforming to `schemas/v1/run.schema.json` with `state.status: active`.
+- Journal artifact: `bin/journal-record.sh --issue <N> --type workflow-run --metadata
+  workflow=<id> --metadata run_id=<id> --metadata status=active|completed`.
+- FlowGoal create (start/debug): `Skill(goal-contract-capture)` writes
+  `.flow/goals/issue-<N>.goal.yaml`; debug uses run id-derived slug when no issue.
+- pr/merge gate read: `bin/flow-active-goal.sh --status` (0=found, 1=none, 2=infra, 3=degenerate)
+  and `--ac-summary` for the missing-evidence escalation body.
+- Settings: `flow.workflows.enabled: true`, `flow.triggers.enabled: true` in settings.json;
+  schema unchanged (already enums/booleans).
+- Each new test file: `bash plugins/flow/tests/<cmd>-v3-integration.test.sh` passes under the
+  zero-dependency harness; `bash plugins/flow/tests/run.sh` exits 0 with count ≥ 646 + new asserts.
+
+## Acceptance criteria → verification command map
+
+| # | AC | Verification |
+|---|----|--------------|
+| 1 | 7 commands write FlowRun at entry + phase boundaries | `tests/<cmd>-v3-integration.test.sh` asserts run.yaml created + activity-write wiring present |
+| 2 | 7 commands write `workflow-run` journal artifacts | test asserts `journal-record.sh ... --type workflow-run` wired per command |
+| 3 | start/debug create FlowGoals; review/address FlowRun-only | start/debug tests assert goal file; review/address tests assert NO goal file |
+| 4 | pr blocks when goal not `achieved` (override) | `tests/pr-v3-integration.test.sh` asserts gate + override escalation wiring |
+| 5 | merge blocks when goal not `achieved` (no override) | `tests/merge-v3-integration.test.sh` asserts gate, no override |
+| 6 | status reads `.flow` + shows goal/run/triggers | existing status-learn-v3 test (goal/run) + new triggers-section assert |
+| 7 | learn mines `events.jsonl` for stuck patterns | existing `flow-status-learn-v3.test.sh` (already green) |
+| 8 | settings workflows.enabled+triggers.enabled true | `python3 -c` enum/flag assert in a test |
+| 9 | 7 new integration test files pass | `bash plugins/flow/tests/run.sh` exits 0 |
+| 10 | existing per-command tests pass unchanged | full-suite run, no regressions |
+| 11 | `run.sh` exits 0 | exit code check |
+| 12 | CHANGELOG entry | grep CHANGELOG for the integration entry |
+
+<!-- auto-log: 2026-05-23 02:53 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-110.md -->

--- a/.decisions/issue-110.md
+++ b/.decisions/issue-110.md
@@ -9,6 +9,9 @@ artifacts:
   - non-goals
   - failure-modes
   - interface-contracts
+- type: verdict
+  captured_at: '2026-05-23T01:23:11Z'
+  result: PASS
 ---
 # Issue #110 — v3 integration: wire FlowGoal + FlowRun into the 7 commands
 
@@ -117,3 +120,127 @@ add a binary `requireGoalForStart` flip.
 | 12 | CHANGELOG entry | grep CHANGELOG for the integration entry |
 
 <!-- auto-log: 2026-05-23 02:53 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-110.md -->
+
+<!-- auto-log: 2026-05-23 02:58 commit "feat(flow): wire FlowRun into release.md (#110)" -->
+
+<!-- auto-log: 2026-05-23 02:59 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-23 03:00 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-23 03:00 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/address.md -->
+
+<!-- auto-log: 2026-05-23 03:00 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-23 03:00 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/address.md -->
+
+<!-- auto-log: 2026-05-23 03:00 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/address.md -->
+
+<!-- auto-log: 2026-05-23 03:00 Write /Users/danielbentes/synapti-marketplace/plugins/flow/tests/review-v3-integration.test.sh -->
+
+<!-- auto-log: 2026-05-23 03:00 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/start.md -->
+
+<!-- auto-log: 2026-05-23 03:00 Write /Users/danielbentes/synapti-marketplace/plugins/flow/tests/address-v3-integration.test.sh -->
+
+<!-- auto-log: 2026-05-23 03:01 Write /Users/danielbentes/synapti-marketplace/plugins/flow/tests/start-v3-integration.test.sh -->
+
+<!-- auto-log: 2026-05-23 03:01 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/start-v3-integration.test.sh -->
+
+<!-- auto-log: 2026-05-23 03:01 commit "feat(flow): wire FlowRun into start.md linked to FlowGoal (#110)" -->
+
+<!-- auto-log: 2026-05-23 03:03 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/pr.md -->
+
+<!-- auto-log: 2026-05-23 03:03 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/pr.md -->
+
+<!-- auto-log: 2026-05-23 03:03 Write /Users/danielbentes/synapti-marketplace/plugins/flow/tests/pr-v3-integration.test.sh -->
+
+<!-- auto-log: 2026-05-23 03:04 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/pr.md -->
+
+<!-- auto-log: 2026-05-23 03:04 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/merge.md -->
+
+<!-- auto-log: 2026-05-23 03:04 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/merge.md -->
+
+<!-- auto-log: 2026-05-23 03:05 Write /Users/danielbentes/synapti-marketplace/plugins/flow/tests/merge-v3-integration.test.sh -->
+
+<!-- auto-log: 2026-05-23 03:05 commit "feat(flow): wire FlowRun into pr/merge/review/address (#110)" -->
+
+<!-- auto-log: 2026-05-23 03:06 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/debug.md -->
+
+<!-- auto-log: 2026-05-23 03:06 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/debug.md -->
+
+<!-- auto-log: 2026-05-23 03:06 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/debug.md -->
+
+<!-- auto-log: 2026-05-23 03:07 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/skills/specification-capture/SKILL.md -->
+
+<!-- auto-log: 2026-05-23 03:07 Write /Users/danielbentes/synapti-marketplace/plugins/flow/tests/debug-v3-integration.test.sh -->
+
+<!-- auto-log: 2026-05-23 03:07 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/debug.md -->
+
+<!-- auto-log: 2026-05-23 03:07 commit "feat(flow): wire FlowRun + FlowGoal into debug.md (#110)" -->
+
+<!-- auto-log: 2026-05-23 03:08 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/status.md -->
+
+<!-- auto-log: 2026-05-23 03:09 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/status.md -->
+
+<!-- auto-log: 2026-05-23 03:09 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/settings.json -->
+
+<!-- auto-log: 2026-05-23 03:09 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/CHANGELOG.md -->
+
+<!-- auto-log: 2026-05-23 03:09 Write /Users/danielbentes/synapti-marketplace/plugins/flow/tests/status-triggers-v3-integration.test.sh -->
+
+<!-- auto-log: 2026-05-23 03:10 commit "feat(flow): status Active Triggers section + enable workflows/triggers defaults (#110)" -->
+
+<!-- auto-log: 2026-05-23 03:17 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/release.md -->
+
+<!-- auto-log: 2026-05-23 03:17 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/start.md -->
+
+<!-- auto-log: 2026-05-23 03:17 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/merge.md -->
+
+<!-- auto-log: 2026-05-23 03:17 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-23 03:17 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/address.md -->
+
+<!-- auto-log: 2026-05-23 03:17 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/debug.md -->
+
+<!-- auto-log: 2026-05-23 03:18 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/release.md -->
+
+<!-- auto-log: 2026-05-23 03:18 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/release.md -->
+
+<!-- auto-log: 2026-05-23 03:18 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/skills/run-state-management/SKILL.md -->
+
+<!-- auto-log: 2026-05-23 03:18 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/workflows/review-pr.workflow.yaml -->
+
+<!-- auto-log: 2026-05-23 03:18 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/workflows/review-pr.workflow.yaml -->
+
+<!-- auto-log: 2026-05-23 03:19 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/workflows/review-pr.workflow.yaml -->
+
+<!-- auto-log: 2026-05-23 03:19 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/workflows/address-pr.workflow.yaml -->
+
+<!-- auto-log: 2026-05-23 03:19 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/workflows/address-pr.workflow.yaml -->
+
+<!-- auto-log: 2026-05-23 03:19 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/workflows/address-pr.workflow.yaml -->
+
+<!-- auto-log: 2026-05-23 03:19 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/pr.md -->
+
+<!-- auto-log: 2026-05-23 03:19 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/start.md -->
+
+<!-- auto-log: 2026-05-23 03:20 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/status.md -->
+
+<!-- auto-log: 2026-05-23 03:20 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/status.md -->
+
+<!-- auto-log: 2026-05-23 03:20 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/release-v3-integration.test.sh -->
+
+<!-- auto-log: 2026-05-23 03:20 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/release-v3-integration.test.sh -->
+
+<!-- auto-log: 2026-05-23 03:20 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/start-v3-integration.test.sh -->
+
+<!-- auto-log: 2026-05-23 03:20 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/merge-v3-integration.test.sh -->
+
+<!-- auto-log: 2026-05-23 03:21 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/debug-v3-integration.test.sh -->
+
+<!-- auto-log: 2026-05-23 03:21 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/review-v3-integration.test.sh -->
+
+<!-- auto-log: 2026-05-23 03:21 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/address-v3-integration.test.sh -->
+
+<!-- auto-log: 2026-05-23 03:21 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/status-triggers-v3-integration.test.sh -->
+
+<!-- auto-log: 2026-05-23 03:22 commit "fix(flow): self-review findings — schema-valid run/goal ids, workflow-yaml reconciliation (#110)" -->

--- a/plugins/flow/CHANGELOG.md
+++ b/plugins/flow/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added: v3 runtime integration — FlowRun + FlowGoal wired into the commands
+
+v3.0 shipped the runtime primitives as infrastructure; this release wires them into the workflow commands so runs and goals are automatic rather than opt-in:
+
+- **FlowRun wiring** in all seven long-running commands (`start`, `debug`, `address`, `review`, `pr`, `merge`, `release`). Each creates (or, for `pr`, appends to) a durable `.flow/runs/<id>/run.yaml` at entry, records FlowActivities at phase boundaries, and transitions to a terminal state on completion — gated by `flow.runtime.enabled` (default `true`; v2 projects opting out see a no-op).
+- **FlowGoal creation** now also covers `/flow:debug` (alongside the existing `/flow:start`), via `goal-contract-capture` after hypothesis confirmation. `/flow:review` and `/flow:address` are FlowRun-only (a review/address session is bounded by the PR). A `debug` row was added to the `specification-capture` per-invoker scope table.
+- **Goal gates**: `/flow:pr` blocks PR creation when the linked goal is not `achieved` (with a journaled override path), and `/flow:merge` blocks merge until the goal is `achieved` and all linked FlowRuns are `completed` (Tier 3, no override).
+- **`/flow:status`** now surfaces an **Active Triggers** section (alongside the existing FlowGoal State + Recent Runs).
+- **Defaults flipped**: `flow.workflows.enabled` and `flow.triggers.enabled` are now `true` (still per-trigger opt-in; overridable to `false` for v2.x behavior via the settings cascade).
+
 ### Added: configurable model for Path A agent-team review
 
 `/flow:review` Path A (agent-team paired-reviewer mode) dispatches ~20 subagents, all previously `model: inherit` — on an Opus session that multiplied Opus-rate tokens ~4x. A new top-level `agentTeamModel` setting (enum `haiku|sonnet|opus|inherit`, default `sonnet`, cascade-resolved) controls the model for those Path A reviewers via the Agent tool's per-invocation `model` override. `inherit` reproduces the prior behavior (override omitted → session model). Invalid values are rejected with a warning and fall back to `sonnet`. Path B (single-session, default) is unchanged.

--- a/plugins/flow/commands/address.md
+++ b/plugins/flow/commands/address.md
@@ -127,6 +127,35 @@ gh pr checkout "$PR_NUM"
 
 **Skill(capability-discovery)**: Discover quality commands for verification.
 
+### FlowRun (v3 runtime)
+
+Addressing review feedback is a long-running workflow, so it gets a durable FlowRun. Runs are gated by `flow.runtime.enabled` (default `true`); v2 projects that opted out see `FLOW_RUN_STATE=skip` and the wiring is a no-op.
+
+```!
+# FLOW_RUN_BLOCK_BEGIN
+CASCADE="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
+if [ ! -x "$CASCADE" ]; then
+  echo "FLOW_RUN_STATE=blocked"
+  echo "FLOW_RUN_ERROR=cascade-resolve.sh missing or non-executable at $CASCADE"
+  true; exit 0
+fi
+RUNTIME_ENABLED=$("$CASCADE" --default "true" '.flow.runtime.enabled' 2>/dev/null)
+if [ "$RUNTIME_ENABLED" != "true" ]; then
+  echo "FLOW_RUN_STATE=skip"
+  echo "FLOW_RUN_REASON=flow.runtime.enabled is not true (v2 mode)"
+else
+  RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-address"
+  echo "FLOW_RUN_STATE=create"
+  echo "RUN_ID=$RUN_ID"
+  echo "WORKFLOW=address-pr"
+  echo "INITIAL_PHASE=preflight"
+fi
+# FLOW_RUN_BLOCK_END
+true
+```
+
+When `FLOW_RUN_STATE=create`, invoke `Skill(run-state-management)` to create `.flow/runs/$RUN_ID/run.yaml` (workflow=`address-pr`, goal=`null`), initial phase `preflight`. Phase order: `preflight → categorize → resolve → verify`. Address is **FlowRun-only — it creates NO FlowGoal**: the PR's own review-thread state (resolved comments, re-request status, cycle history) is the durable record of feedback resolution, so there is no separate acceptance-criteria contract to evaluate.
+
 ## Review Cycle Tracking
 
 ```!
@@ -218,6 +247,8 @@ For each feedback task (in priority order):
 - Boy Scout fixes get separate `improve:` commits
 
 TaskUpdate(testCoverageTaskId, status: "completed", result: "Tests written/updated for {N} fixes")
+
+**FlowActivity writes** (when `FLOW_RUN_STATE=create`): invoke `Skill(run-state-management)` to record one FlowActivity per resolved finding as each fix lands, and invoke `Skill(goal-evidence-ledger)` to capture the verification-evidence sidecar (the test/quality output that proves the fix) attached to the FlowRun — not a goal, since address is FlowRun-only. Each activity write advances `state.current_phase` per the `preflight → categorize → resolve → verify` order.
 
 For **Question** items: prepare a response comment (no code change needed).
 
@@ -359,6 +390,8 @@ Even in minimal-scope mode, P1 and P2 findings in untouched files are always fix
         - Option 3: "Override with written risk acceptance (will be recorded on PR)"
 
 Display summary: fixes applied, Boy Scout improvements, questions answered, pushback items, cycle count.
+
+**FlowRun terminal transition** (when `FLOW_RUN_STATE=create`): once all findings are resolved and the resolution comment is posted, invoke `Skill(run-state-management)` to transition the FlowRun to `state.status: completed`. The `workflow-run` journal artifact is best-effort because address is PR-scoped: emit `bin/journal-record.sh --type workflow-run` only if a single issue can be inferred from the PR (e.g., the PR closes exactly one issue); otherwise the `run.yaml` is the durable record. If feedback resolution fails or is cancelled, transition to `state.status: cancelled` (with `blocked_reason`) instead so `/flow:resume` does not treat it as resumable.
 
 ## Tier Classification
 

--- a/plugins/flow/commands/address.md
+++ b/plugins/flow/commands/address.md
@@ -144,7 +144,7 @@ if [ "$RUNTIME_ENABLED" != "true" ]; then
   echo "FLOW_RUN_STATE=skip"
   echo "FLOW_RUN_REASON=flow.runtime.enabled is not true (v2 mode)"
 else
-  RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-address"
+  RUN_ID="$(date -u +%Y-%m-%dT%H%M%SZ)-address"
   echo "FLOW_RUN_STATE=create"
   echo "RUN_ID=$RUN_ID"
   echo "WORKFLOW=address-pr"

--- a/plugins/flow/commands/debug.md
+++ b/plugins/flow/commands/debug.md
@@ -58,6 +58,37 @@ echo "UNCOMMITTED_COUNT=$UNCOMMITTED_COUNT"
 true
 ```
 
+### FlowRun (v3 runtime)
+
+`/flow:debug` is a long-running workflow, so it gets a durable FlowRun. The companion FlowGoal is created later (after hypothesis confirmation), so the run forward-references its id. Runs are gated by `flow.runtime.enabled` (default `true`); v2 projects that opted out see `FLOW_RUN_STATE=skip` and the wiring is a no-op.
+
+```!
+# FLOW_RUN_BLOCK_BEGIN
+CASCADE="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
+if [ ! -x "$CASCADE" ]; then
+  echo "FLOW_RUN_STATE=blocked"
+  echo "FLOW_RUN_ERROR=cascade-resolve.sh missing or non-executable at $CASCADE"
+  true; exit 0
+fi
+RUNTIME_ENABLED=$("$CASCADE" --default "true" '.flow.runtime.enabled' 2>/dev/null)
+if [ "$RUNTIME_ENABLED" != "true" ]; then
+  echo "FLOW_RUN_STATE=skip"
+  echo "FLOW_RUN_REASON=flow.runtime.enabled is not true (v2 mode)"
+else
+  TS="$(date -u +%Y%m%dT%H%M%SZ)"
+  RUN_ID="${TS}-debug"
+  echo "FLOW_RUN_STATE=create"
+  echo "RUN_ID=$RUN_ID"
+  echo "WORKFLOW=debug"
+  echo "INITIAL_PHASE=preflight"
+  echo "GOAL_LINK=debug-${TS}"
+fi
+# FLOW_RUN_BLOCK_END
+true
+```
+
+When `FLOW_RUN_STATE=create`, invoke `Skill(run-state-management)` to create `.flow/runs/$RUN_ID/run.yaml` (workflow=`debug`, goal=`$GOAL_LINK` — the debug FlowGoal created in Phase 3 below), initial phase `preflight`. Phase order: `preflight → reproduce → diagnose → fix → verify`. Write a FlowActivity at each boundary.
+
 **Parallel searches:**
 
 - `Grep`: Search for error message keywords in the codebase
@@ -118,6 +149,8 @@ For each hypothesis (highest confidence first):
      c. Move to next hypothesis
 ```
 
+**FlowGoal creation (after the confirmed hypothesis — end of the diagnose phase):** when `FLOW_RUN_STATE=create`, invoke `Skill(goal-contract-capture)` with invocation reason `debug`, goal id `$GOAL_LINK` (from the entry block), and the outcome template "The reported failure `$ARGUMENTS` is reproduced, root-caused, and a fix is verified." The acceptance criterion is the reproducing test written in step 4a; constraints come from the confirmed root cause. Then invoke `Skill(goal-lifecycle)` to transition `draft → active`, and write a FlowActivity for the diagnose→fix boundary.
+
 **Stop conditions from debugging-patterns:**
 - 3+ failed fix attempts → problem is architectural, return to EXPLORE
 - Can't explain current behavior → investigate more, don't guess
@@ -143,7 +176,8 @@ For each hypothesis (highest confidence first):
    ```
    If not applicable (non-UI bug): skip TaskCreate entirely.
 5. **TaskList** — confirm all tasks show status: completed
-6. **Display summary**:
+6. **FlowGoal evaluation + FlowRun terminal transition** (when `FLOW_RUN_STATE=create`): invoke `Skill(goal-evaluator)` with `trigger=command` to evaluate the debug FlowGoal against the reproducing test evidence; persist the proposed lifecycle transition (the skill does not write terminal status itself). When the goal reaches `achieved`, transition the FlowRun to `state.status: completed`; if the bug could not be root-caused, transition to `state.status: blocked` (with `blocked_reason`) so `/flow:resume` can pick it up.
+7. **Display summary**:
    - Root cause: {description}
    - Hypothesis confirmed: #{N}
    - Fix: {what was changed}

--- a/plugins/flow/commands/debug.md
+++ b/plugins/flow/commands/debug.md
@@ -75,13 +75,16 @@ if [ "$RUNTIME_ENABLED" != "true" ]; then
   echo "FLOW_RUN_STATE=skip"
   echo "FLOW_RUN_REASON=flow.runtime.enabled is not true (v2 mode)"
 else
-  TS="$(date -u +%Y%m%dT%H%M%SZ)"
-  RUN_ID="${TS}-debug"
+  RUN_ID="$(date -u +%Y-%m-%dT%H%M%SZ)-debug"
+  # The goal id must match the FlowGoal metadata.id pattern
+  # ^[a-z0-9][a-z0-9-]{0,63}$ — no uppercase, so it cannot reuse the ISO run
+  # timestamp (which carries T/Z). Use a hyphen-only lowercase stamp.
+  GOAL_TS="$(date -u +%Y-%m-%d-%H%M%S)"
   echo "FLOW_RUN_STATE=create"
   echo "RUN_ID=$RUN_ID"
   echo "WORKFLOW=debug"
   echo "INITIAL_PHASE=preflight"
-  echo "GOAL_LINK=debug-${TS}"
+  echo "GOAL_LINK=debug-${GOAL_TS}"
 fi
 # FLOW_RUN_BLOCK_END
 true

--- a/plugins/flow/commands/merge.md
+++ b/plugins/flow/commands/merge.md
@@ -426,7 +426,7 @@ if [ "$RUNTIME_ENABLED" != "true" ]; then
   echo "FLOW_RUN_REASON=flow.runtime.enabled is not true (v2 mode)"
 else
   SLUG="${PR_NUM:-nonum}"
-  RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-merge-pr-${SLUG}"
+  RUN_ID="$(date -u +%Y-%m-%dT%H%M%SZ)-merge-pr-${SLUG}"
   echo "FLOW_RUN_STATE=create"
   echo "RUN_ID=$RUN_ID"
   echo "WORKFLOW=merge-pr"

--- a/plugins/flow/commands/merge.md
+++ b/plugins/flow/commands/merge.md
@@ -403,6 +403,43 @@ This gate enforces the "no incomplete shipments" hard boundary.
 
 Do NOT proceed to Phase 2. Exit here.
 
+### FlowRun (v3 runtime)
+
+`/flow:merge` runs the `merge-pr` workflow, so it gets a durable FlowRun. Runs are gated by `flow.runtime.enabled` (default `true`); v2 projects that opted out see `FLOW_RUN_STATE=skip` and the wiring is a no-op.
+
+```!
+# FLOW_RUN_BLOCK_BEGIN
+CASCADE="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
+if [ ! -x "$CASCADE" ]; then
+  echo "FLOW_RUN_STATE=blocked"
+  echo "FLOW_RUN_ERROR=cascade-resolve.sh missing or non-executable at $CASCADE"
+  true; exit 0
+fi
+RUNTIME_ENABLED=$("$CASCADE" --default "true" '.flow.runtime.enabled' 2>/dev/null)
+ARG1="${ARGUMENTS%% *}"
+case "$ARG1" in
+  ''|*[!0-9]*) PR_NUM="" ;;
+  *) PR_NUM="$ARG1" ;;
+esac
+if [ "$RUNTIME_ENABLED" != "true" ]; then
+  echo "FLOW_RUN_STATE=skip"
+  echo "FLOW_RUN_REASON=flow.runtime.enabled is not true (v2 mode)"
+else
+  SLUG="${PR_NUM:-nonum}"
+  RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-merge-pr-${SLUG}"
+  echo "FLOW_RUN_STATE=create"
+  echo "RUN_ID=$RUN_ID"
+  echo "WORKFLOW=merge-pr"
+  echo "INITIAL_PHASE=preflight"
+fi
+# FLOW_RUN_BLOCK_END
+true
+```
+
+When `FLOW_RUN_STATE=create`, invoke `Skill(run-state-management)` to create `.flow/runs/$RUN_ID/run.yaml` (workflow=`merge-pr`, goal=`null` — the merge reads the linked FlowGoal for the gate below but the run itself is not goal-owned), initial phase `preflight`. Phase order: `preflight → verify → confirm → merge`. Write a FlowActivity at each boundary (verify, confirm, merge).
+
+**Linked-run completion check** (Phase 2 / verify): before allowing merge, verify that every FlowRun linked to this PR's branch (the `start-issue` run and any `address-pr` / `review-pr` runs) has reached `state.status: completed`. If any linked run is still `active`, refuse the merge — this is Tier 3, so there is **no override** beyond the standard merge confirmation. Surface the still-active run id and point to `/flow:resume`.
+
 ## Phase 2: Display Assessment
 
 ```markdown
@@ -470,6 +507,8 @@ DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.na
 git checkout $DEFAULT_BRANCH
 git pull origin $DEFAULT_BRANCH
 ```
+
+**FlowRun terminal transition** (when `FLOW_RUN_STATE=create`): after a successful merge, invoke `Skill(run-state-management)` to transition the `merge-pr` FlowRun to `state.status: completed` and update its `workflow-run` journal artifact to `status=completed`. Then transition the linked FlowGoal to a terminal status if it is not already — the merge itself is the achievement signal. If the merge was cancelled, transition the run to `cancelled` (with `blocked_reason`) so it is not treated as resumable.
 
 **Manifest emit** — if this merge resolved any escalations (a Proactive-Autonomy escalation surfaced via `AskUserQuestion` during Phase 1's finding-ledger check, Phase 2's stale-approval warning, or the conflict-resolution path closed because the user provided one of the six canonical fields), record an `escalation-resolved` artifact for each:
 

--- a/plugins/flow/commands/pr.md
+++ b/plugins/flow/commands/pr.md
@@ -292,11 +292,18 @@ After agents return, TaskUpdate each review task with findings.
    - **Option 2: Create PR with goal not-yet-achieved** — proceed with PR creation; the PR body includes a `## FlowGoal Status` section noting the lifecycle is `<status>`. The `/flow:merge` gate will block until the goal is achieved or the user overrides. This is a Proactive-Autonomy override of the gate, so record it to the decision journal:
 
      ```bash
-     "${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/journal-record.sh" \
-       --issue "$ISSUE_NUM" --type escalation-resolved \
-       --metadata gate=flowgoal-pr \
-       --metadata goal_status="$GOAL_LIFECYCLE" \
-       --metadata outcome="user-overrode: created PR with goal not yet achieved"
+     # Self-contained: the Phase 1 !-block's vars do not persist into this
+     # block's shell, so re-derive the issue from the branch and read the
+     # lifecycle from the helper (same pattern as the manifest-emit block).
+     ISSUE_NUM=$(git branch --show-current 2>/dev/null | grep -oE 'issue-[0-9]+' | head -1 | sed 's/issue-//')
+     GOAL_LIFECYCLE=$("${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/flow-active-goal.sh" --status 2>/dev/null || echo "unknown")
+     if [ -n "$ISSUE_NUM" ]; then
+       "${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/journal-record.sh" \
+         --issue "$ISSUE_NUM" --type escalation-resolved \
+         --metadata gate=flowgoal-pr \
+         --metadata goal_status="$GOAL_LIFECYCLE" \
+         --metadata outcome="user-overrode: created PR with goal not yet achieved"
+     fi
      ```
    - **Option 3: Cancel** — exit `/flow:pr` and finish the implementation work first.
 

--- a/plugins/flow/commands/pr.md
+++ b/plugins/flow/commands/pr.md
@@ -289,7 +289,15 @@ After agents return, TaskUpdate each review task with findings.
 7a. **FlowGoal gate (v3, opt-in)** — when the Phase 1 `### FlowGoal State` section reported `GATE=block`, the active FlowGoal is not yet `achieved`. Do NOT push or create the PR with an incomplete goal — use the AskUserQuestion tool with these options:
 
    - **Option 1 (Recommended): Run `/flow:goal evaluate <id>` first** — produces a verdict that may transition the goal to `achieved`. If the verdict is `achieved`, return here and proceed with PR creation.
-   - **Option 2: Create PR with goal not-yet-achieved** — proceed with PR creation; the PR body includes a `## FlowGoal Status` section noting the lifecycle is `<status>`. The `/flow:merge` gate will block until the goal is achieved or the user overrides.
+   - **Option 2: Create PR with goal not-yet-achieved** — proceed with PR creation; the PR body includes a `## FlowGoal Status` section noting the lifecycle is `<status>`. The `/flow:merge` gate will block until the goal is achieved or the user overrides. This is a Proactive-Autonomy override of the gate, so record it to the decision journal:
+
+     ```bash
+     "${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/journal-record.sh" \
+       --issue "$ISSUE_NUM" --type escalation-resolved \
+       --metadata gate=flowgoal-pr \
+       --metadata goal_status="$GOAL_LIFECYCLE" \
+       --metadata outcome="user-overrode: created PR with goal not yet achieved"
+     ```
    - **Option 3: Cancel** — exit `/flow:pr` and finish the implementation work first.
 
    When `STATE=disabled` (v2 mode, `requireGoalForStart` not set): skip this step silently.
@@ -305,8 +313,11 @@ After agents return, TaskUpdate each review task with findings.
 
    - **Goal**: `<GOAL_ID>` (from `.flow/goals/<id>.goal.yaml`)
    - **Lifecycle**: `<status>` (not yet `achieved`)
+   - **Evidence**: per-criterion FlowEvidence sidecars under `.flow/runs/<run-id>/evidence/`
    - **Note**: `/flow:merge` will block until this goal is `achieved` or the user explicitly overrides.
    ```
+
+   The `<run-id>` is the active FlowRun for this branch (the `start-issue` run created by `/flow:start`). List the evidence sidecar filenames so a reviewer can trace each acceptance criterion to its captured output.
    If visual verification ran, include visual evidence section:
    ```markdown
    ## Visual Verification
@@ -322,6 +333,8 @@ After agents return, TaskUpdate each review task with findings.
     ```bash
     gh pr create --title "$TITLE" --body "$BODY"
     ```
+
+    **FlowRun activity** — `/flow:pr` is the tail of the `start-issue` workflow, not a workflow of its own, so it does NOT create a new FlowRun. Instead, when `flow.runtime.enabled` is `true` and an active FlowRun exists for this branch (the `start-issue` run), invoke `Skill(run-state-management)` to append a `pr_create` FlowActivity (type `bash`, phase `verify`) recording the PR number and URL as evidence. Best-effort: if no active run is found for the branch, skip — the PR itself is the durable record.
 11. **Suggest reviewers** using pr-lifecycle skill algorithm
 12. **Verify**: `gh pr view --json number,url`
 13. **Manifest emit** — record the review-cycle artifact for the parallel-review pass that ran during PR creation. Same emit shape as `commands/review.md` Phase 4 step 7 — the PR-creation flow runs an inline review and is morally a cycle:

--- a/plugins/flow/commands/release.md
+++ b/plugins/flow/commands/release.md
@@ -69,6 +69,35 @@ fi
 true
 ```
 
+### FlowRun (v3 runtime)
+
+A release is a long-running workflow, so it gets a durable FlowRun. Runs are gated by `flow.runtime.enabled` (default `true`); v2 projects that opted out see `FLOW_RUN_STATE=skip` and the wiring is a no-op.
+
+```!
+# FLOW_RUN_BLOCK_BEGIN
+CASCADE="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
+if [ ! -x "$CASCADE" ]; then
+  echo "FLOW_RUN_STATE=blocked"
+  echo "FLOW_RUN_ERROR=cascade-resolve.sh missing or non-executable at $CASCADE"
+  true; exit 0
+fi
+RUNTIME_ENABLED=$("$CASCADE" --default "true" '.flow.runtime.enabled' 2>/dev/null)
+if [ "$RUNTIME_ENABLED" != "true" ]; then
+  echo "FLOW_RUN_STATE=skip"
+  echo "FLOW_RUN_REASON=flow.runtime.enabled is not true (v2 mode)"
+else
+  RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-release"
+  echo "FLOW_RUN_STATE=create"
+  echo "RUN_ID=$RUN_ID"
+  echo "WORKFLOW=release"
+  echo "INITIAL_PHASE=preflight"
+fi
+# FLOW_RUN_BLOCK_END
+true
+```
+
+When `FLOW_RUN_STATE=create`, invoke `Skill(run-state-management)` to create `.flow/runs/$RUN_ID/run.yaml` (workflow=`release`, goal=`null` — a release is not goal-bound; it verifies the goals of *included* PRs in Phase 4), initial phase `preflight`. The release is not issue-scoped, so the `workflow-run` journal artifact is best-effort: emit it only if a single issue can be inferred from the included PRs; otherwise the `run.yaml` is the durable record. Phase order: `preflight → bump → tag → push`.
+
 ## Phase 2: Calculate Version
 
 Parse `$ARGUMENTS` for version bump type:
@@ -127,12 +156,16 @@ git push origin "$TAG"
 gh release create "$TAG" --title "$TAG" --notes "$CHANGELOG"
 ```
 
+**FlowActivity writes** (when `FLOW_RUN_STATE=create`): invoke `Skill(run-state-management)` to record one FlowActivity per phase boundary as it completes — `bump` (version calculated, phase `bump`), `tag` (`git tag` succeeded, phase `tag`), and `push` (`git push` + `gh release create` succeeded, phase `push`). Each write advances `state.current_phase` per the `preflight → bump → tag → push` order.
+
 ## Phase 5: Post-Release
 
 ```bash
 # Verify
 gh release view "$TAG"
 ```
+
+**FlowRun terminal transition** (when `FLOW_RUN_STATE=create`): after the release publishes successfully, invoke `Skill(run-state-management)` to transition the FlowRun to `state.status: completed`. If a `workflow-run` journal artifact was emitted at entry, update it to `status=completed` via a second `bin/journal-record.sh` call. If the release failed or was cancelled, transition to `state.status: cancelled` (with `blocked_reason`) instead so `/flow:resume` does not treat it as resumable.
 
 Display release URL and summary.
 

--- a/plugins/flow/commands/release.md
+++ b/plugins/flow/commands/release.md
@@ -86,7 +86,7 @@ if [ "$RUNTIME_ENABLED" != "true" ]; then
   echo "FLOW_RUN_STATE=skip"
   echo "FLOW_RUN_REASON=flow.runtime.enabled is not true (v2 mode)"
 else
-  RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-release"
+  RUN_ID="$(date -u +%Y-%m-%dT%H%M%SZ)-release"
   echo "FLOW_RUN_STATE=create"
   echo "RUN_ID=$RUN_ID"
   echo "WORKFLOW=release"
@@ -96,7 +96,7 @@ fi
 true
 ```
 
-When `FLOW_RUN_STATE=create`, invoke `Skill(run-state-management)` to create `.flow/runs/$RUN_ID/run.yaml` (workflow=`release`, goal=`null` — a release is not goal-bound; it verifies the goals of *included* PRs in Phase 4), initial phase `preflight`. The release is not issue-scoped, so the `workflow-run` journal artifact is best-effort: emit it only if a single issue can be inferred from the included PRs; otherwise the `run.yaml` is the durable record. Phase order: `preflight → bump → tag → push`.
+When `FLOW_RUN_STATE=create`, invoke `Skill(run-state-management)` to create `.flow/runs/$RUN_ID/run.yaml` (workflow=`release`, goal=`null` — a release is not goal-bound; it verifies the goals of *included* PRs in Phase 4), initial phase `preflight`. The release is not issue-scoped, so the `workflow-run` journal artifact is best-effort: emit it only if a single issue can be inferred from the included PRs; otherwise the `run.yaml` is the durable record. Phase order: `preflight → bump → confirm → tag` (matching `workflows/release.workflow.yaml`; the tag push and `gh release create` are steps inside the `tag` phase).
 
 ## Phase 2: Calculate Version
 
@@ -156,7 +156,7 @@ git push origin "$TAG"
 gh release create "$TAG" --title "$TAG" --notes "$CHANGELOG"
 ```
 
-**FlowActivity writes** (when `FLOW_RUN_STATE=create`): invoke `Skill(run-state-management)` to record one FlowActivity per phase boundary as it completes — `bump` (version calculated, phase `bump`), `tag` (`git tag` succeeded, phase `tag`), and `push` (`git push` + `gh release create` succeeded, phase `push`). Each write advances `state.current_phase` per the `preflight → bump → tag → push` order.
+**FlowActivity writes** (when `FLOW_RUN_STATE=create`): invoke `Skill(run-state-management)` to record one FlowActivity per phase boundary as it completes — `bump` (version calculated + changelog generated), `confirm` (user approved the release via AskUserQuestion), and `tag` (`git tag`, `git push origin <tag>`, and `gh release create` all succeeded). Each write advances `state.current_phase` per the `preflight → bump → confirm → tag` order.
 
 ## Phase 5: Post-Release
 

--- a/plugins/flow/commands/review.md
+++ b/plugins/flow/commands/review.md
@@ -167,6 +167,35 @@ true
 
 If previous cycles exist, build a **Previous Feedback Status** table and cross-reference each finding's location against `git diff` to verify resolution.
 
+### FlowRun (v3 runtime)
+
+A review is a long-running workflow, so it gets a durable FlowRun. Runs are gated by `flow.runtime.enabled` (default `true`); v2 projects that opted out see `FLOW_RUN_STATE=skip` and the wiring is a no-op.
+
+```!
+# FLOW_RUN_BLOCK_BEGIN
+CASCADE="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
+if [ ! -x "$CASCADE" ]; then
+  echo "FLOW_RUN_STATE=blocked"
+  echo "FLOW_RUN_ERROR=cascade-resolve.sh missing or non-executable at $CASCADE"
+  true; exit 0
+fi
+RUNTIME_ENABLED=$("$CASCADE" --default "true" '.flow.runtime.enabled' 2>/dev/null)
+if [ "$RUNTIME_ENABLED" != "true" ]; then
+  echo "FLOW_RUN_STATE=skip"
+  echo "FLOW_RUN_REASON=flow.runtime.enabled is not true (v2 mode)"
+else
+  RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-review"
+  echo "FLOW_RUN_STATE=create"
+  echo "RUN_ID=$RUN_ID"
+  echo "WORKFLOW=review-pr"
+  echo "INITIAL_PHASE=preflight"
+fi
+# FLOW_RUN_BLOCK_END
+true
+```
+
+When `FLOW_RUN_STATE=create`, invoke `Skill(run-state-management)` to create `.flow/runs/$RUN_ID/run.yaml` (workflow=`review-pr`, goal=`null`), initial phase `preflight`. Phase order: `preflight → fan-out → consolidate → report`. Review is **FlowRun-only — it creates NO FlowGoal**: a review session is bounded by the PR under review, and the PR's own review-thread state (the posted review comment plus its FLOW_REVIEW_CYCLE marker) is the durable record of what the review found. The `run.yaml` captures the workflow's resumability state; there is no separate goal contract to satisfy.
+
 ## Phase 2: PLAN
 
 ```
@@ -577,6 +606,8 @@ Skill(holdout-validation):
 
 TaskUpdate each review task as agents complete.
 
+**FlowActivity writes** (when `FLOW_RUN_STATE=create`): invoke `Skill(run-state-management)` to record a FlowActivity as the consolidate boundary completes — once the per-facet findings (Path A consolidation or Path B synthesis) have been merged into a single deduplicated finding set, advancing `state.current_phase` to `consolidate` per the `preflight → fan-out → consolidate → report` order.
+
 ## Phase 4: VERIFY
 
 **CRITICAL: Posting review findings to the PR is MANDATORY. NEVER skip posting. The review is not complete until `gh pr review` has been executed and TaskUpdate confirms the post task is completed. Do not suggest next steps until posting is verified.**
@@ -697,6 +728,10 @@ TaskUpdate each review task as agents complete.
 8. **Verify posting**: TaskList — confirm "Post review comment" or "Post self-review comment" task is completed. Do NOT proceed to step 9 until this is verified.
 
 9. **Post-review**: If self-review fixed everything, suggest `/flow:pr`. If external review, suggest `/flow:address $PR_NUM` for the PR author.
+
+**FlowActivity writes** (when `FLOW_RUN_STATE=create`): invoke `Skill(run-state-management)` to record a FlowActivity as the report boundary completes — once the review comment is posted (step 7) and posting is verified (step 8), advancing `state.current_phase` to `report` per the `preflight → fan-out → consolidate → report` order.
+
+**FlowRun terminal transition** (when `FLOW_RUN_STATE=create`): once the review comment is posted (or no-finding evidence is recorded), invoke `Skill(run-state-management)` to transition the FlowRun to `state.status: completed`. The `workflow-run` journal artifact is best-effort — a review is PR-scoped, not issue-scoped — so emit `bin/journal-record.sh --type workflow-run` only if a single issue can be inferred from the PR (the linked issue parsed from the PR body); otherwise the `run.yaml` is the durable record and no journal artifact is written. If the review failed or was cancelled before posting, transition to `state.status: cancelled` (with `blocked_reason`) instead so `/flow:resume` does not treat it as resumable.
 
 ## Tier Classification
 

--- a/plugins/flow/commands/review.md
+++ b/plugins/flow/commands/review.md
@@ -184,7 +184,7 @@ if [ "$RUNTIME_ENABLED" != "true" ]; then
   echo "FLOW_RUN_STATE=skip"
   echo "FLOW_RUN_REASON=flow.runtime.enabled is not true (v2 mode)"
 else
-  RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-review"
+  RUN_ID="$(date -u +%Y-%m-%dT%H%M%SZ)-review"
   echo "FLOW_RUN_STATE=create"
   echo "RUN_ID=$RUN_ID"
   echo "WORKFLOW=review-pr"

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -620,6 +620,50 @@ For `FLOW_GOAL_STATE=create`:
    FlowGoal created: <GOAL_ID> at <GOAL_PATH> (status: active)
    ```
 
+### FlowRun (v3 runtime)
+
+`/flow:start` is a long-running workflow, so it gets a durable FlowRun linked to the FlowGoal. Runs are gated by `flow.runtime.enabled` (default `true`); v2 projects that opted out see `FLOW_RUN_STATE=skip` and the wiring is a no-op.
+
+```!
+# FLOW_RUN_BLOCK_BEGIN
+CASCADE="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
+if [ ! -x "$CASCADE" ]; then
+  echo "FLOW_RUN_STATE=blocked"
+  echo "FLOW_RUN_ERROR=cascade-resolve.sh missing or non-executable at $CASCADE"
+  true; exit 0
+fi
+RUNTIME_ENABLED=$("$CASCADE" --default "true" '.flow.runtime.enabled' 2>/dev/null)
+ARG1="${ARGUMENTS%% *}"
+case "$ARG1" in
+  ''|*[!0-9]*) ISSUE_NUM="" ;;
+  *) ISSUE_NUM="$ARG1" ;;
+esac
+if [ "$RUNTIME_ENABLED" != "true" ]; then
+  echo "FLOW_RUN_STATE=skip"
+  echo "FLOW_RUN_REASON=flow.runtime.enabled is not true (v2 mode)"
+else
+  SLUG="${ISSUE_NUM:-nonum}"
+  RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-issue-${SLUG}"
+  echo "FLOW_RUN_STATE=create"
+  echo "RUN_ID=$RUN_ID"
+  echo "WORKFLOW=start-issue"
+  echo "INITIAL_PHASE=preflight"
+  if [ -n "$ISSUE_NUM" ]; then echo "GOAL_LINK=issue-$ISSUE_NUM"; else echo "GOAL_LINK=null"; fi
+fi
+# FLOW_RUN_BLOCK_END
+true
+```
+
+When `FLOW_RUN_STATE=create`, invoke `Skill(run-state-management)` to create `.flow/runs/$RUN_ID/run.yaml` (workflow=`start-issue`, goal=`$GOAL_LINK` — the FlowGoal created above, or `null` when goal creation was skipped), initial phase `preflight`. Because `/flow:start` is issue-scoped, also emit the `workflow-run` artifact to `.decisions/issue-$ISSUE_NUM.md`:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/journal-record.sh" \
+  --issue "$ISSUE_NUM" --type workflow-run \
+  --metadata workflow=start-issue --metadata run_id="$RUN_ID" --metadata status=active
+```
+
+Phase order: `preflight → explore → plan → code → verify`. At each subsequent phase boundary (PLAN, CODE, VERIFY), invoke `Skill(run-state-management)` to write a FlowActivity record and advance `state.current_phase`. After the Phase 4 verdict settles, transition the FlowRun: `state.status: completed` when the verdict is PASS (and update the `workflow-run` artifact to `status=completed`); `state.status: blocked` (with `blocked_reason`) when the verdict is FAIL or the session ends mid-workflow, so `/flow:resume` can pick it up.
+
 ## Phase 2: PLAN
 
 Create branch and decompose tasks.

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -643,7 +643,7 @@ if [ "$RUNTIME_ENABLED" != "true" ]; then
   echo "FLOW_RUN_REASON=flow.runtime.enabled is not true (v2 mode)"
 else
   SLUG="${ISSUE_NUM:-nonum}"
-  RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-issue-${SLUG}"
+  RUN_ID="$(date -u +%Y-%m-%dT%H%M%SZ)-issue-${SLUG}"
   echo "FLOW_RUN_STATE=create"
   echo "RUN_ID=$RUN_ID"
   echo "WORKFLOW=start-issue"
@@ -657,9 +657,14 @@ true
 When `FLOW_RUN_STATE=create`, invoke `Skill(run-state-management)` to create `.flow/runs/$RUN_ID/run.yaml` (workflow=`start-issue`, goal=`$GOAL_LINK` — the FlowGoal created above, or `null` when goal creation was skipped), initial phase `preflight`. Because `/flow:start` is issue-scoped, also emit the `workflow-run` artifact to `.decisions/issue-$ISSUE_NUM.md`:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/journal-record.sh" \
-  --issue "$ISSUE_NUM" --type workflow-run \
-  --metadata workflow=start-issue --metadata run_id="$RUN_ID" --metadata status=active
+# Self-contained: re-derive the issue from $ARGUMENTS (the entry !-block's vars
+# do not persist here). RUN_ID is the value emitted by the FlowRun entry block.
+ARG1="${ARGUMENTS%% *}"; case "$ARG1" in ''|*[!0-9]*) ISSUE_NUM="" ;; *) ISSUE_NUM="$ARG1" ;; esac
+if [ -n "$ISSUE_NUM" ]; then
+  "${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/journal-record.sh" \
+    --issue "$ISSUE_NUM" --type workflow-run \
+    --metadata workflow=start-issue --metadata run_id="$RUN_ID" --metadata status=active
+fi
 ```
 
 Phase order: `preflight → explore → plan → code → verify`. At each subsequent phase boundary (PLAN, CODE, VERIFY), invoke `Skill(run-state-management)` to write a FlowActivity record and advance `state.current_phase`. After the Phase 4 verdict settles, transition the FlowRun: `state.status: completed` when the verdict is PASS (and update the `workflow-run` artifact to `status=completed`); `state.status: blocked` (with `blocked_reason`) when the verdict is FAIL or the session ends mid-workflow, so `/flow:resume` can pick it up.

--- a/plugins/flow/commands/status.md
+++ b/plugins/flow/commands/status.md
@@ -218,11 +218,10 @@ else
 import sys, yaml
 d = yaml.safe_load(open(sys.argv[1], encoding="utf-8")) or {}
 m = d.get("metadata", {}) or {}
-state = d.get("state", {}) or {}
 tid = m.get("id", "?")
-ttype = (d.get("trigger", {}) or {}).get("type", m.get("type", "?"))
-last = state.get("last_fired", "never")
-print(f"TRIGGER=id={tid} type={ttype} last_fired={last}")
+ttype = (d.get("trigger", {}) or {}).get("type", "?")
+enabled = m.get("enabled", True)
+print(f"TRIGGER=id={tid} type={ttype} enabled={enabled}")
 PY
     done
   else
@@ -447,9 +446,9 @@ State values: `unavailable` (gh API failed) | `no_open_prs` (user has no open PR
 {When STATE=degraded: render "Unavailable: {REASON}"}
 {When STATE=ok: render a table of registered triggers}
 
-| Trigger | Type | Last Fired |
-|---------|------|------------|
-| `{id}` | `{type}` | {last_fired} |
+| Trigger | Type | Enabled |
+|---------|------|---------|
+| `{id}` | `{type}` | {enabled} |
 
 ### Findings Ledger
 {single line: `P1: {n}[ (annotation)]    P2: {n}[ (annotation)]    P3: {n}[ (annotation)]` — annotations are omitted when count is 0; see render rules below}

--- a/plugins/flow/commands/status.md
+++ b/plugins/flow/commands/status.md
@@ -191,6 +191,46 @@ else
   fi
 fi
 
+# Section: Active Triggers (v3, gated behind flow.triggers.enabled)
+# Surface registered triggers under .flow/triggers/*.trigger.yaml so the user
+# can see what is wired to fire automatically. v2 projects (flag false/unset)
+# emit STATE=disabled.
+echo ""
+echo "### Active Triggers"
+TRIG_HELPER="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
+TRIGGERS_ENABLED="false"
+[ -x "$TRIG_HELPER" ] && TRIGGERS_ENABLED=$("$TRIG_HELPER" --default "false" '.flow.triggers.enabled' 2>/dev/null)
+if [ "$TRIGGERS_ENABLED" != "true" ]; then
+  echo "STATE=disabled"
+elif [ ! -d ".flow/triggers" ]; then
+  echo "STATE=empty"
+else
+  TRIGGER_FILES=$(ls -1 .flow/triggers/*.trigger.yaml 2>/dev/null)
+  if [ -z "$TRIGGER_FILES" ]; then
+    echo "STATE=empty"
+  elif command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" >/dev/null 2>&1; then
+    echo "STATE=ok"
+    printf '%s\n' "$TRIGGER_FILES" | while read -r tf; do
+      [ -f "$tf" ] || continue
+      # [ -L ] symlink defense — matches the reader guards elsewhere.
+      [ -L "$tf" ] && { echo "TRIGGER=skipped (symlink rejected): $tf"; continue; }
+      python3 - "$tf" <<'PY' 2>/dev/null
+import sys, yaml
+d = yaml.safe_load(open(sys.argv[1], encoding="utf-8")) or {}
+m = d.get("metadata", {}) or {}
+state = d.get("state", {}) or {}
+tid = m.get("id", "?")
+ttype = (d.get("trigger", {}) or {}).get("type", m.get("type", "?"))
+last = state.get("last_fired", "never")
+print(f"TRIGGER=id={tid} type={ttype} last_fired={last}")
+PY
+    done
+  else
+    echo "STATE=degraded"
+    echo "REASON=python3/PyYAML unavailable — cannot parse trigger yamls"
+  fi
+fi
+
 true
 ```
 
@@ -400,6 +440,16 @@ State values: `unavailable` (gh API failed) | `no_open_prs` (user has no open PR
 | Run ID | Verdict | Activities |
 |--------|---------|------------|
 | `{run}` | `{verdict}` | {activities} |
+
+### Active Triggers
+{When STATE=disabled: render "(Triggers v3 not enabled — set `flow.triggers.enabled: true` in `.claude/settings.flow.json` to opt in)"}
+{When STATE=empty: render "No triggers registered."}
+{When STATE=degraded: render "Unavailable: {REASON}"}
+{When STATE=ok: render a table of registered triggers}
+
+| Trigger | Type | Last Fired |
+|---------|------|------------|
+| `{id}` | `{type}` | {last_fired} |
 
 ### Findings Ledger
 {single line: `P1: {n}[ (annotation)]    P2: {n}[ (annotation)]    P3: {n}[ (annotation)]` — annotations are omitted when count is 0; see render rules below}

--- a/plugins/flow/settings.json
+++ b/plugins/flow/settings.json
@@ -104,10 +104,10 @@
       }
     },
     "workflows": {
-      "enabled": false
+      "enabled": true
     },
     "triggers": {
-      "enabled": false,
+      "enabled": true,
       "allowedTypes": ["manual", "hook", "loop_prompt"],
       "allowAutonomousMerge": false,
       "allowTriggerCreationFromTriggeredRun": false,

--- a/plugins/flow/skills/run-state-management/SKILL.md
+++ b/plugins/flow/skills/run-state-management/SKILL.md
@@ -172,7 +172,7 @@ When SessionEnd fires (separate hook: `session-end-state.sh`), if an active Flow
 | `address-pr` | preflight → categorize → resolve → verify |
 | `review-pr` | preflight → fan-out → consolidate → report |
 | `merge-pr` | preflight → verify → confirm → merge |
-| `release` | preflight → bump → tag → push |
+| `release` | preflight → bump → confirm → tag |
 
 The machine-readable equivalents live at `plugins/flow/workflows/<id>.workflow.yaml`.
 

--- a/plugins/flow/skills/specification-capture/SKILL.md
+++ b/plugins/flow/skills/specification-capture/SKILL.md
@@ -135,6 +135,7 @@ Downstream consumers (`implementation-planner` agent, Stranger Test gate, Phase 
 | `commands/start.md` Phase 1 | All three (non-goals, failure modes, interface contracts) | Required for PLAN to proceed. Treat partial capture as BLOCK; complete it via Step 3. |
 | `commands/design.md` Phase 1 | Non-goals + interface contracts (failure modes optional but recommended) | If the journal already has the elements, surface them in the design discussion as the fence. If missing, capture during the design conversation. |
 | `commands/brainstorm.md` Phase 1 | Non-goals only (the brainstorm is bounded by what's IN scope) | If non-goals exist in the journal, brainstorm only inside the fence. If missing, capture them BEFORE generating approaches — otherwise the brainstorm sprawls. |
+| `commands/debug.md` Phase 3 (via `goal-contract-capture`) | Outcome (from the failure description) + acceptance criterion (the reproducing test) + root-cause constraints. The full three-element specification is skipped — a confirmed bug already carries its context. | Captured after hypothesis confirmation, not at entry. The reproducing test is the AC; no separate spec gate. |
 
 The skill always writes the elements it captures to the journal regardless of invoker. A `/flow:brainstorm` call that captures non-goals first will pre-populate that element for a later `/flow:start` call on the same issue, eliminating duplicate prompting.
 

--- a/plugins/flow/tests/address-v3-integration.test.sh
+++ b/plugins/flow/tests/address-v3-integration.test.sh
@@ -1,4 +1,4 @@
-# Tests for #110 v3 integration — FlowRun wiring in commands/address.md.
+# Tests for the v3 runtime integration — FlowRun wiring in commands/address.md.
 #
 # Contract under test:
 #   - address.md wires a FlowRun at the end of Phase 1 (FLOW_RUN_STATE block,

--- a/plugins/flow/tests/address-v3-integration.test.sh
+++ b/plugins/flow/tests/address-v3-integration.test.sh
@@ -1,0 +1,75 @@
+# Tests for #110 v3 integration — FlowRun wiring in commands/address.md.
+#
+# Contract under test:
+#   - address.md wires a FlowRun at the end of Phase 1 (FLOW_RUN_STATE block,
+#     gated by flow.runtime.enabled), invokes Skill(run-state-management),
+#     records activities per resolved finding at the categorize→resolve→verify
+#     boundaries, captures verification-evidence sidecars via
+#     goal-evidence-ledger, and transitions the run to a terminal state.
+#   - address is FlowRun-only (no FlowGoal) — the PR's review-thread state is
+#     the durable record of feedback resolution.
+#   - The entry block (between FLOW_RUN_BLOCK_BEGIN/END) is runnable: it emits
+#     FLOW_RUN_STATE=create with RUN_ID + WORKFLOW=address-pr when runtime is
+#     enabled, and FLOW_RUN_STATE=skip when flow.runtime.enabled is false.
+#
+# Prereq: jq (cascade-resolve.sh dependency). SKIPS gracefully if absent.
+
+if ! command -v jq >/dev/null 2>&1; then
+  _flow_test_begin "jq prerequisite"
+  _flow_assert_pass "SKIP: jq not installed"
+  return 0
+fi
+
+PLUGIN_DIR="$REPO_ROOT/plugins/flow"
+ADDRESS_MD="$PLUGIN_DIR/commands/address.md"
+CASCADE="$PLUGIN_DIR/bin/cascade-resolve.sh"
+
+ADDR_CLEANUP=()
+_addr_cleanup() { local p; for p in "${ADDR_CLEANUP[@]:-}"; do [ -n "$p" ] && rm -rf "$p" 2>/dev/null; done; }
+trap _addr_cleanup EXIT
+
+CONTENT=$(cat "$ADDRESS_MD")
+
+# --- source-presence: FlowRun wiring
+_flow_test_begin "address.md wires a FlowRun at entry"
+assert_contains "FLOW_RUN_BLOCK_BEGIN" "$CONTENT" "extractable FlowRun block markers present"
+assert_contains "FLOW_RUN_STATE=create" "$CONTENT" "emits create state"
+assert_contains "WORKFLOW=address-pr" "$CONTENT" "names the address-pr workflow"
+assert_contains "flow.runtime.enabled" "$CONTENT" "gated behind runtime.enabled"
+assert_contains "run-state-management" "$CONTENT" "delegates to run-state-management skill"
+
+_flow_test_begin "address.md records activities at phase boundaries"
+assert_contains "FlowActivity writes" "$CONTENT" "activity-write step documented"
+assert_match 'preflight . categorize . resolve . verify' "$CONTENT" "documents the address phase order"
+assert_contains "goal-evidence-ledger" "$CONTENT" "captures verification-evidence sidecar"
+
+_flow_test_begin "address.md transitions the FlowRun to terminal state"
+assert_contains "FlowRun terminal transition" "$CONTENT" "terminal-transition step documented"
+assert_contains "state.status: completed" "$CONTENT" "completes the run on success"
+assert_contains "cancelled" "$CONTENT" "cancels the run on failure (not left resumable)"
+
+_flow_test_begin "address is FlowRun-only (no FlowGoal)"
+assert_not_contains "goal-contract-capture" "$CONTENT" "address does not create a FlowGoal"
+assert_contains "creates NO FlowGoal" "$CONTENT" "documents address is FlowRun-only"
+
+# --- functional: extract the entry block and run it under controlled settings
+_extract_run_block() {
+  awk '/FLOW_RUN_BLOCK_BEGIN/{f=1;next} /FLOW_RUN_BLOCK_END/{f=0} f' "$ADDRESS_MD"
+}
+
+_flow_test_begin "entry block emits FLOW_RUN_STATE=create when runtime enabled (default)"
+WORK=$(mktemp -d -t flow-addr.XXXXXX); ADDR_CLEANUP+=("$WORK")
+_extract_run_block > "$WORK/block.sh"
+OUT=$(cd "$WORK" && CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" bash block.sh 2>/dev/null)
+assert_contains "FLOW_RUN_STATE=create" "$OUT" "default runtime → create"
+assert_contains "WORKFLOW=address-pr" "$OUT" "workflow id emitted"
+assert_match 'RUN_ID=[0-9]{8}T[0-9]{6}Z-address' "$OUT" "RUN_ID is an ISO-compact timestamp slug"
+
+_flow_test_begin "entry block emits FLOW_RUN_STATE=skip when runtime disabled (v2 mode)"
+WORK2=$(mktemp -d -t flow-addr2.XXXXXX); ADDR_CLEANUP+=("$WORK2")
+mkdir -p "$WORK2/.claude"
+printf '%s\n' '{"flow":{"runtime":{"enabled":false}}}' > "$WORK2/.claude/settings.flow.json"
+_extract_run_block > "$WORK2/block.sh"
+OUT2=$(cd "$WORK2" && CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" bash block.sh 2>/dev/null)
+assert_contains "FLOW_RUN_STATE=skip" "$OUT2" "runtime disabled → skip (no-op for v2 projects)"
+assert_not_contains "FLOW_RUN_STATE=create" "$OUT2" "does not create when disabled"

--- a/plugins/flow/tests/address-v3-integration.test.sh
+++ b/plugins/flow/tests/address-v3-integration.test.sh
@@ -63,7 +63,10 @@ _extract_run_block > "$WORK/block.sh"
 OUT=$(cd "$WORK" && CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" bash block.sh 2>/dev/null)
 assert_contains "FLOW_RUN_STATE=create" "$OUT" "default runtime → create"
 assert_contains "WORKFLOW=address-pr" "$OUT" "workflow id emitted"
-assert_match 'RUN_ID=[0-9]{8}T[0-9]{6}Z-address' "$OUT" "RUN_ID is an ISO-compact timestamp slug"
+RUN_ID=$(printf '%s\n' "$OUT" | grep '^RUN_ID=' | cut -d= -f2-)
+SCHEMA_PAT=$(jq -r '.properties.metadata.properties.id.pattern' "$PLUGIN_DIR/schemas/v1/run.schema.json")
+if printf '%s' "$RUN_ID" | grep -qE "$SCHEMA_PAT"; then _flow_assert_pass "RUN_ID '$RUN_ID' conforms to run.schema"; else _flow_assert_fail "RUN_ID '$RUN_ID' violates /$SCHEMA_PAT/"; fi
+assert_contains "address" "$RUN_ID" "RUN_ID carries the address slug"
 
 _flow_test_begin "entry block emits FLOW_RUN_STATE=skip when runtime disabled (v2 mode)"
 WORK2=$(mktemp -d -t flow-addr2.XXXXXX); ADDR_CLEANUP+=("$WORK2")

--- a/plugins/flow/tests/debug-v3-integration.test.sh
+++ b/plugins/flow/tests/debug-v3-integration.test.sh
@@ -1,0 +1,74 @@
+# Tests for #110 v3 integration — FlowRun + FlowGoal wiring in commands/debug.md.
+#
+# debug is the second goal-creating command (alongside start). It:
+#   - creates a FlowRun at entry (workflow=debug), gated by flow.runtime.enabled,
+#     forward-referencing the debug FlowGoal id (GOAL_LINK=debug-<ts>).
+#   - creates the FlowGoal via goal-contract-capture (reason=debug) AFTER
+#     hypothesis confirmation (end of diagnose), with the failure-outcome template.
+#   - evaluates the goal via goal-evaluator after VERIFY and transitions the run.
+#   - adds a `debug` row to the specification-capture per-invoker scope table.
+#
+# Prereq: jq. SKIPS gracefully if absent.
+
+if ! command -v jq >/dev/null 2>&1; then
+  _flow_test_begin "jq prerequisite"
+  _flow_assert_pass "SKIP: jq not installed"
+  return 0
+fi
+
+PLUGIN_DIR="$REPO_ROOT/plugins/flow"
+DEBUG_MD="$PLUGIN_DIR/commands/debug.md"
+SPEC_SKILL="$PLUGIN_DIR/skills/specification-capture/SKILL.md"
+
+DBG_CLEANUP=()
+_dbg_cleanup() { local p; for p in "${DBG_CLEANUP[@]:-}"; do [ -n "$p" ] && rm -rf "$p" 2>/dev/null; done; }
+trap _dbg_cleanup EXIT
+
+CONTENT=$(cat "$DEBUG_MD")
+
+_flow_test_begin "debug.md wires a FlowRun at entry"
+assert_contains "FLOW_RUN_BLOCK_BEGIN" "$CONTENT" "extractable FlowRun block markers present"
+assert_contains "FLOW_RUN_STATE=create" "$CONTENT" "emits create state"
+assert_contains "WORKFLOW=debug" "$CONTENT" "names the debug workflow"
+assert_contains "flow.runtime.enabled" "$CONTENT" "gated behind runtime.enabled"
+assert_contains "run-state-management" "$CONTENT" "delegates to run-state-management skill"
+assert_match 'preflight . reproduce . diagnose . fix . verify' "$CONTENT" "documents the debug phase order"
+
+_flow_test_begin "debug.md creates the FlowGoal after hypothesis confirmation"
+assert_contains "goal-contract-capture" "$CONTENT" "creates a FlowGoal via goal-contract-capture"
+assert_match 'invocation reason .debug' "$CONTENT" "uses the debug invocation reason"
+assert_contains "reproduced, root-caused" "$CONTENT" "uses the failure-outcome template"
+assert_contains "GOAL_LINK" "$CONTENT" "the run forward-references the goal id"
+
+_flow_test_begin "debug.md evaluates the goal + transitions the run after verify"
+assert_contains "goal-evaluator" "$CONTENT" "invokes goal-evaluator after verify"
+assert_contains "state.status: completed" "$CONTENT" "completes the run when goal achieved"
+assert_match 'state.status: blocked' "$CONTENT" "blocks (resumable) when not root-caused"
+
+_flow_test_begin "specification-capture scope table has a debug row"
+SPEC=$(cat "$SPEC_SKILL")
+assert_contains "commands/debug.md" "$SPEC" "debug invoker row present"
+assert_contains "reproducing test" "$SPEC" "AC is the reproducing test"
+
+# --- functional: extract entry block, run under controlled settings
+_extract_run_block() {
+  awk '/FLOW_RUN_BLOCK_BEGIN/{f=1;next} /FLOW_RUN_BLOCK_END/{f=0} f' "$DEBUG_MD"
+}
+
+_flow_test_begin "entry block creates a debug run forward-referencing the goal id"
+WORK=$(mktemp -d -t flow-dbg.XXXXXX); DBG_CLEANUP+=("$WORK")
+_extract_run_block > "$WORK/block.sh"
+OUT=$(cd "$WORK" && CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" bash block.sh 2>/dev/null)
+assert_contains "FLOW_RUN_STATE=create" "$OUT" "default runtime → create"
+assert_contains "WORKFLOW=debug" "$OUT" "workflow id emitted"
+assert_match 'RUN_ID=[0-9]{8}T[0-9]{6}Z-debug' "$OUT" "RUN_ID carries the debug slug"
+assert_match 'GOAL_LINK=debug-[0-9]{8}T[0-9]{6}Z' "$OUT" "goal id forward-reference emitted"
+
+_flow_test_begin "entry block skips when runtime disabled (v2 mode)"
+WORK2=$(mktemp -d -t flow-dbg2.XXXXXX); DBG_CLEANUP+=("$WORK2")
+mkdir -p "$WORK2/.claude"
+printf '%s\n' '{"flow":{"runtime":{"enabled":false}}}' > "$WORK2/.claude/settings.flow.json"
+_extract_run_block > "$WORK2/block.sh"
+OUT2=$(cd "$WORK2" && CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" bash block.sh 2>/dev/null)
+assert_contains "FLOW_RUN_STATE=skip" "$OUT2" "runtime disabled → skip"
+assert_not_contains "FLOW_RUN_STATE=create" "$OUT2" "does not create when disabled"

--- a/plugins/flow/tests/debug-v3-integration.test.sh
+++ b/plugins/flow/tests/debug-v3-integration.test.sh
@@ -1,4 +1,4 @@
-# Tests for #110 v3 integration — FlowRun + FlowGoal wiring in commands/debug.md.
+# Tests for the v3 runtime integration — FlowRun + FlowGoal wiring in commands/debug.md.
 #
 # debug is the second goal-creating command (alongside start). It:
 #   - creates a FlowRun at entry (workflow=debug), gated by flow.runtime.enabled,

--- a/plugins/flow/tests/debug-v3-integration.test.sh
+++ b/plugins/flow/tests/debug-v3-integration.test.sh
@@ -61,8 +61,16 @@ _extract_run_block > "$WORK/block.sh"
 OUT=$(cd "$WORK" && CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" bash block.sh 2>/dev/null)
 assert_contains "FLOW_RUN_STATE=create" "$OUT" "default runtime → create"
 assert_contains "WORKFLOW=debug" "$OUT" "workflow id emitted"
-assert_match 'RUN_ID=[0-9]{8}T[0-9]{6}Z-debug' "$OUT" "RUN_ID carries the debug slug"
-assert_match 'GOAL_LINK=debug-[0-9]{8}T[0-9]{6}Z' "$OUT" "goal id forward-reference emitted"
+# Validate RUN_ID against run.schema and GOAL_LINK against goal.schema — the
+# goal id pattern forbids uppercase, so the forward-referenced goal id must NOT
+# reuse the ISO run timestamp (the bug a hand-written regex would have missed).
+RUN_ID=$(printf '%s\n' "$OUT" | grep '^RUN_ID=' | cut -d= -f2-)
+GOAL_LINK=$(printf '%s\n' "$OUT" | grep '^GOAL_LINK=' | cut -d= -f2-)
+RUN_PAT=$(jq -r '.properties.metadata.properties.id.pattern' "$PLUGIN_DIR/schemas/v1/run.schema.json")
+GOAL_PAT=$(jq -r '.properties.metadata.properties.id.pattern' "$PLUGIN_DIR/schemas/v1/goal.schema.json")
+if printf '%s' "$RUN_ID" | grep -qE "$RUN_PAT"; then _flow_assert_pass "RUN_ID '$RUN_ID' conforms to run.schema"; else _flow_assert_fail "RUN_ID '$RUN_ID' violates /$RUN_PAT/"; fi
+if printf '%s' "$GOAL_LINK" | grep -qE "$GOAL_PAT"; then _flow_assert_pass "GOAL_LINK '$GOAL_LINK' conforms to goal.schema (no uppercase)"; else _flow_assert_fail "GOAL_LINK '$GOAL_LINK' violates /$GOAL_PAT/"; fi
+assert_contains "debug" "$RUN_ID" "RUN_ID carries the debug slug"
 
 _flow_test_begin "entry block skips when runtime disabled (v2 mode)"
 WORK2=$(mktemp -d -t flow-dbg2.XXXXXX); DBG_CLEANUP+=("$WORK2")

--- a/plugins/flow/tests/merge-v3-integration.test.sh
+++ b/plugins/flow/tests/merge-v3-integration.test.sh
@@ -1,4 +1,4 @@
-# Tests for #110 v3 integration — FlowRun wiring in commands/merge.md.
+# Tests for the v3 runtime integration — FlowRun wiring in commands/merge.md.
 #
 # The FlowGoal gate (block on lifecycle != achieved) already exists; this file
 # covers the NEW FlowRun layer + the AC5 contract:

--- a/plugins/flow/tests/merge-v3-integration.test.sh
+++ b/plugins/flow/tests/merge-v3-integration.test.sh
@@ -1,0 +1,66 @@
+# Tests for #110 v3 integration — FlowRun wiring in commands/merge.md.
+#
+# The FlowGoal gate (block on lifecycle != achieved) already exists; this file
+# covers the NEW FlowRun layer + the AC5 contract:
+#   - merge.md creates a FlowRun at entry (workflow=merge-pr), gated by
+#     flow.runtime.enabled, delegating to run-state-management.
+#   - It verifies every linked FlowRun is completed before merge, with NO
+#     override (Tier 3) — distinct from pr.md's overridable gate (AC5 vs AC4).
+#   - It transitions the run + linked goal to terminal after a successful merge.
+#
+# Prereq: jq. SKIPS gracefully if absent.
+
+if ! command -v jq >/dev/null 2>&1; then
+  _flow_test_begin "jq prerequisite"
+  _flow_assert_pass "SKIP: jq not installed"
+  return 0
+fi
+
+PLUGIN_DIR="$REPO_ROOT/plugins/flow"
+MERGE_MD="$PLUGIN_DIR/commands/merge.md"
+
+MRG_CLEANUP=()
+_mrg_cleanup() { local p; for p in "${MRG_CLEANUP[@]:-}"; do [ -n "$p" ] && rm -rf "$p" 2>/dev/null; done; }
+trap _mrg_cleanup EXIT
+
+CONTENT=$(cat "$MERGE_MD")
+
+_flow_test_begin "merge.md wires a FlowRun at entry"
+assert_contains "FLOW_RUN_BLOCK_BEGIN" "$CONTENT" "extractable FlowRun block markers present"
+assert_contains "FLOW_RUN_STATE=create" "$CONTENT" "emits create state"
+assert_contains "WORKFLOW=merge-pr" "$CONTENT" "names the merge-pr workflow"
+assert_contains "flow.runtime.enabled" "$CONTENT" "gated behind runtime.enabled"
+assert_contains "run-state-management" "$CONTENT" "delegates to run-state-management skill"
+assert_match 'preflight . verify . confirm . merge' "$CONTENT" "documents the merge phase order"
+
+_flow_test_begin "merge.md verifies linked FlowRuns are completed (AC5, no override)"
+assert_contains "Linked-run completion check" "$CONTENT" "linked-run check documented"
+assert_contains "no override" "$CONTENT" "Tier 3 — no override beyond confirmation"
+assert_match 'state.status: completed' "$CONTENT" "requires linked runs completed"
+
+_flow_test_begin "merge.md transitions run + goal to terminal after merge"
+assert_contains "FlowRun terminal transition" "$CONTENT" "terminal-transition step documented"
+assert_contains "status=completed" "$CONTENT" "updates workflow-run artifact to completed"
+assert_contains "cancelled" "$CONTENT" "cancels the run on aborted merge (not left resumable)"
+
+# --- functional: extract entry block, run under controlled settings
+_extract_run_block() {
+  awk '/FLOW_RUN_BLOCK_BEGIN/{f=1;next} /FLOW_RUN_BLOCK_END/{f=0} f' "$MERGE_MD"
+}
+
+_flow_test_begin "entry block creates a merge-pr run carrying the PR slug"
+WORK=$(mktemp -d -t flow-mrg.XXXXXX); MRG_CLEANUP+=("$WORK")
+_extract_run_block > "$WORK/block.sh"
+OUT=$(cd "$WORK" && CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" ARGUMENTS="113" bash block.sh 2>/dev/null)
+assert_contains "FLOW_RUN_STATE=create" "$OUT" "default runtime → create"
+assert_contains "WORKFLOW=merge-pr" "$OUT" "workflow id emitted"
+assert_match 'RUN_ID=[0-9]{8}T[0-9]{6}Z-merge-pr-113' "$OUT" "RUN_ID carries the PR slug"
+
+_flow_test_begin "entry block skips when runtime disabled (v2 mode)"
+WORK2=$(mktemp -d -t flow-mrg2.XXXXXX); MRG_CLEANUP+=("$WORK2")
+mkdir -p "$WORK2/.claude"
+printf '%s\n' '{"flow":{"runtime":{"enabled":false}}}' > "$WORK2/.claude/settings.flow.json"
+_extract_run_block > "$WORK2/block.sh"
+OUT2=$(cd "$WORK2" && CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" ARGUMENTS="113" bash block.sh 2>/dev/null)
+assert_contains "FLOW_RUN_STATE=skip" "$OUT2" "runtime disabled → skip"
+assert_not_contains "FLOW_RUN_STATE=create" "$OUT2" "does not create when disabled"

--- a/plugins/flow/tests/merge-v3-integration.test.sh
+++ b/plugins/flow/tests/merge-v3-integration.test.sh
@@ -54,7 +54,14 @@ _extract_run_block > "$WORK/block.sh"
 OUT=$(cd "$WORK" && CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" ARGUMENTS="113" bash block.sh 2>/dev/null)
 assert_contains "FLOW_RUN_STATE=create" "$OUT" "default runtime → create"
 assert_contains "WORKFLOW=merge-pr" "$OUT" "workflow id emitted"
-assert_match 'RUN_ID=[0-9]{8}T[0-9]{6}Z-merge-pr-113' "$OUT" "RUN_ID carries the PR slug"
+RUN_ID=$(printf '%s\n' "$OUT" | grep '^RUN_ID=' | cut -d= -f2-)
+SCHEMA_PAT=$(jq -r '.properties.metadata.properties.id.pattern' "$PLUGIN_DIR/schemas/v1/run.schema.json")
+if printf '%s' "$RUN_ID" | grep -qE "$SCHEMA_PAT"; then
+  _flow_assert_pass "RUN_ID '$RUN_ID' conforms to run.schema metadata.id pattern"
+else
+  _flow_assert_fail "RUN_ID '$RUN_ID' violates run.schema pattern /$SCHEMA_PAT/"
+fi
+assert_contains "merge-pr-113" "$RUN_ID" "RUN_ID carries the PR slug"
 
 _flow_test_begin "entry block skips when runtime disabled (v2 mode)"
 WORK2=$(mktemp -d -t flow-mrg2.XXXXXX); MRG_CLEANUP+=("$WORK2")

--- a/plugins/flow/tests/pr-v3-integration.test.sh
+++ b/plugins/flow/tests/pr-v3-integration.test.sh
@@ -1,0 +1,38 @@
+# Tests for #110 v3 integration — pr.md goal gate + FlowRun activity.
+#
+# The FlowGoal gate (5-state) already exists from a prior cycle and is covered
+# by flow-cycle14-behavioral.test.sh; this file asserts the AC4 contract holds
+# and the NEW pieces are wired:
+#   - AC4: pr.md blocks PR creation when the linked goal is not `achieved`,
+#     WITH an override path (Option 2) that records an escalation-resolved
+#     artifact.
+#   - PR body links FlowEvidence sidecars under .flow/runs/<id>/evidence/.
+#   - pr.md appends a `pr_create` FlowActivity to the branch's start-issue run
+#     (it does NOT create its own FlowRun — pr is the tail of start-issue).
+
+PLUGIN_DIR="$REPO_ROOT/plugins/flow"
+PR_MD="$PLUGIN_DIR/commands/pr.md"
+CONTENT=$(cat "$PR_MD")
+
+_flow_test_begin "pr.md FlowGoal gate blocks when goal not achieved (AC4)"
+assert_contains "GATE=block" "$CONTENT" "gate can block"
+assert_contains "GATE=pass" "$CONTENT" "gate can pass"
+assert_contains "flow-active-goal.sh" "$CONTENT" "reads the active goal via the centralized helper"
+assert_match 'achieved' "$CONTENT" "gate keys on achieved lifecycle"
+
+_flow_test_begin "pr.md gate has an override path (AC4 override)"
+assert_contains "Option 2" "$CONTENT" "override option present"
+assert_contains "escalation-resolved" "$CONTENT" "override records an escalation-resolved artifact"
+
+_flow_test_begin "pr.md PR body links FlowEvidence sidecars"
+assert_contains ".flow/runs/" "$CONTENT" "references the run directory"
+assert_contains "evidence/" "$CONTENT" "links the evidence sidecars"
+
+_flow_test_begin "pr.md appends a pr_create FlowActivity to the start-issue run"
+assert_contains "run-state-management" "$CONTENT" "delegates to run-state-management"
+assert_contains "pr_create" "$CONTENT" "names the pr_create activity"
+assert_contains "tail of the" "$CONTENT" "documents pr as the start-issue tail"
+
+_flow_test_begin "pr.md does NOT create its own FlowRun (pr has no workflow of its own)"
+assert_not_contains "FLOW_RUN_BLOCK_BEGIN" "$CONTENT" "no run-create block (pr continues start-issue)"
+assert_not_contains "WORKFLOW=pr-create" "$CONTENT" "no invented pr workflow id"

--- a/plugins/flow/tests/pr-v3-integration.test.sh
+++ b/plugins/flow/tests/pr-v3-integration.test.sh
@@ -1,8 +1,8 @@
-# Tests for #110 v3 integration — pr.md goal gate + FlowRun activity.
+# Tests for the v3 runtime integration — pr.md goal gate + FlowRun activity.
 #
-# The FlowGoal gate (5-state) already exists from a prior cycle and is covered
-# by flow-cycle14-behavioral.test.sh; this file asserts the AC4 contract holds
-# and the NEW pieces are wired:
+# The FlowGoal 5-state gate already exists and is covered by
+# flow-cycle14-behavioral.test.sh; this file asserts that gate contract holds
+# and the newer pieces are wired:
 #   - AC4: pr.md blocks PR creation when the linked goal is not `achieved`,
 #     WITH an override path (Option 2) that records an escalation-resolved
 #     artifact.

--- a/plugins/flow/tests/release-v3-integration.test.sh
+++ b/plugins/flow/tests/release-v3-integration.test.sh
@@ -38,7 +38,7 @@ assert_contains "run-state-management" "$CONTENT" "delegates to run-state-manage
 
 _flow_test_begin "release.md records activities at phase boundaries"
 assert_contains "FlowActivity writes" "$CONTENT" "activity-write step documented"
-assert_match 'preflight . bump . tag . push' "$CONTENT" "documents the release phase order"
+assert_match 'preflight . bump . confirm . tag' "$CONTENT" "documents the release phase order (matches workflow yaml)"
 
 _flow_test_begin "release.md transitions the FlowRun to terminal state"
 assert_contains "FlowRun terminal transition" "$CONTENT" "terminal-transition step documented"
@@ -60,7 +60,15 @@ _extract_run_block > "$WORK/block.sh"
 OUT=$(cd "$WORK" && CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" bash block.sh 2>/dev/null)
 assert_contains "FLOW_RUN_STATE=create" "$OUT" "default runtime → create"
 assert_contains "WORKFLOW=release" "$OUT" "workflow id emitted"
-assert_match 'RUN_ID=[0-9]{8}T[0-9]{6}Z-release' "$OUT" "RUN_ID is an ISO-compact timestamp slug"
+# Validate the emitted RUN_ID against the ACTUAL run.schema.json metadata.id
+# pattern (not just a hand-written regex) — guards against id-format drift.
+RUN_ID=$(printf '%s\n' "$OUT" | grep '^RUN_ID=' | cut -d= -f2-)
+SCHEMA_PAT=$(jq -r '.properties.metadata.properties.id.pattern' "$PLUGIN_DIR/schemas/v1/run.schema.json")
+if printf '%s' "$RUN_ID" | grep -qE "$SCHEMA_PAT"; then
+  _flow_assert_pass "RUN_ID '$RUN_ID' conforms to run.schema metadata.id pattern"
+else
+  _flow_assert_fail "RUN_ID '$RUN_ID' violates run.schema pattern /$SCHEMA_PAT/"
+fi
 
 _flow_test_begin "entry block emits FLOW_RUN_STATE=skip when runtime disabled (v2 mode)"
 WORK2=$(mktemp -d -t flow-rel2.XXXXXX); REL_CLEANUP+=("$WORK2")

--- a/plugins/flow/tests/release-v3-integration.test.sh
+++ b/plugins/flow/tests/release-v3-integration.test.sh
@@ -1,4 +1,4 @@
-# Tests for #110 v3 integration — FlowRun wiring in commands/release.md.
+# Tests for the v3 runtime integration — FlowRun wiring in commands/release.md.
 #
 # Contract under test:
 #   - release.md wires a FlowRun at entry (FLOW_RUN_STATE block, gated by

--- a/plugins/flow/tests/release-v3-integration.test.sh
+++ b/plugins/flow/tests/release-v3-integration.test.sh
@@ -1,0 +1,72 @@
+# Tests for #110 v3 integration — FlowRun wiring in commands/release.md.
+#
+# Contract under test:
+#   - release.md wires a FlowRun at entry (FLOW_RUN_STATE block, gated by
+#     flow.runtime.enabled), invokes Skill(run-state-management), records
+#     activities at the preflight→bump→tag→push boundaries, and transitions
+#     the run to a terminal state in Phase 5.
+#   - release is FlowRun-only (no FlowGoal) — it is not goal-bound.
+#   - The entry block (between FLOW_RUN_BLOCK_BEGIN/END) is runnable: it emits
+#     FLOW_RUN_STATE=create with RUN_ID + WORKFLOW=release when runtime is
+#     enabled, and FLOW_RUN_STATE=skip when flow.runtime.enabled is false.
+#
+# Prereq: jq (cascade-resolve.sh dependency). SKIPS gracefully if absent.
+
+if ! command -v jq >/dev/null 2>&1; then
+  _flow_test_begin "jq prerequisite"
+  _flow_assert_pass "SKIP: jq not installed"
+  return 0
+fi
+
+PLUGIN_DIR="$REPO_ROOT/plugins/flow"
+RELEASE_MD="$PLUGIN_DIR/commands/release.md"
+CASCADE="$PLUGIN_DIR/bin/cascade-resolve.sh"
+
+REL_CLEANUP=()
+_rel_cleanup() { local p; for p in "${REL_CLEANUP[@]:-}"; do [ -n "$p" ] && rm -rf "$p" 2>/dev/null; done; }
+trap _rel_cleanup EXIT
+
+CONTENT=$(cat "$RELEASE_MD")
+
+# --- source-presence: FlowRun wiring
+_flow_test_begin "release.md wires a FlowRun at entry"
+assert_contains "FLOW_RUN_BLOCK_BEGIN" "$CONTENT" "extractable FlowRun block markers present"
+assert_contains "FLOW_RUN_STATE=create" "$CONTENT" "emits create state"
+assert_contains "WORKFLOW=release" "$CONTENT" "names the release workflow"
+assert_contains "flow.runtime.enabled" "$CONTENT" "gated behind runtime.enabled"
+assert_contains "run-state-management" "$CONTENT" "delegates to run-state-management skill"
+
+_flow_test_begin "release.md records activities at phase boundaries"
+assert_contains "FlowActivity writes" "$CONTENT" "activity-write step documented"
+assert_match 'preflight . bump . tag . push' "$CONTENT" "documents the release phase order"
+
+_flow_test_begin "release.md transitions the FlowRun to terminal state"
+assert_contains "FlowRun terminal transition" "$CONTENT" "terminal-transition step documented"
+assert_contains "state.status: completed" "$CONTENT" "completes the run on success"
+assert_contains "cancelled" "$CONTENT" "cancels the run on failure (not left resumable)"
+
+_flow_test_begin "release is FlowRun-only (no FlowGoal)"
+assert_not_contains "goal-contract-capture" "$CONTENT" "release does not create a FlowGoal"
+assert_contains "goal=" "$CONTENT" "documents goal linkage is null (release is not goal-bound)"
+
+# --- functional: extract the entry block and run it under controlled settings
+_extract_run_block() {
+  awk '/FLOW_RUN_BLOCK_BEGIN/{f=1;next} /FLOW_RUN_BLOCK_END/{f=0} f' "$RELEASE_MD"
+}
+
+_flow_test_begin "entry block emits FLOW_RUN_STATE=create when runtime enabled (default)"
+WORK=$(mktemp -d -t flow-rel.XXXXXX); REL_CLEANUP+=("$WORK")
+_extract_run_block > "$WORK/block.sh"
+OUT=$(cd "$WORK" && CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" bash block.sh 2>/dev/null)
+assert_contains "FLOW_RUN_STATE=create" "$OUT" "default runtime → create"
+assert_contains "WORKFLOW=release" "$OUT" "workflow id emitted"
+assert_match 'RUN_ID=[0-9]{8}T[0-9]{6}Z-release' "$OUT" "RUN_ID is an ISO-compact timestamp slug"
+
+_flow_test_begin "entry block emits FLOW_RUN_STATE=skip when runtime disabled (v2 mode)"
+WORK2=$(mktemp -d -t flow-rel2.XXXXXX); REL_CLEANUP+=("$WORK2")
+mkdir -p "$WORK2/.claude"
+printf '%s\n' '{"flow":{"runtime":{"enabled":false}}}' > "$WORK2/.claude/settings.flow.json"
+_extract_run_block > "$WORK2/block.sh"
+OUT2=$(cd "$WORK2" && CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" bash block.sh 2>/dev/null)
+assert_contains "FLOW_RUN_STATE=skip" "$OUT2" "runtime disabled → skip (no-op for v2 projects)"
+assert_not_contains "FLOW_RUN_STATE=create" "$OUT2" "does not create when disabled"

--- a/plugins/flow/tests/review-v3-integration.test.sh
+++ b/plugins/flow/tests/review-v3-integration.test.sh
@@ -61,7 +61,10 @@ _extract_run_block > "$WORK/block.sh"
 OUT=$(cd "$WORK" && CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" bash block.sh 2>/dev/null)
 assert_contains "FLOW_RUN_STATE=create" "$OUT" "default runtime → create"
 assert_contains "WORKFLOW=review-pr" "$OUT" "workflow id emitted"
-assert_match 'RUN_ID=[0-9]{8}T[0-9]{6}Z-review' "$OUT" "RUN_ID is an ISO-compact timestamp slug"
+RUN_ID=$(printf '%s\n' "$OUT" | grep '^RUN_ID=' | cut -d= -f2-)
+SCHEMA_PAT=$(jq -r '.properties.metadata.properties.id.pattern' "$PLUGIN_DIR/schemas/v1/run.schema.json")
+if printf '%s' "$RUN_ID" | grep -qE "$SCHEMA_PAT"; then _flow_assert_pass "RUN_ID '$RUN_ID' conforms to run.schema"; else _flow_assert_fail "RUN_ID '$RUN_ID' violates /$SCHEMA_PAT/"; fi
+assert_contains "review" "$RUN_ID" "RUN_ID carries the review slug"
 
 _flow_test_begin "entry block emits FLOW_RUN_STATE=skip when runtime disabled (v2 mode)"
 WORK2=$(mktemp -d -t flow-rev2.XXXXXX); REV_CLEANUP+=("$WORK2")

--- a/plugins/flow/tests/review-v3-integration.test.sh
+++ b/plugins/flow/tests/review-v3-integration.test.sh
@@ -1,0 +1,73 @@
+# Tests for #110 v3 integration — FlowRun wiring in commands/review.md.
+#
+# Contract under test:
+#   - review.md wires a FlowRun at the end of Phase 1 (FLOW_RUN_STATE block,
+#     gated by flow.runtime.enabled), invokes Skill(run-state-management),
+#     records activities at the consolidate/report boundaries, and transitions
+#     the run to a terminal state at the end of the report phase.
+#   - review is FlowRun-only (no FlowGoal) — a review session is bounded by the
+#     PR and the PR's own review-thread state is the durable record.
+#   - The entry block (between FLOW_RUN_BLOCK_BEGIN/END) is runnable: it emits
+#     FLOW_RUN_STATE=create with RUN_ID + WORKFLOW=review-pr when runtime is
+#     enabled, and FLOW_RUN_STATE=skip when flow.runtime.enabled is false.
+#
+# Prereq: jq (cascade-resolve.sh dependency). SKIPS gracefully if absent.
+
+if ! command -v jq >/dev/null 2>&1; then
+  _flow_test_begin "jq prerequisite"
+  _flow_assert_pass "SKIP: jq not installed"
+  return 0
+fi
+
+PLUGIN_DIR="$REPO_ROOT/plugins/flow"
+REVIEW_MD="$PLUGIN_DIR/commands/review.md"
+CASCADE="$PLUGIN_DIR/bin/cascade-resolve.sh"
+
+REV_CLEANUP=()
+_rev_cleanup() { local p; for p in "${REV_CLEANUP[@]:-}"; do [ -n "$p" ] && rm -rf "$p" 2>/dev/null; done; }
+trap _rev_cleanup EXIT
+
+CONTENT=$(cat "$REVIEW_MD")
+
+# --- source-presence: FlowRun wiring
+_flow_test_begin "review.md wires a FlowRun at entry"
+assert_contains "FLOW_RUN_BLOCK_BEGIN" "$CONTENT" "extractable FlowRun block markers present"
+assert_contains "FLOW_RUN_STATE=create" "$CONTENT" "emits create state"
+assert_contains "WORKFLOW=review-pr" "$CONTENT" "names the review-pr workflow"
+assert_contains "flow.runtime.enabled" "$CONTENT" "gated behind runtime.enabled"
+assert_contains "run-state-management" "$CONTENT" "delegates to run-state-management skill"
+
+_flow_test_begin "review.md records activities at phase boundaries"
+assert_contains "FlowActivity writes" "$CONTENT" "activity-write step documented"
+assert_match 'preflight . fan-out . consolidate . report' "$CONTENT" "documents the review phase order"
+
+_flow_test_begin "review.md transitions the FlowRun to terminal state"
+assert_contains "FlowRun terminal transition" "$CONTENT" "terminal-transition step documented"
+assert_contains "state.status: completed" "$CONTENT" "completes the run on success"
+assert_contains "cancelled" "$CONTENT" "cancels the run on failure (not left resumable)"
+
+_flow_test_begin "review is FlowRun-only (no FlowGoal)"
+assert_not_contains "goal-contract-capture" "$CONTENT" "review does not create a FlowGoal"
+assert_contains "creates NO FlowGoal" "$CONTENT" "documents review creates no goal"
+
+# --- functional: extract the entry block and run it under controlled settings
+_extract_run_block() {
+  awk '/FLOW_RUN_BLOCK_BEGIN/{f=1;next} /FLOW_RUN_BLOCK_END/{f=0} f' "$REVIEW_MD"
+}
+
+_flow_test_begin "entry block emits FLOW_RUN_STATE=create when runtime enabled (default)"
+WORK=$(mktemp -d -t flow-rev.XXXXXX); REV_CLEANUP+=("$WORK")
+_extract_run_block > "$WORK/block.sh"
+OUT=$(cd "$WORK" && CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" bash block.sh 2>/dev/null)
+assert_contains "FLOW_RUN_STATE=create" "$OUT" "default runtime → create"
+assert_contains "WORKFLOW=review-pr" "$OUT" "workflow id emitted"
+assert_match 'RUN_ID=[0-9]{8}T[0-9]{6}Z-review' "$OUT" "RUN_ID is an ISO-compact timestamp slug"
+
+_flow_test_begin "entry block emits FLOW_RUN_STATE=skip when runtime disabled (v2 mode)"
+WORK2=$(mktemp -d -t flow-rev2.XXXXXX); REV_CLEANUP+=("$WORK2")
+mkdir -p "$WORK2/.claude"
+printf '%s\n' '{"flow":{"runtime":{"enabled":false}}}' > "$WORK2/.claude/settings.flow.json"
+_extract_run_block > "$WORK2/block.sh"
+OUT2=$(cd "$WORK2" && CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" bash block.sh 2>/dev/null)
+assert_contains "FLOW_RUN_STATE=skip" "$OUT2" "runtime disabled → skip (no-op for v2 projects)"
+assert_not_contains "FLOW_RUN_STATE=create" "$OUT2" "does not create when disabled"

--- a/plugins/flow/tests/review-v3-integration.test.sh
+++ b/plugins/flow/tests/review-v3-integration.test.sh
@@ -1,4 +1,4 @@
-# Tests for #110 v3 integration — FlowRun wiring in commands/review.md.
+# Tests for the v3 runtime integration — FlowRun wiring in commands/review.md.
 #
 # Contract under test:
 #   - review.md wires a FlowRun at the end of Phase 1 (FLOW_RUN_STATE block,

--- a/plugins/flow/tests/start-v3-integration.test.sh
+++ b/plugins/flow/tests/start-v3-integration.test.sh
@@ -1,0 +1,76 @@
+# Tests for #110 v3 integration — FlowRun wiring in commands/start.md.
+#
+# FlowGoal creation in start.md already exists (gated on requireGoalForStart)
+# and is covered elsewhere. This file covers only the NEW FlowRun layer:
+#   - start.md creates a FlowRun at entry (workflow=start-issue), linked to the
+#     FlowGoal, gated by flow.runtime.enabled, delegating to run-state-management.
+#   - It emits a workflow-run journal artifact (start is issue-scoped).
+#   - It writes activities at explore/plan/code/verify boundaries and transitions
+#     the run to a terminal state after the verdict.
+#   - The entry block is runnable and links the goal: ARGUMENTS=<issue> →
+#     GOAL_LINK=issue-<n>; no issue → GOAL_LINK=null; runtime off → skip.
+#
+# Prereq: jq. SKIPS gracefully if absent.
+
+if ! command -v jq >/dev/null 2>&1; then
+  _flow_test_begin "jq prerequisite"
+  _flow_assert_pass "SKIP: jq not installed"
+  return 0
+fi
+
+PLUGIN_DIR="$REPO_ROOT/plugins/flow"
+START_MD="$PLUGIN_DIR/commands/start.md"
+
+START_CLEANUP=()
+_start_cleanup() { local p; for p in "${START_CLEANUP[@]:-}"; do [ -n "$p" ] && rm -rf "$p" 2>/dev/null; done; }
+trap _start_cleanup EXIT
+
+CONTENT=$(cat "$START_MD")
+
+_flow_test_begin "start.md wires a FlowRun at entry"
+assert_contains "FLOW_RUN_BLOCK_BEGIN" "$CONTENT" "extractable FlowRun block markers present"
+assert_contains "FLOW_RUN_STATE=create" "$CONTENT" "emits create state"
+assert_contains "WORKFLOW=start-issue" "$CONTENT" "names the start-issue workflow"
+assert_contains "flow.runtime.enabled" "$CONTENT" "gated behind runtime.enabled"
+assert_contains "run-state-management" "$CONTENT" "delegates to run-state-management skill"
+
+_flow_test_begin "start.md links the FlowRun to the FlowGoal"
+assert_contains "GOAL_LINK" "$CONTENT" "computes goal linkage"
+assert_match 'goal=.{1,2}GOAL_LINK' "$CONTENT" "passes the goal link to run-state-management"
+
+_flow_test_begin "start.md emits a workflow-run journal artifact"
+assert_contains "--type workflow-run" "$CONTENT" "emits workflow-run artifact"
+assert_contains "workflow=start-issue" "$CONTENT" "artifact names the workflow"
+assert_match 'status=active' "$CONTENT" "artifact records active status at entry"
+
+_flow_test_begin "start.md records activities + terminal transition"
+assert_match 'preflight . explore . plan . code . verify' "$CONTENT" "documents the start phase order"
+assert_contains "state.status: completed" "$CONTENT" "completes the run on PASS verdict"
+assert_match 'state.status: blocked' "$CONTENT" "blocks (resumable) on FAIL/session-end"
+
+# --- functional: extract entry block, run with controlled ARGUMENTS + settings
+_extract_run_block() {
+  awk '/FLOW_RUN_BLOCK_BEGIN/{f=1;next} /FLOW_RUN_BLOCK_END/{f=0} f' "$START_MD"
+}
+
+_flow_test_begin "entry block creates + links goal when given an issue number"
+WORK=$(mktemp -d -t flow-start.XXXXXX); START_CLEANUP+=("$WORK")
+_extract_run_block > "$WORK/block.sh"
+OUT=$(cd "$WORK" && CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" ARGUMENTS="110" bash block.sh 2>/dev/null)
+assert_contains "FLOW_RUN_STATE=create" "$OUT" "issue arg → create"
+assert_contains "WORKFLOW=start-issue" "$OUT" "workflow id emitted"
+assert_contains "GOAL_LINK=issue-110" "$OUT" "goal linked to issue-110"
+assert_match 'RUN_ID=[0-9]{8}T[0-9]{6}Z-issue-110' "$OUT" "RUN_ID carries the issue slug"
+
+_flow_test_begin "entry block links goal=null when no issue number"
+OUT_NO=$(cd "$WORK" && CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" ARGUMENTS="" bash block.sh 2>/dev/null)
+assert_contains "GOAL_LINK=null" "$OUT_NO" "no issue → null goal link"
+
+_flow_test_begin "entry block skips when runtime disabled (v2 mode)"
+WORK2=$(mktemp -d -t flow-start2.XXXXXX); START_CLEANUP+=("$WORK2")
+mkdir -p "$WORK2/.claude"
+printf '%s\n' '{"flow":{"runtime":{"enabled":false}}}' > "$WORK2/.claude/settings.flow.json"
+_extract_run_block > "$WORK2/block.sh"
+OUT2=$(cd "$WORK2" && CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" ARGUMENTS="110" bash block.sh 2>/dev/null)
+assert_contains "FLOW_RUN_STATE=skip" "$OUT2" "runtime disabled → skip"
+assert_not_contains "FLOW_RUN_STATE=create" "$OUT2" "does not create when disabled"

--- a/plugins/flow/tests/start-v3-integration.test.sh
+++ b/plugins/flow/tests/start-v3-integration.test.sh
@@ -60,7 +60,14 @@ OUT=$(cd "$WORK" && CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" ARGUMENTS="110" bash block.
 assert_contains "FLOW_RUN_STATE=create" "$OUT" "issue arg → create"
 assert_contains "WORKFLOW=start-issue" "$OUT" "workflow id emitted"
 assert_contains "GOAL_LINK=issue-110" "$OUT" "goal linked to issue-110"
-assert_match 'RUN_ID=[0-9]{8}T[0-9]{6}Z-issue-110' "$OUT" "RUN_ID carries the issue slug"
+RUN_ID=$(printf '%s\n' "$OUT" | grep '^RUN_ID=' | cut -d= -f2-)
+SCHEMA_PAT=$(jq -r '.properties.metadata.properties.id.pattern' "$PLUGIN_DIR/schemas/v1/run.schema.json")
+if printf '%s' "$RUN_ID" | grep -qE "$SCHEMA_PAT"; then
+  _flow_assert_pass "RUN_ID '$RUN_ID' conforms to run.schema metadata.id pattern"
+else
+  _flow_assert_fail "RUN_ID '$RUN_ID' violates run.schema pattern /$SCHEMA_PAT/"
+fi
+assert_contains "issue-110" "$RUN_ID" "RUN_ID carries the issue slug"
 
 _flow_test_begin "entry block links goal=null when no issue number"
 OUT_NO=$(cd "$WORK" && CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" ARGUMENTS="" bash block.sh 2>/dev/null)

--- a/plugins/flow/tests/start-v3-integration.test.sh
+++ b/plugins/flow/tests/start-v3-integration.test.sh
@@ -1,4 +1,4 @@
-# Tests for #110 v3 integration — FlowRun wiring in commands/start.md.
+# Tests for the v3 runtime integration — FlowRun wiring in commands/start.md.
 #
 # FlowGoal creation in start.md already exists (gated on requireGoalForStart)
 # and is covered elsewhere. This file covers only the NEW FlowRun layer:

--- a/plugins/flow/tests/status-triggers-v3-integration.test.sh
+++ b/plugins/flow/tests/status-triggers-v3-integration.test.sh
@@ -1,4 +1,4 @@
-# Tests for #110 v3 integration — status Active Triggers section + settings flips.
+# Tests for the v3 runtime integration — status Active Triggers section + settings flips.
 #
 #   - AC6 sub-part: /flow:status surfaces an Active Triggers section reading
 #     .flow/triggers/*.trigger.yaml, gated behind flow.triggers.enabled, with a
@@ -39,7 +39,7 @@ assert_equal "true" "$WF" "flow.workflows.enabled is true"
 assert_equal "true" "$TR" "flow.triggers.enabled is true"
 
 _flow_test_begin "goal-creation default NOT flipped here (owned by the UX layer)"
-# #110 must NOT introduce a binary requireGoalForStart:true default — that
-# migration belongs to the UX layer. Assert the plugin default stays false.
+# The FlowRun integration must NOT introduce a binary requireGoalForStart:true
+# default — that migration belongs to the UX layer. Assert the default stays false.
 RGS=$(jq -r '.flow.goals.requireGoalForStart' "$SETTINGS")
 assert_equal "false" "$RGS" "requireGoalForStart default left false (not flipped by this work)"

--- a/plugins/flow/tests/status-triggers-v3-integration.test.sh
+++ b/plugins/flow/tests/status-triggers-v3-integration.test.sh
@@ -1,0 +1,44 @@
+# Tests for #110 v3 integration — status Active Triggers section + settings flips.
+#
+#   - AC6 sub-part: /flow:status surfaces an Active Triggers section reading
+#     .flow/triggers/*.trigger.yaml, gated behind flow.triggers.enabled, with a
+#     render block in the output template.
+#   - AC8: plugin default settings flip flow.workflows.enabled and
+#     flow.triggers.enabled to true.
+#
+# Prereq: jq (for the settings assertions). SKIPS gracefully if absent.
+
+if ! command -v jq >/dev/null 2>&1; then
+  _flow_test_begin "jq prerequisite"
+  _flow_assert_pass "SKIP: jq not installed"
+  return 0
+fi
+
+PLUGIN_DIR="$REPO_ROOT/plugins/flow"
+STATUS_MD="$PLUGIN_DIR/commands/status.md"
+SETTINGS="$PLUGIN_DIR/settings.json"
+
+CONTENT=$(cat "$STATUS_MD")
+
+_flow_test_begin "status.md has an Active Triggers section (AC6)"
+assert_contains "### Active Triggers" "$CONTENT" "Active Triggers heading present (both reader + render)"
+assert_contains ".flow/triggers" "$CONTENT" "reads the triggers directory"
+assert_contains "*.trigger.yaml" "$CONTENT" "enumerates trigger yamls"
+assert_contains "flow.triggers.enabled" "$CONTENT" "gated behind the triggers flag"
+assert_contains "last_fired" "$CONTENT" "surfaces last-fired per trigger"
+
+_flow_test_begin "status.md triggers reader has a v2 disabled sentinel + symlink defense"
+assert_contains "STATE=disabled" "$CONTENT" "v2 mode renders disabled"
+assert_contains "symlink rejected" "$CONTENT" "symlink defense on trigger yamls"
+
+_flow_test_begin "settings flip workflows.enabled + triggers.enabled to true (AC8)"
+WF=$(jq -r '.flow.workflows.enabled' "$SETTINGS")
+TR=$(jq -r '.flow.triggers.enabled' "$SETTINGS")
+assert_equal "true" "$WF" "flow.workflows.enabled is true"
+assert_equal "true" "$TR" "flow.triggers.enabled is true"
+
+_flow_test_begin "goal-creation default NOT flipped here (owned by the UX layer)"
+# #110 must NOT introduce a binary requireGoalForStart:true default — that
+# migration belongs to the UX layer. Assert the plugin default stays false.
+RGS=$(jq -r '.flow.goals.requireGoalForStart' "$SETTINGS")
+assert_equal "false" "$RGS" "requireGoalForStart default left false (not flipped by this work)"

--- a/plugins/flow/tests/status-triggers-v3-integration.test.sh
+++ b/plugins/flow/tests/status-triggers-v3-integration.test.sh
@@ -25,7 +25,8 @@ assert_contains "### Active Triggers" "$CONTENT" "Active Triggers heading presen
 assert_contains ".flow/triggers" "$CONTENT" "reads the triggers directory"
 assert_contains "*.trigger.yaml" "$CONTENT" "enumerates trigger yamls"
 assert_contains "flow.triggers.enabled" "$CONTENT" "gated behind the triggers flag"
-assert_contains "last_fired" "$CONTENT" "surfaces last-fired per trigger"
+assert_contains "enabled" "$CONTENT" "surfaces the enabled state per trigger (schema-backed metadata.enabled)"
+assert_not_contains "state.last_fired" "$CONTENT" "no phantom state.last_fired field (not in the trigger schema)"
 
 _flow_test_begin "status.md triggers reader has a v2 disabled sentinel + symlink defense"
 assert_contains "STATE=disabled" "$CONTENT" "v2 mode renders disabled"

--- a/plugins/flow/workflows/address-pr.workflow.yaml
+++ b/plugins/flow/workflows/address-pr.workflow.yaml
@@ -17,8 +17,7 @@ required_skills:
   - change-classification
   - holdout-validation
   - runtime-verification
-  - goal-contract-capture
-  - goal-lifecycle
+  - goal-evidence-ledger
   - run-state-management
 
 required_agents:
@@ -44,14 +43,10 @@ phases:
         type: skill
         skill: feedback-resolution
         evidence: categorized_findings_table
-      - id: goal_creation
-        type: skill
-        skill: goal-contract-capture
-        evidence: address_goal_yaml
 
   - id: resolve
     type: loop
-    loop_over: goal.acceptance_criteria
+    loop_over: categorized_findings
     activities:
       - id: implement_fix
         type: task
@@ -81,10 +76,10 @@ phases:
       - id: reply_to_threads
         type: bash
         evidence: thread_replies
-      - id: goal_evaluation
-        type: evaluation
-        command: /flow:goal evaluate
-        evidence: goal_verdict
+      - id: workflow_run_terminal
+        type: skill
+        skill: run-state-management
+        evidence: workflow_run_completed
 
 completion_gate:
   documented_requirements:
@@ -93,7 +88,7 @@ completion_gate:
     - runtime_verification_pass_or_valid_skip
     - holdout_validation_pass_or_p3_only
     - thread_replies_posted
-    - goal_status_achieved
+    - flow_run_completed
 
 tier_classification:
   file_edits: autonomous

--- a/plugins/flow/workflows/review-pr.workflow.yaml
+++ b/plugins/flow/workflows/review-pr.workflow.yaml
@@ -15,8 +15,6 @@ inputs:
 required_skills:
   - capability-discovery
   - holdout-validation
-  - goal-contract-capture
-  - goal-lifecycle
   - run-state-management
 
 required_agents:
@@ -38,10 +36,6 @@ phases:
   - id: fan_out
     type: parallel_then_judge
     activities:
-      - id: goal_creation
-        type: skill
-        skill: goal-contract-capture
-        evidence: review_goal_yaml
       - id: parallel_reviewer_dispatch
         type: agent
         agent: code-reviewer
@@ -67,17 +61,17 @@ phases:
       - id: review_cycle_artifact
         type: bash
         evidence: review_cycle_journal_entry
-      - id: goal_evaluation
-        type: evaluation
-        command: /flow:goal evaluate
-        evidence: goal_verdict
+      - id: workflow_run_terminal
+        type: skill
+        skill: run-state-management
+        evidence: workflow_run_completed
 
 completion_gate:
   documented_requirements:
     - findings_consolidated
     - review_comment_posted_or_no_findings
     - holdout_validation_pass_or_p3_only
-    - goal_status_achieved
+    - flow_run_completed
 
 tier_classification:
   pr_comment: journal


### PR DESCRIPTION
## Summary

Closes #110. Wires the v3 runtime layer (shipped as infrastructure in #109) into the workflow commands so FlowRuns and FlowGoals are automatic rather than opt-in.

**Scope correction (verified, not assumed):** the issue assumed #109 left the commands "byte-identical to v2." In reality #109's later cycles already shipped the **FlowGoal** machinery — `start` auto-creates goals, `pr` has the 5-state gate + override, `merge` gates on achievement, and `status`/`learn` already mine `.flow/`. So **AC3/AC4/AC5/AC6-main/AC7 were already satisfied**. The genuine consistent gap was the **FlowRun** layer (AC1/AC2), which this PR delivers, plus the smaller remaining pieces. The goal layer and `requireGoalForStart` (owned by #111) are left intact.

## What changed

- **FlowRun wired into all 7 commands** — runtime-gated entry blocks (`# FLOW_RUN_BLOCK` sentinels), `Skill(run-state-management)` delegation, phase-boundary FlowActivities, terminal transitions, best-effort `workflow-run` journal artifacts:
  - `release`, `start`, `debug`, `merge` create their own runs; `review`/`address` are **FlowRun-only** (no FlowGoal — a review/address session is bounded by the PR, per #111 AC-3); `pr` appends a `pr_create` activity to the branch's `start-issue` run (pr is that workflow's tail, not its own).
- **`debug`** gained FlowGoal creation (2nd goal-creating command) via `goal-contract-capture` after hypothesis confirmation + a `debug` row in the `specification-capture` per-invoker scope table.
- **`pr`** override now records an `escalation-resolved` artifact + links FlowEvidence sidecars in the PR body; **`merge`** added the linked-run-completed check (Tier 3, no override).
- **`status`** got an **Active Triggers** section (reads `.flow/triggers/*.trigger.yaml`, surfaces schema-backed `metadata.enabled`).
- **Settings**: `flow.workflows.enabled` + `flow.triggers.enabled` flipped to `true` (still cascade-overridable for v2.x). `requireGoalForStart` left `false` (goal-creation default owned by #111).
- **CHANGELOG** entry under Unreleased.
- **8 new test files** (7 command + status/settings), all under the zero-dependency bash harness.

## Acceptance criteria

All 12 ACs verified — see `.decisions/issue-110.md` for the AC→verification map. Highlights:
- AC1/AC2: FlowRun + `workflow-run` wiring asserted per command.
- AC3: start/debug create goals; review/address assert **no** goal file.
- AC4/AC5: pr gate (overridable) vs merge gate (Tier 3, no override) asserted distinctly.
- AC8: settings flags asserted true; `requireGoalForStart` asserted still false.
- AC9/AC11: `bash plugins/flow/tests/run.sh` → **TOTAL pass=785 fail=0** (baseline was 646).

## Review

An independent code-review pass ran during development and surfaced 6 findings — all fixed fix-forward and re-verified (APPROVE, zero remaining):
- **P1:** every `RUN_ID` was schema-invalid (`%Y%m%dT…` vs the run.schema-required `%Y-%m-%dT…`); debug's goal id carried illegal uppercase. Tests now validate emitted ids against the **actual JSON schemas** via `jq` (the gap that let the format bug slip past regex-only checks).
- **P1:** release phase order contradicted `release.workflow.yaml` → realigned (`preflight → bump → confirm → tag`).
- **P2:** `review-pr`/`address-pr` workflow YAMLs still declared goal steps → reconciled to FlowRun-only.
- **P2/P3:** pr/start journal blocks relied on non-persisting `!`-block vars → made self-contained.
- **P2:** status read a phantom `state.last_fired` → switched to schema-backed `metadata.enabled`.

## Test plan

- [x] `bash plugins/flow/tests/run.sh` exits 0 (785 assertions, 0 fail)
- [x] Each entry block extracted + executed against a scratch repo (create + v2-skip paths)
- [x] Emitted RUN_IDs / GOAL_LINKs validated against `run.schema.json` / `goal.schema.json`
- [x] Edited workflow YAMLs validate against `workflow.schema.json` (suite includes schema tests)
- [x] No regressions in existing per-command tests
- [ ] Runtime/visual verification: N/A — diff is markdown command definitions + bash tests + workflow YAML; the test harness is the runtime.