### PR TITLE
fix(flow): merge-aware force-branch-delete in block-destructive hook

### DIFF
--- a/plugins/flow/hooks/scripts/block-destructive.sh
+++ b/plugins/flow/hooks/scripts/block-destructive.sh
@@ -33,31 +33,49 @@ if echo "$COMMAND" | grep -qE 'rm\s+(-[rfRF]+\s+)+|rm\s+(-[a-zA-Z]\s+)*-[a-zA-Z]
   fi
 fi
 
-# Force branch deletion (git branch -D): allowed ONLY when every target branch
-# is provably merged into the default branch. `git branch -d` (the safe form)
-# cannot delete squash-merged branches — git doesn't see their commits on the
-# default branch — so a blanket -D block makes squash-merged cleanup impossible.
-# This check distinguishes merged (safe to drop) from unmerged (would lose work)
-# and fails safe (blocks) on any uncertainty.
-if echo "$COMMAND" | grep -qE 'git[[:space:]]+branch[[:space:]]+-D([[:space:]]|$)'; then
+# Force branch deletion: allowed ONLY when every target branch is provably
+# merged into the default branch. `git branch -d` (the safe form) cannot delete
+# squash-merged branches — git doesn't see their commits on the default branch —
+# so a blanket force-delete block makes squash-merged cleanup impossible. This
+# check distinguishes merged (safe to drop) from unmerged (would lose work) and
+# fails safe (blocks) on any uncertainty.
+#
+# Force-delete is detected in every equivalent form: -D, a combined short
+# cluster containing D (-Df, -fD, -rD), or a delete flag (-d/--delete) together
+# with a force flag (-f/--force). Plain `git branch -d` (safe delete, no force)
+# is NOT matched and passes through.
+IS_FORCE_DELETE=0
+if printf '%s' "$COMMAND" | grep -qE 'git[[:space:]]+branch([[:space:]]|$)'; then
+  if printf '%s' "$COMMAND" | grep -qE '(^|[[:space:]])-[A-Za-z]*D[A-Za-z]*([[:space:]]|$)'; then
+    IS_FORCE_DELETE=1
+  elif printf '%s' "$COMMAND" | grep -qE '(^|[[:space:]])(--delete|-[A-Za-z]*d[A-Za-z]*)([[:space:]]|$)' \
+    && printf '%s' "$COMMAND" | grep -qE '(^|[[:space:]])(--force|-[A-Za-z]*f[A-Za-z]*)([[:space:]]|$)'; then
+    IS_FORCE_DELETE=1
+  fi
+fi
+
+if [ "$IS_FORCE_DELETE" = "1" ]; then
   set +e          # this block is fully conditional and always exits explicitly
   set -f          # no pathname expansion of parsed tokens
 
-  # Targets = non-flag tokens after the -D flag.
+  # Targets = every non-flag token that isn't `git`/`branch`. A force-delete
+  # chained into a compound command (`&& rm ...`, `; ...`, `| ...`) leaves
+  # junk tokens that fail the show-ref check below, so compounds always fall
+  # through to BLOCK rather than being allowed on a merged target.
   TARGETS=$(printf '%s' "$COMMAND" | awk '{
-    seen=0
     for (i=1;i<=NF;i++) {
-      if (seen) { if ($i ~ /^-/) continue; print $i }
-      else if ($i == "-D") seen=1
+      if ($i == "git" || $i == "branch") continue
+      if ($i ~ /^-/) continue
+      print $i
     }
   }')
 
   if [ -z "$TARGETS" ]; then
-    echo "BLOCKED: Force branch deletion with no resolvable target. Run -D manually if intended." >&2
+    echo "BLOCKED: Force branch deletion with no resolvable target. Run it manually if intended." >&2
     exit 2
   fi
   if ! command -v git >/dev/null 2>&1 || ! git rev-parse --git-dir >/dev/null 2>&1; then
-    echo "BLOCKED: Force branch deletion — cannot verify merge status (not a git repo / git unavailable). Run -D manually if intended." >&2
+    echo "BLOCKED: Force branch deletion — cannot verify merge status (not a git repo / git unavailable). Run it manually if intended." >&2
     exit 2
   fi
 
