### PR TITLE
ci: CodeQL advanced setup with submodule checkout

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,55 @@
+name: "CodeQL"
+
+# Advanced setup (replaces GitHub's CodeQL "default setup"). Default setup's
+# checkout did not authenticate the git submodule fetch, so the python analysis
+# died at "Checkout repository" — the repo's only python lives in the
+# `plugins/agent-capability-standard` submodule. This workflow checks the
+# submodule out explicitly with credentials so CodeQL can scan it.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: python
+            build-mode: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # The repo's python lives in a submodule; CodeQL needs it present to
+          # scan. persist-credentials keeps the token so the submodule fetch
+          # authenticates (the default-setup checkout failed here with
+          # "could not read Username for https://github.com").
+          submodules: recursive
+          persist-credentials: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # Default query suite — matches the prior default-setup config
+          # (query_suite: default). This change fixes the submodule checkout
+          # only; it does not widen scan scope.
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Replaces GitHub's CodeQL **default setup** with an explicit advanced-setup workflow (`.github/workflows/codeql.yml`).

**Why:** the default-setup "Analyze (python)" job was failing at the **Checkout repository** step with `could not read Username for 'https://github.com'` (git exit 128) — it never ran any analysis. Root cause: the repo's only python lives in the public git submodule `plugins/agent-capability-standard`, and default setup's checkout didn't authenticate the submodule fetch. (Surfaced on PR #114; unrelated to that diff.)

**Fix:** advanced setup runs `actions/checkout@v4` with `submodules: recursive` + `persist-credentials: true` before `init`/`analyze`, so the submodule is present and the fetch is authenticated.

## Behavior-preserving

- Languages unchanged: `actions`, `python` (matches prior default-setup config).
- Query suite unchanged: default (omitting `queries` uses the default suite).
- `build-mode: none` for both languages (no autobuild — avoids the autobuild git step entirely).

## Activation note

Advanced setup and default setup are mutually exclusive — **default setup must be disabled** (repo → Settings → Security → Code scanning) for this workflow to take effect; otherwise the analyze step is rejected with a "default setup is enabled" conflict.

## Test plan

- [ ] With default setup disabled, this PR's own `Analyze (python)` run completes the Checkout step and produces analysis (no `could not read Username`).
- [ ] `Analyze (actions)` still passes.