@@ -72,8 +90,18 @@ if echo "$COMMAND" | grep -qE 'git[[:space:]]+branch[[:space:]]+-D([[:space:]]|$
     done
   fi
   if [ -z "$DEFAULT" ]; then
-    echo "BLOCKED: Force branch deletion — cannot resolve a default branch to verify against. Run -D manually if intended." >&2
+    echo "BLOCKED: Force branch deletion — cannot resolve a default branch to verify against. Run it manually if intended." >&2
     exit 2
+  fi
+
+  # Candidate "merged into" refs: the local default branch plus, if present, the
+  # remote-tracking default. Accepting origin/<default> means a branch already
+  # merged on the remote is deletable even when the local default is behind
+  # (un-pulled) — the work is preserved on the remote, so this is safe and only
+  # ever turns a false-block into a correct allow (never a false allow).
+  DEFAULT_REFS="$DEFAULT"
+  if git show-ref --verify --quiet "refs/remotes/origin/$DEFAULT"; then
+    DEFAULT_REFS="$DEFAULT_REFS origin/$DEFAULT"
   fi
 
   for BR in $TARGETS; do
@@ -82,36 +110,37 @@ if echo "$COMMAND" | grep -qE 'git[[:space:]]+branch[[:space:]]+-D([[:space:]]|$
       exit 2
     fi
     if ! git show-ref --verify --quiet "refs/heads/$BR"; then
-      echo "BLOCKED: Force branch deletion — '$BR' is not a local branch (cannot verify merge status). Run -D manually if intended." >&2
+      echo "BLOCKED: Force branch deletion — '$BR' is not a local branch (cannot verify merge status). Run it manually if intended." >&2
       exit 2
     fi
 
     MERGED=0
-    # (1) Regular / fast-forward merge: branch tip is an ancestor of the default.
-    if git merge-base --is-ancestor "$BR" "$DEFAULT" 2>/dev/null; then
-      MERGED=1
-    else
+    for REF in $DEFAULT_REFS; do
+      # (1) Regular / fast-forward merge: branch tip is an ancestor of the default.
+      if git merge-base --is-ancestor "$BR" "$REF" 2>/dev/null; then
+        MERGED=1; break
+      fi
       # (2) Squash merge: the branch's *combined* change is patch-equivalent to a
       # commit already in the default branch. Synthesize a single commit of the
       # branch's tree atop the merge-base, then ask `git cherry` whether the
       # default already contains an equivalent patch ('-' prefix == present).
       # Author/committer identity is forced inline so commit-tree never depends
       # on (possibly unset) git config.
-      MB=$(git merge-base "$DEFAULT" "$BR" 2>/dev/null)
+      MB=$(git merge-base "$REF" "$BR" 2>/dev/null)
       TREE=$(git rev-parse --quiet --verify "$BR^{tree}" 2>/dev/null)
       if [ -n "$MB" ] && [ -n "$TREE" ]; then
         SYNTH=$(GIT_AUTHOR_NAME=_ GIT_AUTHOR_EMAIL=_@_ GIT_COMMITTER_NAME=_ GIT_COMMITTER_EMAIL=_@_ \
                 git commit-tree "$TREE" -p "$MB" -m _ 2>/dev/null)
         if [ -n "$SYNTH" ]; then
-          case "$(git cherry "$DEFAULT" "$SYNTH" 2>/dev/null | head -n1)" in
-            -*) MERGED=1 ;;
+          case "$(git cherry "$REF" "$SYNTH" 2>/dev/null | head -n1)" in
+            -*) MERGED=1; break ;;
           esac
         fi
       fi
-    fi
+    done
 
     if [ "$MERGED" != "1" ]; then
-      echo "BLOCKED: '$BR' is not merged into '$DEFAULT' — force-delete would lose unmerged work. Run -D manually if intended." >&2
+      echo "BLOCKED: '$BR' is not merged into '$DEFAULT' — force-delete would lose unmerged work. Run it manually if intended." >&2
       exit 2
     fi
   done

--- a/plugins/flow/hooks/scripts/block-destructive.sh
+++ b/plugins/flow/hooks/scripts/block-destructive.sh
@@ -33,10 +33,91 @@ if echo "$COMMAND" | grep -qE 'rm\s+(-[rfRF]+\s+)+|rm\s+(-[a-zA-Z]\s+)*-[a-zA-Z]
   fi
 fi
 
-# Block git branch -D (force delete)
-if echo "$COMMAND" | grep -qE 'git\s+branch\s+-D\s'; then
-  echo "BLOCKED: Force branch deletion detected. Use 'git branch -d' for safe delete, or run -D manually." >&2
-  exit 2
+# Force branch deletion (git branch -D): allowed ONLY when every target branch
+# is provably merged into the default branch. `git branch -d` (the safe form)
+# cannot delete squash-merged branches — git doesn't see their commits on the
+# default branch — so a blanket -D block makes squash-merged cleanup impossible.
+# This check distinguishes merged (safe to drop) from unmerged (would lose work)
+# and fails safe (blocks) on any uncertainty.
+if echo "$COMMAND" | grep -qE 'git[[:space:]]+branch[[:space:]]+-D([[:space:]]|$)'; then
+  set +e          # this block is fully conditional and always exits explicitly
+  set -f          # no pathname expansion of parsed tokens
+
+  # Targets = non-flag tokens after the -D flag.
+  TARGETS=$(printf '%s' "$COMMAND" | awk '{
+    seen=0
+    for (i=1;i<=NF;i++) {
+      if (seen) { if ($i ~ /^-/) continue; print $i }
+      else if ($i == "-D") seen=1
+    }
+  }')
+
+  if [ -z "$TARGETS" ]; then
+    echo "BLOCKED: Force branch deletion with no resolvable target. Run -D manually if intended." >&2
+    exit 2
+  fi
+  if ! command -v git >/dev/null 2>&1 || ! git rev-parse --git-dir >/dev/null 2>&1; then
+    echo "BLOCKED: Force branch deletion — cannot verify merge status (not a git repo / git unavailable). Run -D manually if intended." >&2
+    exit 2
+  fi
+
+  # Resolve the default branch: origin/HEAD, else local main/master.
+  DEFAULT=""
+  if DH=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null); then
+    DEFAULT="${DH#origin/}"
+  fi
+  if [ -z "$DEFAULT" ]; then
+    for cand in main master; do
+      if git show-ref --verify --quiet "refs/heads/$cand"; then DEFAULT="$cand"; break; fi
+    done
+  fi
+  if [ -z "$DEFAULT" ]; then
+    echo "BLOCKED: Force branch deletion — cannot resolve a default branch to verify against. Run -D manually if intended." >&2
+    exit 2
+  fi
+
+  for BR in $TARGETS; do
+    if [ "$BR" = "$DEFAULT" ]; then
+      echo "BLOCKED: Refusing to force-delete the default branch '$DEFAULT'." >&2
+      exit 2
+    fi
+    if ! git show-ref --verify --quiet "refs/heads/$BR"; then
+      echo "BLOCKED: Force branch deletion — '$BR' is not a local branch (cannot verify merge status). Run -D manually if intended." >&2
+      exit 2
+    fi
+
+    MERGED=0
+    # (1) Regular / fast-forward merge: branch tip is an ancestor of the default.
+    if git merge-base --is-ancestor "$BR" "$DEFAULT" 2>/dev/null; then
+      MERGED=1
+    else
+      # (2) Squash merge: the branch's *combined* change is patch-equivalent to a
+      # commit already in the default branch. Synthesize a single commit of the
+      # branch's tree atop the merge-base, then ask `git cherry` whether the
+      # default already contains an equivalent patch ('-' prefix == present).
+      # Author/committer identity is forced inline so commit-tree never depends
+      # on (possibly unset) git config.
+      MB=$(git merge-base "$DEFAULT" "$BR" 2>/dev/null)
+      TREE=$(git rev-parse --quiet --verify "$BR^{tree}" 2>/dev/null)
+      if [ -n "$MB" ] && [ -n "$TREE" ]; then
+        SYNTH=$(GIT_AUTHOR_NAME=_ GIT_AUTHOR_EMAIL=_@_ GIT_COMMITTER_NAME=_ GIT_COMMITTER_EMAIL=_@_ \
+                git commit-tree "$TREE" -p "$MB" -m _ 2>/dev/null)
+        if [ -n "$SYNTH" ]; then
+          case "$(git cherry "$DEFAULT" "$SYNTH" 2>/dev/null | head -n1)" in
+            -*) MERGED=1 ;;
+          esac
+        fi
+      fi
+    fi
+
+    if [ "$MERGED" != "1" ]; then
+      echo "BLOCKED: '$BR' is not merged into '$DEFAULT' — force-delete would lose unmerged work. Run -D manually if intended." >&2
+      exit 2
+    fi
+  done
+
+  # Every target is merged into the default branch — safe to drop.
+  exit 0
 fi
 
 # Block git checkout -- . (discard all changes)

--- a/plugins/flow/tests/block-destructive-branch.test.sh
+++ b/plugins/flow/tests/block-destructive-branch.test.sh
@@ -112,8 +112,44 @@ _run_hook "$R" "git clean -fd"; assert_exit 2 "$?" "git clean -f still blocked"
 _run_hook "$R" "rm -rf /some/important/path"; assert_exit 2 "$?" "rm -rf still blocked"
 _run_hook "$R" "git restore ."; assert_exit 2 "$?" "git restore . still blocked"
 
+# --- force-delete EQUIVALENT forms are also merge-aware (not bypassed)
+_flow_test_begin "force-delete equivalents (--delete --force, -Df, -fD) are merge-aware"
+R=$(_new_repo)
+( cd "$R" && git checkout -qb gone && echo a > a.txt && git add a.txt && git commit -qm ca \
+  && git checkout -q main && git merge -q --no-ff gone -m "merge gone" \
+  && git checkout -qb live && echo b > b.txt && git add b.txt && git commit -qm cb \
+  && git checkout -q main ) >/dev/null 2>&1
+# merged target via each equivalent form → allowed
+_run_hook "$R" "git branch --delete --force gone"; assert_exit 0 "$?" "--delete --force on merged → allowed"
+_run_hook "$R" "git branch -Df gone"; assert_exit 0 "$?" "-Df on merged → allowed"
+_run_hook "$R" "git branch -fD gone"; assert_exit 0 "$?" "-fD on merged → allowed"
+# unmerged target via each equivalent form → blocked (the bypass is closed)
+_run_hook "$R" "git branch --delete --force live"; assert_exit 2 "$?" "--delete --force on unmerged → blocked"
+_run_hook "$R" "git branch -Df live"; assert_exit 2 "$?" "-Df on unmerged → blocked"
+_run_hook "$R" "git branch -d --force live"; assert_exit 2 "$?" "-d --force on unmerged → blocked"
+
+# --- merged into origin/<default> while local default is behind → allowed
+_flow_test_begin "force-delete allowed when merged into origin/<default> (local behind)"
+R=$(_new_repo)
+( cd "$R" \
+  && git checkout -qb feat && echo x > f.txt && git add f.txt && git commit -qm c1 \
+  && git checkout -q main && git merge -q --squash feat && git commit -qm "squash feat" \
+  && git update-ref refs/remotes/origin/main main \
+  && git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main \
+  && git reset -q --hard HEAD~1 ) >/dev/null 2>&1   # local main now BEHIND origin/main
+_run_hook "$R" "git branch -D feat"; assert_exit 0 "$?" "merged on origin/main but not local → allowed"
+
+# --- compound command with a force-delete falls through to BLOCK
+_flow_test_begin "force-delete chained into a compound command is blocked"
+R=$(_new_repo)
+( cd "$R" && git checkout -qb m1 && echo a > a.txt && git add a.txt && git commit -qm ca \
+  && git checkout -q main && git merge -q --no-ff m1 -m "merge m1" ) >/dev/null 2>&1
+# m1 is merged, but the chained tail must NOT be greenlit → block
+_run_hook "$R" "git branch -D m1 && echo pwned"; assert_exit 2 "$?" "compound force-delete → blocked (no false allow)"
+
 # --- ordinary commands pass
 _flow_test_begin "non-destructive commands pass"
 R=$(_new_repo)
 _run_hook "$R" "git status"; assert_exit 0 "$?" "git status allowed"
 _run_hook "$R" "rm -rf node_modules"; assert_exit 0 "$?" "rm -rf in safe dir allowed"
+_run_hook "$R" "git branch -f other main"; assert_exit 0 "$?" "git branch -f (force-create/move, no delete) allowed"

--- a/plugins/flow/tests/block-destructive-branch.test.sh
+++ b/plugins/flow/tests/block-destructive-branch.test.sh
@@ -1,0 +1,119 @@
+# Tests for the merge-aware force-branch-delete rule in
+# hooks/scripts/block-destructive.sh.
+#
+# Contract under test: a force branch-delete is allowed ONLY when every target
+# branch is provably merged into the default branch — via ancestor check
+# (regular/fast-forward merge) or synthetic-commit patch-equivalence (squash
+# merge). Otherwise, and on any uncertainty, it is blocked (exit 2). All other
+# destructive blocks are unchanged.
+#
+# The hook reads a JSON payload on stdin ({"tool_input":{"command":"..."}}) and
+# exits 0 (allow) or 2 (block). It inspects the git repo in its CWD, so each
+# scenario runs the hook from inside a purpose-built scratch repo.
+#
+# Prereq: jq (the hook hard-requires it) + git. SKIPS gracefully otherwise.
+
+if ! command -v jq >/dev/null 2>&1; then
+  _flow_test_begin "jq prerequisite"; _flow_assert_pass "SKIP: jq not installed"; return 0
+fi
+if ! command -v git >/dev/null 2>&1; then
+  _flow_test_begin "git prerequisite"; _flow_assert_pass "SKIP: git not installed"; return 0
+fi
+
+HOOK="$REPO_ROOT/plugins/flow/hooks/scripts/block-destructive.sh"
+
+BD_CLEANUP=()
+_bd_cleanup() { local p; for p in "${BD_CLEANUP[@]:-}"; do [ -n "$p" ] && rm -rf "$p" 2>/dev/null; done; }
+trap _bd_cleanup EXIT
+
+# Run the hook from inside <repo> with <command>; returns the hook's exit code.
+_run_hook() {
+  local repo="$1" cmd="$2" json
+  json=$(printf '%s' "$cmd" | jq -Rs .)
+  ( cd "$repo" && printf '{"tool_input":{"command":%s}}' "$json" | bash "$HOOK" ) >/dev/null 2>&1
+}
+
+# Fresh repo on `main` with one commit; prints its path.
+_new_repo() {
+  local d; d=$(mktemp -d -t flow-bd.XXXXXX); BD_CLEANUP+=("$d")
+  ( cd "$d" \
+    && git init -q -b main \
+    && git config user.email t@t.test && git config user.name tester \
+    && echo base > base.txt && git add base.txt && git commit -qm m0 ) >/dev/null 2>&1
+  printf '%s' "$d"
+}
+
+# --- regular (no-ff) merge → branch tip is an ancestor of main → allow
+_flow_test_begin "force-delete allowed for a normally-merged branch"
+R=$(_new_repo)
+( cd "$R" && git checkout -qb feat && echo x > f.txt && git add f.txt && git commit -qm c1 \
+  && git checkout -q main && git merge -q --no-ff feat -m "merge feat" ) >/dev/null 2>&1
+_run_hook "$R" "git branch -D feat"; assert_exit 0 "$?" "merged branch (--no-ff) → allowed"
+
+# --- squash merge → branch NOT an ancestor, but combined diff is in main → allow
+_flow_test_begin "force-delete allowed for a squash-merged branch"
+R=$(_new_repo)
+( cd "$R" && git checkout -qb feat && echo x > f.txt && git add f.txt && git commit -qm c1 \
+  && echo y >> f.txt && git add f.txt && git commit -qm c2 \
+  && git checkout -q main && git merge -q --squash feat && git commit -qm "squash feat" ) >/dev/null 2>&1
+_run_hook "$R" "git branch -D feat"; assert_exit 0 "$?" "squash-merged branch → allowed (the core fix)"
+
+# --- unmerged branch → block
+_flow_test_begin "force-delete blocked for an unmerged branch"
+R=$(_new_repo)
+( cd "$R" && git checkout -qb feat && echo x > f.txt && git add f.txt && git commit -qm c1 \
+  && git checkout -q main ) >/dev/null 2>&1
+_run_hook "$R" "git branch -D feat"; assert_exit 2 "$?" "unmerged work → blocked"
+
+# --- default branch is never force-deletable
+_flow_test_begin "force-delete blocked for the default branch itself"
+R=$(_new_repo)
+_run_hook "$R" "git branch -D main"; assert_exit 2 "$?" "deleting main → blocked"
+
+# --- multi-target: one merged, one unmerged → block (all must be merged)
+_flow_test_begin "multi-branch force-delete blocked when any target is unmerged"
+R=$(_new_repo)
+( cd "$R" && git checkout -qb done && echo a > a.txt && git add a.txt && git commit -qm ca \
+  && git checkout -q main && git merge -q --no-ff done -m "merge done" \
+  && git checkout -qb wip && echo b > b.txt && git add b.txt && git commit -qm cb \
+  && git checkout -q main ) >/dev/null 2>&1
+_run_hook "$R" "git branch -D done wip"; assert_exit 2 "$?" "mixed merged/unmerged → blocked"
+
+# --- multi-target: all merged → allow
+_flow_test_begin "multi-branch force-delete allowed when all targets merged"
+R=$(_new_repo)
+( cd "$R" && git checkout -qb d1 && echo a > a.txt && git add a.txt && git commit -qm ca \
+  && git checkout -q main && git merge -q --no-ff d1 -m "merge d1" \
+  && git checkout -qb d2 && echo b > b.txt && git add b.txt && git commit -qm cb \
+  && git checkout -q main && git merge -q --no-ff d2 -m "merge d2" ) >/dev/null 2>&1
+_run_hook "$R" "git branch -D d1 d2"; assert_exit 0 "$?" "all merged → allowed"
+
+# --- non-existent branch → fail-safe block (cannot verify)
+_flow_test_begin "force-delete blocked for an unresolvable branch (fail-safe)"
+R=$(_new_repo)
+_run_hook "$R" "git branch -D ghost"; assert_exit 2 "$?" "nonexistent branch → blocked"
+
+# --- not a git repo → cannot verify merge status → fail-safe block
+_flow_test_begin "force-delete blocked outside a git repo (fail-safe)"
+NR=$(mktemp -d -t flow-bd-nr.XXXXXX); BD_CLEANUP+=("$NR")
+_run_hook "$NR" "git branch -D feat"; assert_exit 2 "$?" "no git repo → blocked"
+
+# --- safe-delete (-d) is not our trigger and passes through
+_flow_test_begin "safe-delete (-d) passes through untouched"
+R=$(_new_repo)
+( cd "$R" && git checkout -qb feat && git checkout -q main ) >/dev/null 2>&1
+_run_hook "$R" "git branch -d feat"; assert_exit 0 "$?" "lowercase -d is allowed (git itself guards it)"
+
+# --- other destructive blocks remain intact
+_flow_test_begin "other destructive operations remain blocked"
+R=$(_new_repo)
+_run_hook "$R" "git reset --hard HEAD~1"; assert_exit 2 "$?" "git reset --hard still blocked"
+_run_hook "$R" "git clean -fd"; assert_exit 2 "$?" "git clean -f still blocked"
+_run_hook "$R" "rm -rf /some/important/path"; assert_exit 2 "$?" "rm -rf still blocked"
+_run_hook "$R" "git restore ."; assert_exit 2 "$?" "git restore . still blocked"
+
+# --- ordinary commands pass
+_flow_test_begin "non-destructive commands pass"
+R=$(_new_repo)
+_run_hook "$R" "git status"; assert_exit 0 "$?" "git status allowed"
+_run_hook "$R" "rm -rf node_modules"; assert_exit 0 "$?" "rm -rf in safe dir allowed"

--- a/plugins/flow/tests/lib/assert.sh
+++ b/plugins/flow/tests/lib/assert.sh
@@ -61,9 +61,15 @@ assert_equal() {
 
 # assert_match <regex> <actual> [<label>]
 # Uses grep -E so the regex is ERE — same flavor the test bodies already use.
+# A here-string (not `printf ... | grep`) feeds the haystack: with a pipe,
+# `grep -q` exits at the first match and closes the pipe, so printf is killed by
+# SIGPIPE (141) and — under the runner's `set -o pipefail` — the pipeline
+# reports non-zero even though the match succeeded. That produced nondeterministic
+# false failures on large haystacks (the match position races the pipe buffer).
+# A here-string has no pipeline, so pipefail/SIGPIPE cannot corrupt the result.
 assert_match() {
   local pattern="$1" actual="$2" label="${3:-match}"
-  if printf '%s' "$actual" | grep -qE "$pattern"; then
+  if grep -qE "$pattern" <<<"$actual"; then
     _flow_assert_pass "$label"
     return 0
   fi


### PR DESCRIPTION
## Summary

Closes #116. Makes the flow plugin's `block-destructive.sh` force-branch-delete rule **merge-aware** instead of a blanket block.

**Problem:** the hook blocked every force branch-delete and told the user to use safe-delete instead — but this repo squash-merges PRs, and safe-delete refuses to remove squash-merged branches (git doesn't see their commits on the default branch). So force-delete was the only option, and it was blocked → merged branches could never be cleaned up by the agent (which is exactly what stranded the `feature/issue-110` branch).

## Change

Force-delete is now allowed **only when every target branch is provably merged into the default branch**, and blocked otherwise (and on any uncertainty — fail-safe):

- **Merge detection:** `git merge-base --is-ancestor` for regular/fast-forward merges; a synthetic-commit + `git cherry` patch-equivalence check for squash merges (the branch's *combined* tree change vs the default). Checked against the local default **and** `origin/<default>`, so a branch merged on the remote is deletable even if the local default is behind.
- **All force-delete forms** are detected and routed through the same check — `-D`, combined clusters (`-Df`, `-fD`), and `--delete --force` / `-d --force` — not just bare `-D`.
- **Always blocked:** the default branch itself, unresolvable/nonexistent refs, unmerged work, missing git/default-branch, and force-deletes chained into compound commands (`&& …`).
- Branch names are passed to git as quoted args under `set -f`; no shell-injection or globbing surface.
- All other destructive blocks (`rm -rf`, `git reset --hard`, `git clean -f`, `git checkout -- .` / `git restore .`) are unchanged.

## Review

An independent review pass found 0 P1 (core safety property holds — no path allows deleting unmerged work) and 1 P2 (force-delete *equivalent* forms bypassed the trigger). That P2 and the P3 robustness items (origin-default merges, added test coverage) are fixed in this PR and re-verified.

## Test plan

- [x] New `tests/block-destructive-branch.test.sh` (24 assertions): regular-merged / squash-merged / unmerged / default-branch / multi-target / nonexistent / non-repo / safe-delete / equivalent forms / origin-default / compound-command / force-create — all via real scratch git repos driving the hook script.
- [x] `bash plugins/flow/tests/run.sh` → 809 pass / 0 fail.
- [x] Real-repo end-to-end: the stranded squash-merged `feature/issue-110` branch → allowed (via both `-D` and `--delete --force`); a genuinely unmerged branch → blocked.

## Bundled: flaky test-harness fix

This PR also includes a one-line fix to `tests/lib/assert.sh` (separate commit). `assert_match` piped the haystack into `grep -q`, which exits at the first match and closes the pipe — killing `printf` with SIGPIPE (141); under the CI runner's `set -o pipefail` the pipeline then reported non-zero despite a successful match, causing nondeterministic false failures on large haystacks (it surfaced here as a spurious `start-v3-integration` failure on Linux CI, never on macOS). Switched to a here-string so there is no pipeline. Pre-existing, suite-wide, and independent of the hook change — bundled because it was blocking this PR's CI. Verified: the CI `test` job, previously red on the race, is now green.

## Note

The live hook runs from the installed plugin cache, so this fix takes effect after the plugin updates from the marketplace (a release), not immediately in this session.

## Out of scope (noted for follow-up)

The hook matches its patterns as raw substrings, so a command that merely *mentions* a blocked pattern (e.g. an `echo`/heredoc) is also blocked, and `rm -f` of a single non-safe-dir file is treated like `rm -rf`. Both are pre-existing over-matches, unrelated to merge-awareness.
