### PR TITLE
fix(flow): resolve plugin root in command bash blocks; commit journal churn at PR time

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -109,7 +109,7 @@
       "name": "flow",
       "source": "./plugins/flow",
       "description": "Skill-driven workflow plugin for GitHub development with excellence-by-default quality gates. Encodes team knowledge as composable skills, enforces safety through hooks, compounds learning across sessions, and provides durable goals, workflows, triggers, and runs at .flow/.",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "author": {
         "name": "Daniel Bentes"
       },

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,13 @@ docs/flow-team-session/*.pdf
 .flow/evidence/
 .flow/triggers/*.local.yaml
 
+# Flow decision-journal lockfiles (left by bin/_journal_atomic.py after the
+# flock is released), session audit trail, and scheduler lock — all ephemeral
+# per-developer runtime state, never committed.
+.decisions/*.lock
+.trail/
+.claude/scheduled_tasks.lock
+
 # Python bytecode caches in plugin bin/ — _journal_atomic.py is imported
 # by helper scripts; the .pyc cache is per-developer noise.
 plugins/flow/bin/__pycache__/

--- a/plugins/flow/.claude-plugin/plugin.json
+++ b/plugins/flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Skill-driven workflow plugin for GitHub development with excellence-by-default quality gates. Encodes team knowledge as composable skills, enforces safety through hooks, and compounds learning across sessions. Strict TDD, Stranger Test, holdout validation, and evidence-based verification built in. Durable goals, workflows, triggers, and runs at .flow/.",
   "author": {
     "name": "Synapti AI",

--- a/plugins/flow/CHANGELOG.md
+++ b/plugins/flow/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 3.1.1 (2026-05-25)
+
+### Fixed: command bash blocks could not locate bundled `bin/` on marketplace installs
+
+Command `!`/bash blocks located bundled helpers via `${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/…`. `CLAUDE_PLUGIN_ROOT` is documented for hooks/MCP/LSP/monitors/skill substitution but **not** for slash-command bash blocks (and is unset when an agent runs the steps through its Bash tool), and the `:-plugins/flow` fallback only resolves for an in-repo checkout — never for a marketplace install. The result: in a consumer repo, helpers were unreachable, so `/flow:start` with `flow.goals.requireGoalForStart: true` could not auto-create the FlowGoal (`.flow/` was never created) and the `/flow:merge` goal gate had nothing to check.
+
+Command blocks now use an inline resolver that probes, in order: `$CLAUDE_PLUGIN_ROOT`, in-repo `plugins/flow`, the highest-semver marketplace cache install, then the marketplaces checkout — failing loud (existing `*_STATE=blocked` sentinels) when none resolves. Hooks are unaffected (they receive `CLAUDE_PLUGIN_ROOT` per the docs). See `references/plugin-root-resolution.md`.
+
+### Added: `/flow:pr` commits trailing decision-journal churn
+
+The decision journal (`.decisions/`, tracked) is appended to by the auto-log hooks during normal work and never committed, so it showed dirty at PR time. `/flow:pr` now sweeps journal-only churn into a `chore(decisions):` commit before pushing (new `bin/commit-journal-churn.sh`). It no-ops if any non-journal path is dirty and never stages lockfiles; the `chore(decisions):` subject is skipped by the `log-commits.sh` Guard 1, so there is no re-append loop. Journal lockfiles, `.trail/`, and `.claude/scheduled_tasks.lock` are now gitignored.
+
 ## 3.1.0 (2026-05-23)
 
 ### Fixed: merge-aware force-branch-delete in the destructive-command hook

--- a/plugins/flow/agents/convention-checker.md
+++ b/plugins/flow/agents/convention-checker.md
@@ -21,7 +21,7 @@ You are a Git convention validator for the flow plugin. Verify adherence to repo
 # an array) — those return empty from the filter and the helper falls
 # through to the next source.
 DEFAULT_TYPES="feat|fix|docs|style|refactor|test|chore|perf|ci|build|revert"
-HELPER="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
+HELPER="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh"
 COMMIT_TYPES="$DEFAULT_TYPES"
 [ -x "$HELPER" ] && COMMIT_TYPES=$("$HELPER" --default "$DEFAULT_TYPES" '.conventions.commitTypes // empty | if type == "array" then join("|") else empty end')
 echo "Commit types: $COMMIT_TYPES"

--- a/plugins/flow/bin/commit-journal-churn.sh
+++ b/plugins/flow/bin/commit-journal-churn.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# [flow] Commit trailing decision-journal churn as housekeeping.
+#
+# The decision journal (`.decisions/`, tracked) is appended to by the auto-log
+# PostToolUse hooks after every edit/commit. Those appends are never staged by
+# the hooks, so after normal work the journal shows dirty — and shows dirty at
+# PR/merge time. This helper commits that churn as a `chore(decisions):` commit
+# so the working tree is clean for PR creation.
+#
+# Safety: it commits ONLY when every pending change is inside the journal dir.
+# If any non-journal path is dirty or staged, it no-ops (it must never sweep
+# unrelated work into a housekeeping commit). The `chore(decisions):` prefix is
+# matched by hooks/scripts/log-commits.sh Guard 1, so this commit does not
+# trigger another auto-log append (no recursion).
+#
+# Usage:  commit-journal-churn.sh
+# Exits:  0 always (best-effort housekeeping; never blocks the caller).
+
+set -uo pipefail
+
+# Not a git repo → nothing to do.
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+# Resolve the journal directory via the sibling cascade-resolve.sh (does not
+# depend on CLAUDE_PLUGIN_ROOT — this script's own location is authoritative).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+JOURNAL_DIR=".decisions"
+if [ -x "$SCRIPT_DIR/cascade-resolve.sh" ]; then
+  JOURNAL_DIR=$("$SCRIPT_DIR/cascade-resolve.sh" --default ".decisions" '.journal.dir // empty' 2>/dev/null)
+  [ -n "$JOURNAL_DIR" ] || JOURNAL_DIR=".decisions"
+fi
+
+DIRTY=$(git status --porcelain 2>/dev/null)
+[ -z "$DIRTY" ] && exit 0   # clean tree
+
+# Classify every pending path. `.md` inside the journal dir is committable
+# churn; `.lock` inside it is transient (ignore); anything else disqualifies
+# the auto-commit entirely.
+HAS_JOURNAL_MD=0
+HAS_OTHER=0
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  # Porcelain v1: "XY <path>" (or "XY <old> -> <new>" for renames). cut -c4-
+  # yields the path field; a rename's " -> " never matches the journal globs
+  # below, so renames fall through to HAS_OTHER and we safely no-op.
+  p=$(printf '%s' "$line" | cut -c4-)
+  case "$p" in
+    "$JOURNAL_DIR"/*.md)   HAS_JOURNAL_MD=1 ;;
+    "$JOURNAL_DIR"/*.lock) : ;;
+    *)                     HAS_OTHER=1 ;;
+  esac
+done <<EOF
+$DIRTY
+EOF
+
+if [ "$HAS_OTHER" -eq 1 ]; then
+  echo "commit-journal-churn: working tree has non-journal changes — skipping auto-commit" >&2
+  exit 0
+fi
+[ "$HAS_JOURNAL_MD" -eq 0 ] && exit 0   # only locks dirty; nothing to commit
+
+# Stage only journal markdown. The HAS_OTHER guard above guarantees nothing
+# non-journal is dirty or pre-staged, so a plain commit cannot capture unrelated
+# work; the explicit pathspec on `add` keeps lockfiles out of the index.
+git add -- "$JOURNAL_DIR"/*.md 2>/dev/null
+if git diff --cached --quiet 2>/dev/null; then
+  exit 0   # nothing actually staged (defensive)
+fi
+git commit -m "chore(decisions): record session journal entries" >/dev/null 2>&1 || true
+exit 0

--- a/plugins/flow/bin/commit-journal-churn.sh
+++ b/plugins/flow/bin/commit-journal-churn.sh
@@ -30,12 +30,18 @@ if [ -x "$SCRIPT_DIR/cascade-resolve.sh" ]; then
   [ -n "$JOURNAL_DIR" ] || JOURNAL_DIR=".decisions"
 fi
 
-DIRTY=$(git status --porcelain 2>/dev/null)
+# `-uall` expands untracked directories to individual file paths. Without it, a
+# journal dir that was never committed (the fresh-consumer-repo case this
+# feature targets) collapses to a single `?? .decisions/` entry that matches
+# neither glob below and is misread as a non-journal change — so the helper
+# would no-op exactly when it is needed most.
+DIRTY=$(git status --porcelain -uall 2>/dev/null)
 [ -z "$DIRTY" ] && exit 0   # clean tree
 
-# Classify every pending path. `.md` inside the journal dir is committable
-# churn; `.lock` inside it is transient (ignore); anything else disqualifies
-# the auto-commit entirely.
+# Classify every pending path. The journal is flat by contract (issue-N.md,
+# session-DATE.md), so single-level globs suffice: `.md` inside the journal dir
+# is committable churn; `.lock` inside it is transient (ignore); anything else
+# disqualifies the auto-commit entirely.
 HAS_JOURNAL_MD=0
 HAS_OTHER=0
 while IFS= read -r line; do

--- a/plugins/flow/bin/commit-journal-churn.sh
+++ b/plugins/flow/bin/commit-journal-churn.sh
@@ -51,6 +51,12 @@ while IFS= read -r line; do
   # below, so renames fall through to HAS_OTHER and we safely no-op.
   p=$(printf '%s' "$line" | cut -c4-)
   case "$p" in
+    # Nested path under the journal dir: the journal is flat by contract, and
+    # the staging glob below is single-level — so anything nested would be
+    # classified-but-not-staged (a silent partial commit). Treat it as a
+    # non-journal change and no-op instead. Must precede the *.md/*.lock arms
+    # because shell `case` `*` spans `/`.
+    "$JOURNAL_DIR"/*/*)    HAS_OTHER=1 ;;
     "$JOURNAL_DIR"/*.md)   HAS_JOURNAL_MD=1 ;;
     "$JOURNAL_DIR"/*.lock) : ;;
     *)                     HAS_OTHER=1 ;;

--- a/plugins/flow/commands/address.md
+++ b/plugins/flow/commands/address.md
@@ -133,7 +133,7 @@ Addressing review feedback is a long-running workflow, so it gets a durable Flow
 
 ```!
 # FLOW_RUN_BLOCK_BEGIN
-CASCADE="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
+CASCADE="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh"
 if [ ! -x "$CASCADE" ]; then
   echo "FLOW_RUN_STATE=blocked"
   echo "FLOW_RUN_ERROR=cascade-resolve.sh missing or non-executable at $CASCADE"

--- a/plugins/flow/commands/brainstorm.md
+++ b/plugins/flow/commands/brainstorm.md
@@ -201,7 +201,7 @@ ENTRY
 
    ```bash
    if [ -n "$ISSUE_NUM" ]; then
-     "${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/journal-record.sh" \
+     "$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/journal-record.sh" \
        --issue $ISSUE_NUM \
        --type brainstorm-decision \
        --metadata topic="$TOPIC" \

--- a/plugins/flow/commands/debug.md
+++ b/plugins/flow/commands/debug.md
@@ -64,7 +64,7 @@ true
 
 ```!
 # FLOW_RUN_BLOCK_BEGIN
-CASCADE="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
+CASCADE="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh"
 if [ ! -x "$CASCADE" ]; then
   echo "FLOW_RUN_STATE=blocked"
   echo "FLOW_RUN_ERROR=cascade-resolve.sh missing or non-executable at $CASCADE"

--- a/plugins/flow/commands/design.md
+++ b/plugins/flow/commands/design.md
@@ -222,7 +222,7 @@ ENTRY
 
    ```bash
    if [ -n "$ISSUE_NUM" ]; then
-     "${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/journal-record.sh" \
+     "$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/journal-record.sh" \
        --issue $ISSUE_NUM \
        --type design-decision \
        --metadata decision="$DECISION_TITLE" \

--- a/plugins/flow/commands/explain.md
+++ b/plugins/flow/commands/explain.md
@@ -26,7 +26,7 @@ echo "ISSUE_NUM=${ISSUE_NUM:-\"(none)\"}"
 
 echo ""
 echo "### Decision Journal"
-HELPER="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
+HELPER="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh"
 JOURNAL_DIR=".decisions"
 [ -x "$HELPER" ] && JOURNAL_DIR=$("$HELPER" --default ".decisions" '.journal.dir // empty')
 echo "JOURNAL_DIR=$JOURNAL_DIR"

--- a/plugins/flow/commands/goal.md
+++ b/plugins/flow/commands/goal.md
@@ -23,7 +23,7 @@ Before any subcommand:
 
 ```bash
 # Resolve flow.goals.enabled (default true)
-ENABLED=$("${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh" \
+ENABLED=$("$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh" \
   --default "true" '.flow.goals.enabled')
 if [ "$ENABLED" != "true" ]; then
   echo "flow.goals.enabled is false — /flow:goal is disabled in this project's settings cascade." >&2
@@ -31,7 +31,7 @@ if [ "$ENABLED" != "true" ]; then
 fi
 
 # Resolve stopHookEnforcement (warn | block | evaluator-loop)
-STOP_MODE=$("${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh" \
+STOP_MODE=$("$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh" \
   --default "warn" '.flow.goals.stopHookEnforcement // empty')
 
 mkdir -p .flow/goals
@@ -131,7 +131,7 @@ jq -n \
   --arg r "<reason>" \
   --arg h "<next_step_hint>" \
   '{verdict:$v, confidence:$c, delta:$d, reason:$r, next_step_hint:$h, source:"command"}' > "$TMP"
-"${CLAUDE_PLUGIN_ROOT}/bin/flow-record-verdict.sh" \
+"$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/flow-record-verdict.sh" \
   --run-id "<run-id-from-goal.scope.run_id>" \
   --verdict-file "$TMP" \
   || echo "command: last-verdict.json write failed; next turn's delta will be 'unchanged'" >&2
@@ -166,7 +166,7 @@ last_evaluation:
   reason: ${PROPOSED_REASON}
   at: $(date -u +%Y-%m-%dT%H:%M:%SZ)
 EOF
-"${CLAUDE_PLUGIN_ROOT}/bin/flow-goal-record.sh" --update-lifecycle \
+"$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/flow-goal-record.sh" --update-lifecycle \
   --goal-id "$GOAL_ID" \
   --lifecycle-file "$LIFE_TMP" \
   --from-status "$CURRENT_FROM_STATUS"

--- a/plugins/flow/commands/learn.md
+++ b/plugins/flow/commands/learn.md
@@ -171,7 +171,7 @@ Write each proposal to `$PROPOSAL_DIR/YYYY-MM-DD-{topic}.md` using the skill-pro
 To promote a proposal to an active skill, use the canonical helper:
 
 ```bash
-$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/promote-proposal.sh \
+"$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/promote-proposal.sh" \
   --proposal ~/.claude/flow-proposals/YYYY-MM-DD-{topic}.md
 ```
 
@@ -187,7 +187,7 @@ The PR is **always draft** — `bin/promote-proposal.sh` is Tier 2 (journal-and-
 Use `--dry-run` to validate a proposal without filesystem effects:
 
 ```bash
-$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/promote-proposal.sh \
+"$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/promote-proposal.sh" \
   --proposal ~/.claude/flow-proposals/YYYY-MM-DD-{topic}.md \
   --dry-run
 ```

--- a/plugins/flow/commands/learn.md
+++ b/plugins/flow/commands/learn.md
@@ -24,7 +24,7 @@ echo "### Resolved Paths"
 # without expansion, so downstream tools that don't auto-expand tildes
 # (Read/Write/Edit, Python os.path) would fail. Manually expand `~` to
 # $HOME so the agent always receives an absolute path.
-HELPER="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
+HELPER="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh"
 JOURNAL_DIR=".decisions"
 PROPOSAL_DIR="$HOME/.claude/flow-proposals"
 if [ -x "$HELPER" ]; then
@@ -171,7 +171,7 @@ Write each proposal to `$PROPOSAL_DIR/YYYY-MM-DD-{topic}.md` using the skill-pro
 To promote a proposal to an active skill, use the canonical helper:
 
 ```bash
-${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/promote-proposal.sh \
+$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/promote-proposal.sh \
   --proposal ~/.claude/flow-proposals/YYYY-MM-DD-{topic}.md
 ```
 
@@ -187,7 +187,7 @@ The PR is **always draft** — `bin/promote-proposal.sh` is Tier 2 (journal-and-
 Use `--dry-run` to validate a proposal without filesystem effects:
 
 ```bash
-${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/promote-proposal.sh \
+$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/promote-proposal.sh \
   --proposal ~/.claude/flow-proposals/YYYY-MM-DD-{topic}.md \
   --dry-run
 ```

--- a/plugins/flow/commands/merge.md
+++ b/plugins/flow/commands/merge.md
@@ -174,7 +174,7 @@ TRUST_LIST="$TRUST_DEFAULT"
 LOCAL_SETTINGS=".claude/settings.flow.local.json"
 PROJECT_SETTINGS=".claude/settings.flow.json"
 USER_SETTINGS="${HOME:-/nonexistent}/.claude/settings.flow.json"
-PLUGIN_SETTINGS="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/settings.json"
+PLUGIN_SETTINGS="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/settings.json"
 for SETTINGS_PATH in "$LOCAL_SETTINGS" "$PROJECT_SETTINGS" "$USER_SETTINGS" "$PLUGIN_SETTINGS"; do
   [ -f "$SETTINGS_PATH" ] || continue
   # Capture jq stderr/exit so a parse error in $HOME does not silently mask
@@ -324,14 +324,14 @@ true
 Independent of the finding-ledger gate, the FlowGoal gate verifies the active goal has reached `lifecycle.status == achieved`. Gated behind `flow.goals.requireGoalForStart` — when false (v2 mode), this block emits `FLOW_GOAL_GATE_STATE=disabled` and the gate is skipped silently.
 
 ```!
-HELPER="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
+HELPER="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh"
 REQUIRE_GOAL=$("$HELPER" --default "false" '.flow.goals.requireGoalForStart' 2>/dev/null)
 
 echo "### FlowGoal Gate"
 if [ "$REQUIRE_GOAL" != "true" ]; then
   echo "FLOW_GOAL_GATE_STATE=disabled"
 else
-  ACTIVE_GOAL_HELPER="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/flow-active-goal.sh"
+  ACTIVE_GOAL_HELPER="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/flow-active-goal.sh"
   if [ ! -x "$ACTIVE_GOAL_HELPER" ]; then
     echo "FLOW_GOAL_GATE_STATE=blocked"
     echo "FLOW_GOAL_BLOCK_REASON=flow-active-goal.sh missing or non-executable"
@@ -409,7 +409,7 @@ Do NOT proceed to Phase 2. Exit here.
 
 ```!
 # FLOW_RUN_BLOCK_BEGIN
-CASCADE="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
+CASCADE="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh"
 if [ ! -x "$CASCADE" ]; then
   echo "FLOW_RUN_STATE=blocked"
   echo "FLOW_RUN_ERROR=cascade-resolve.sh missing or non-executable at $CASCADE"
@@ -516,7 +516,7 @@ git pull origin $DEFAULT_BRANCH
 ISSUE=$(gh pr view "$PR_NUM" --json body --jq '.body' | grep -oE '#[0-9]+' | head -1 | tr -d '#')
 if [ -n "$ISSUE" ]; then
   # Repeat once per escalation that closed during this merge run.
-  "${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/journal-record.sh" \
+  "$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/journal-record.sh" \
     --issue $ISSUE \
     --type escalation-resolved \
     --metadata escalation_field={situation|tried|options|recommendation|blocking|risk} \

--- a/plugins/flow/commands/pr.md
+++ b/plugins/flow/commands/pr.md
@@ -120,13 +120,13 @@ else
   # see STATE=disabled and the gate is skipped silently.
   echo ""
   echo "### FlowGoal State"
-  HELPER="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
+  HELPER="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh"
   REQUIRE_GOAL=$("$HELPER" --default "false" '.flow.goals.requireGoalForStart' 2>/dev/null)
   if [ "$REQUIRE_GOAL" != "true" ]; then
     echo "STATE=disabled"
     echo "REASON=flow.goals.requireGoalForStart is not true"
   else
-    ACTIVE_GOAL_HELPER="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/flow-active-goal.sh"
+    ACTIVE_GOAL_HELPER="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/flow-active-goal.sh"
     if [ ! -x "$ACTIVE_GOAL_HELPER" ]; then
       echo "STATE=unavailable"
       echo "REASON=flow-active-goal.sh missing or non-executable"
@@ -296,9 +296,9 @@ After agents return, TaskUpdate each review task with findings.
      # block's shell, so re-derive the issue from the branch and read the
      # lifecycle from the helper (same pattern as the manifest-emit block).
      ISSUE_NUM=$(git branch --show-current 2>/dev/null | grep -oE 'issue-[0-9]+' | head -1 | sed 's/issue-//')
-     GOAL_LIFECYCLE=$("${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/flow-active-goal.sh" --status 2>/dev/null || echo "unknown")
+     GOAL_LIFECYCLE=$("$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/flow-active-goal.sh" --status 2>/dev/null || echo "unknown")
      if [ -n "$ISSUE_NUM" ]; then
-       "${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/journal-record.sh" \
+       "$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/journal-record.sh" \
          --issue "$ISSUE_NUM" --type escalation-resolved \
          --metadata gate=flowgoal-pr \
          --metadata goal_status="$GOAL_LIFECYCLE" \
@@ -332,8 +332,13 @@ After agents return, TaskUpdate each review task with findings.
    |------|----------|--------|------------|
    ```
    Note: screenshots are local files; for remote visibility, mention "verified locally"
-9. **Push** (Tier 2: journal-and-proceed):
+9. **Push** (Tier 2: journal-and-proceed). First sweep any trailing decision-journal
+   churn into a `chore(decisions):` commit so the working tree is clean for the PR — the
+   auto-log hooks append to the tracked journal during normal work and never commit it.
+   The helper no-ops if any non-journal path is dirty (it never sweeps unrelated work), and
+   its `chore(decisions):` subject is skipped by `log-commits.sh` Guard 1 (no re-append):
    ```bash
+   "$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/commit-journal-churn.sh" 2>/dev/null || true
    git push -u origin $BRANCH
    ```
 10. **Create PR** (Tier 2):
@@ -353,7 +358,7 @@ After agents return, TaskUpdate each review task with findings.
       ISSUE=$(echo "$BRANCH" | grep -oE 'issue-([0-9]+)' | head -1 | sed 's/issue-//')
     fi
     if [ -n "$ISSUE" ]; then
-      "${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/journal-record.sh" \
+      "$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/journal-record.sh" \
         --issue $ISSUE \
         --type review-cycle \
         --metadata cycle=1 \

--- a/plugins/flow/commands/release.md
+++ b/plugins/flow/commands/release.md
@@ -75,7 +75,7 @@ A release is a long-running workflow, so it gets a durable FlowRun. Runs are gat
 
 ```!
 # FLOW_RUN_BLOCK_BEGIN
-CASCADE="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
+CASCADE="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh"
 if [ ! -x "$CASCADE" ]; then
   echo "FLOW_RUN_STATE=blocked"
   echo "FLOW_RUN_ERROR=cascade-resolve.sh missing or non-executable at $CASCADE"

--- a/plugins/flow/commands/resume.md
+++ b/plugins/flow/commands/resume.md
@@ -14,7 +14,7 @@ When a session ends mid-workflow (interrupted, paused, blocked), `.flow/runs/<id
 ## Pre-flight
 
 ```bash
-ENABLED=$("${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh" \
+ENABLED=$("$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh" \
   --default "true" '.flow.runtime.enabled')
 if [ "$ENABLED" != "true" ]; then
   echo "flow.runtime.enabled is false — /flow:resume requires the runtime layer." >&2

--- a/plugins/flow/commands/review.md
+++ b/plugins/flow/commands/review.md
@@ -173,7 +173,7 @@ A review is a long-running workflow, so it gets a durable FlowRun. Runs are gate
 
 ```!
 # FLOW_RUN_BLOCK_BEGIN
-CASCADE="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
+CASCADE="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh"
 if [ ! -x "$CASCADE" ]; then
   echo "FLOW_RUN_STATE=blocked"
   echo "FLOW_RUN_ERROR=cascade-resolve.sh missing or non-executable at $CASCADE"
@@ -236,7 +236,7 @@ USE_PATH_A=0
 LOCAL_SETTINGS=".claude/settings.flow.local.json"
 PROJECT_SETTINGS=".claude/settings.flow.json"
 USER_SETTINGS="${HOME:-/nonexistent}/.claude/settings.flow.json"
-PLUGIN_SETTINGS="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/settings.json"
+PLUGIN_SETTINGS="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/settings.json"
 AGENT_TEAMS=""
 SOURCE_USED=""
 
@@ -347,7 +347,7 @@ fi
 # marginal review value. An invalid value is rejected with a WARN (NOT silently
 # coerced) and falls back to sonnet.
 if [ "$USE_PATH_A" = "1" ]; then
-  AGENT_TEAM_MODEL=$("${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh" --default sonnet '.agentTeamModel // empty' 2>/dev/null)
+  AGENT_TEAM_MODEL=$("$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh" --default sonnet '.agentTeamModel // empty' 2>/dev/null)
   case "$AGENT_TEAM_MODEL" in
     haiku|sonnet|opus|inherit) ;;
     *)
@@ -534,7 +534,7 @@ Apply the consolidation table from `team-coordination/SKILL.md` Phase 4. For eac
 **Manifest emit** — for each DROPPED finding, append a `dropped-finding` artifact to the journal manifest so `/flow:learn` can detect repeated drop reasons across cycles (a recurring drop reason is a learnable signal):
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/journal-record.sh" \
+"$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/journal-record.sh" \
   --issue $ISSUE \
   --type dropped-finding \
   --metadata cycle=$CYCLE \
@@ -713,7 +713,7 @@ TaskUpdate each review task as agents complete.
    ```bash
    ISSUE=$(gh pr view "$PR_NUM" --json body --jq '.body' | grep -oE '#[0-9]+' | head -1 | tr -d '#')
    if [ -n "$ISSUE" ]; then
-     "${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/journal-record.sh" \
+     "$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/journal-record.sh" \
        --issue $ISSUE \
        --type review-cycle \
        --metadata cycle=$CYCLE_NUMBER \

--- a/plugins/flow/commands/run.md
+++ b/plugins/flow/commands/run.md
@@ -15,7 +15,7 @@ When a FlowTrigger's target needs to run NOW (manual invocation, loop iteration,
 ## Pre-flight
 
 ```bash
-ENABLED=$("${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh" \
+ENABLED=$("$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh" \
   --default "false" '.flow.triggers.enabled')
 [ "$ENABLED" != "true" ] && { echo "flow.triggers.enabled is false"; exit 0; }
 ```

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -470,7 +470,7 @@ If any check fails, halt and re-invoke the skill with the failure noted. Do NOT 
 **Manifest emit** — record the specification artifact in the journal manifest so downstream tooling and `/flow:status` can see it without parsing the freeform `## Specification` body:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/journal-record.sh" \
+"$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/journal-record.sh" \
   --issue "$ISSUE_NUM" \
   --type specification \
   --metadata by=specification-capture \
@@ -527,7 +527,7 @@ gh issue edit "$ISSUE_NUM" --add-assignee @me
 **FlowGoal auto-creation (gated by `flow.goals.requireGoalForStart`):**
 
 ```!
-CASCADE="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
+CASCADE="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh"
 # Surface cascade-resolve unavailability instead of silently degrading the gate.
 if [ ! -x "$CASCADE" ]; then
   echo "FLOW_GOAL_STATE=blocked"
@@ -626,7 +626,7 @@ For `FLOW_GOAL_STATE=create`:
 
 ```!
 # FLOW_RUN_BLOCK_BEGIN
-CASCADE="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
+CASCADE="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh"
 if [ ! -x "$CASCADE" ]; then
   echo "FLOW_RUN_STATE=blocked"
   echo "FLOW_RUN_ERROR=cascade-resolve.sh missing or non-executable at $CASCADE"
@@ -661,7 +661,7 @@ When `FLOW_RUN_STATE=create`, invoke `Skill(run-state-management)` to create `.f
 # do not persist here). RUN_ID is the value emitted by the FlowRun entry block.
 ARG1="${ARGUMENTS%% *}"; case "$ARG1" in ''|*[!0-9]*) ISSUE_NUM="" ;; *) ISSUE_NUM="$ARG1" ;; esac
 if [ -n "$ISSUE_NUM" ]; then
-  "${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/journal-record.sh" \
+  "$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/journal-record.sh" \
     --issue "$ISSUE_NUM" --type workflow-run \
     --metadata workflow=start-issue --metadata run_id="$RUN_ID" --metadata status=active
 fi
@@ -747,7 +747,7 @@ Record the Stranger Test result to `.decisions/issue-$ISSUE_NUM.md` under a `## 
 **Manifest emit** — append the stranger-test artifact (alongside the freeform `## Stranger Test` section) so the manifest captures the gate's outcome:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/journal-record.sh" \
+"$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/journal-record.sh" \
   --issue "$ISSUE_NUM" \
   --type stranger-test \
   --metadata result={PASS|BLOCK} \
@@ -909,7 +909,7 @@ Prove everything works with fix-forward:
    **Manifest emit** — record the verdict artifact after the verdict-judge returns (and any fix-loop iterations have settled):
 
    ```bash
-   "${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/journal-record.sh" \
+   "$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/journal-record.sh" \
      --issue "$ISSUE_NUM" \
      --type verdict \
      --metadata result={PASS|FAIL|NEEDS-HUMAN-REVIEW}

--- a/plugins/flow/commands/status.md
+++ b/plugins/flow/commands/status.md
@@ -101,7 +101,7 @@ fi
 # `JOURNAL_DIR` is resolved via the standard settings cascade (bin/cascade-resolve.sh).
 echo ""
 echo "### Decision Journal"
-HELPER="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
+HELPER="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh"
 JOURNAL_DIR=".decisions"
 [ -x "$HELPER" ] && JOURNAL_DIR=$("$HELPER" --default ".decisions" '.journal.dir // empty')
 JOURNAL_FILES=0
@@ -120,13 +120,13 @@ fi
 # (flag false/unset) emit STATE=disabled and the section renders as "(v3 not enabled)".
 echo ""
 echo "### FlowGoal State"
-HELPER="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
+HELPER="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh"
 GOALS_ENABLED="false"
 [ -x "$HELPER" ] && GOALS_ENABLED=$("$HELPER" --default "true" '.flow.goals.enabled' 2>/dev/null)
 if [ "$GOALS_ENABLED" != "true" ]; then
   echo "STATE=disabled"
 else
-  ACTIVE_GOAL_HELPER="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/flow-active-goal.sh"
+  ACTIVE_GOAL_HELPER="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/flow-active-goal.sh"
   if [ ! -x "$ACTIVE_GOAL_HELPER" ]; then
     echo "STATE=unavailable"
     echo "REASON=flow-active-goal.sh missing"
@@ -197,7 +197,7 @@ fi
 # emit STATE=disabled.
 echo ""
 echo "### Active Triggers"
-TRIG_HELPER="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
+TRIG_HELPER="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh"
 TRIGGERS_ENABLED="false"
 [ -x "$TRIG_HELPER" ] && TRIGGERS_ENABLED=$("$TRIG_HELPER" --default "false" '.flow.triggers.enabled' 2>/dev/null)
 if [ "$TRIGGERS_ENABLED" != "true" ]; then
@@ -249,7 +249,7 @@ TRUST_LIST="$TRUST_DEFAULT"
 LOCAL_SETTINGS=".claude/settings.flow.local.json"
 PROJECT_SETTINGS=".claude/settings.flow.json"
 USER_SETTINGS="${HOME:-/nonexistent}/.claude/settings.flow.json"
-PLUGIN_SETTINGS="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/settings.json"
+PLUGIN_SETTINGS="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/settings.json"
 for SETTINGS_PATH in "$LOCAL_SETTINGS" "$PROJECT_SETTINGS" "$USER_SETTINGS" "$PLUGIN_SETTINGS"; do
   [ -f "$SETTINGS_PATH" ] || continue
   CONFIGURED=$(jq -c '.merge.markerTrust.allowedAssociations // empty' "$SETTINGS_PATH" 2>&1)

--- a/plugins/flow/commands/trigger.md
+++ b/plugins/flow/commands/trigger.md
@@ -15,7 +15,7 @@ Flow cannot invoke native `/loop`, scheduled tasks, or any external runner from 
 ## Pre-flight
 
 ```bash
-ENABLED=$("${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh" \
+ENABLED=$("$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh" \
   --default "false" '.flow.triggers.enabled')
 if [ "$ENABLED" != "true" ]; then
   echo "flow.triggers.enabled is false — /flow:trigger is opt-in." >&2

--- a/plugins/flow/commands/watch.md
+++ b/plugins/flow/commands/watch.md
@@ -20,7 +20,7 @@ The user manually starts the loop. Flow does NOT invoke `/loop` from plugin code
 ## Pre-flight
 
 ```bash
-ENABLED=$("${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh" \
+ENABLED=$("$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh" \
   --default "false" '.flow.triggers.enabled')
 if [ "$ENABLED" != "true" ]; then
   echo "flow.triggers.enabled is false — /flow:watch is opt-in."

--- a/plugins/flow/commands/workflow.md
+++ b/plugins/flow/commands/workflow.md
@@ -17,7 +17,7 @@ The command markdown remains Claude's execution manual; this YAML is the inspect
 ## Pre-flight
 
 ```bash
-ENABLED=$("${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh" \
+ENABLED=$("$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh" \
   --default "false" '.flow.workflows.enabled')
 if [ "$ENABLED" != "true" ]; then
   echo "flow.workflows.enabled is false — /flow:workflow is opt-in." >&2
@@ -34,7 +34,7 @@ List all plugin-shipped workflows + any project-local overrides:
 
 ```bash
 echo "Plugin-shipped workflows:"
-for f in "${CLAUDE_PLUGIN_ROOT:-plugins/flow}/workflows/"*.workflow.yaml; do
+for f in "$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/workflows/"*.workflow.yaml; do
   ID=$(basename "$f" .workflow.yaml)
   CMD=$(python3 -c "import yaml; print(yaml.safe_load(open('$f'))['metadata']['command'])" 2>/dev/null)
   DESC=$(python3 -c "import yaml; print(yaml.safe_load(open('$f'))['metadata']['description'])" 2>/dev/null)
@@ -58,7 +58,7 @@ Dump the workflow's frontmatter + phase structure:
 
 ```bash
 ID="${ARGUMENTS}"
-WF_PATH="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/workflows/${ID}.workflow.yaml"
+WF_PATH="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/workflows/${ID}.workflow.yaml"
 [ -f ".flow/workflows/${ID}.workflow.yaml" ] && WF_PATH=".flow/workflows/${ID}.workflow.yaml"
 
 if [ ! -f "$WF_PATH" ]; then
@@ -97,7 +97,7 @@ Render a textual graph of the workflow's phase structure:
 
 ```bash
 ID="${ARGUMENTS}"
-WF_PATH="${CLAUDE_PLUGIN_ROOT:-plugins/flow}/workflows/${ID}.workflow.yaml"
+WF_PATH="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/workflows/${ID}.workflow.yaml"
 [ -f ".flow/workflows/${ID}.workflow.yaml" ] && WF_PATH=".flow/workflows/${ID}.workflow.yaml"
 
 python3 - "$WF_PATH" <<'PYEOF'

--- a/plugins/flow/references/flow-triggers-quickstart.md
+++ b/plugins/flow/references/flow-triggers-quickstart.md
@@ -20,7 +20,7 @@ jq '.flow.triggers.enabled = true' .claude/settings.flow.json > /tmp/s && mv /tm
 Verify:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh" --default "false" '.flow.triggers.enabled'
+"$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh" --default "false" '.flow.triggers.enabled'
 # expect: true
 ```
 

--- a/plugins/flow/references/flow-workflows-quickstart.md
+++ b/plugins/flow/references/flow-workflows-quickstart.md
@@ -20,7 +20,7 @@ jq '.flow.workflows.enabled = true' .claude/settings.flow.json > /tmp/s && mv /t
 Verify:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh" --default "false" '.flow.workflows.enabled'
+"$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh" --default "false" '.flow.workflows.enabled'
 # expect: true
 ```
 

--- a/plugins/flow/references/plugin-root-resolution.md
+++ b/plugins/flow/references/plugin-root-resolution.md
@@ -1,0 +1,98 @@
+# Plugin-Root Resolution (command bash blocks)
+
+## Why this exists
+
+Flow's slash-command `!` bash blocks invoke bundled helpers under `bin/`
+(e.g. `cascade-resolve.sh`, `journal-record.sh`, `flow-active-goal.sh`). They
+used to locate them with:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/cascade-resolve.sh"
+```
+
+This is unsafe for **marketplace installs**:
+
+- `CLAUDE_PLUGIN_ROOT` is documented as available in **hooks, MCP servers, LSP
+  servers, monitor commands, and skill/agent content substitution** — but the
+  Claude Code docs are **silent on slash-command `!` bash blocks**. It is also
+  empirically **unset** when an agent runs these steps through its own Bash
+  tool rather than as a first-class command invocation.
+- The `:-plugins/flow` fallback only resolves when flow is checked out **in-repo**
+  at `plugins/flow/` (i.e. the `synapti-marketplace` repo itself). In a consumer
+  repo the plugin lives under `~/.claude/plugins/...`, so the fallback points at
+  a path that does not exist and every bundled helper becomes unreachable.
+
+Observed failure: `/flow:start` in a consumer repo with
+`flow.goals.requireGoalForStart: true` could not find `cascade-resolve.sh`, so
+the FlowGoal was never created and the `/flow:merge` goal gate had nothing to
+check.
+
+Hooks are unaffected (they get `CLAUDE_PLUGIN_ROOT` per the docs), so
+`hooks/scripts/*` and `bin/journal-record.sh`'s `SCRIPT_DIR` sibling resolution
+need no change. This document covers **command `!` bash blocks only**.
+
+## Canonical resolver (copy verbatim)
+
+Command blocks use an **inline** resolver in place of the old
+`${CLAUDE_PLUGIN_ROOT:-plugins/flow}` root token. It is inlined (rather than a
+shared `FLOW_ROOT=` line) on purpose: each `!`/`bash` block is its own subshell
+so a variable could not be shared across blocks, and substituting in place — vs.
+inserting a statement — cannot disturb the surrounding statement/continuation
+structure of these dense command files. Use it as the directory prefix:
+
+```bash
+"$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh"
+```
+
+For readability, the same logic in expanded form (functionally identical):
+
+```bash
+__fr="${CLAUDE_PLUGIN_ROOT:-}"
+if [ ! -x "$__fr/bin/cascade-resolve.sh" ]; then
+  __fr=$(
+    { echo plugins/flow
+      ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null | sort -Vr
+      echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"
+    } | while read -r __p; do
+      [ -x "${__p%/}/bin/cascade-resolve.sh" ] && { echo "${__p%/}"; break; }
+    done)
+fi
+# "$__fr" is now the plugin root (empty if nothing resolved — guard before use).
+```
+
+Resolution order (first match with an executable `bin/cascade-resolve.sh` wins):
+
+1. `$CLAUDE_PLUGIN_ROOT` — authoritative when a real command context sets it.
+2. `plugins/flow` — in-repo checkout (developing flow inside `synapti-marketplace`).
+3. highest-semver marketplace **cache** install
+   (`~/.claude/plugins/cache/synapti-marketplace/flow/<version>/`), newest via `sort -Vr`.
+4. `~/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow` — marketplaces checkout.
+
+## Loud-fail contract
+
+A command block MUST NOT silently degrade when the root cannot be found. When
+nothing resolves, the inline resolver yields an empty string, so the helper path
+becomes `/bin/cascade-resolve.sh` (not executable) — the block's existing
+`[ ! -x "$CASCADE" ]`-style guard then fires its `*_STATE=blocked` sentinel:
+
+```bash
+CASCADE="$(...resolver...)/bin/cascade-resolve.sh"
+if [ ! -x "$CASCADE" ]; then
+  echo "FLOW_GOAL_STATE=blocked"
+  echo "FLOW_GOAL_ERROR=cascade-resolve.sh missing or non-executable at $CASCADE — reinstall or upgrade the flow plugin"
+  true; exit 0
+fi
+```
+
+Any block that assigns the resolved helper to a variable and guards
+`[ -x "$VAR" ]` before use inherits this loud-fail behavior automatically.
+
+## Known tradeoffs
+
+- The cache-glob heuristic (step 3) picks the **highest installed version**,
+  which may differ from the version Claude Code would load when
+  `CLAUDE_PLUGIN_ROOT` is set. It only fires as a fallback, and "newest
+  installed" is strictly better than "unreachable."
+- The marketplace slug `synapti-marketplace` is hardcoded — flow ships from it.
+- Unquoted command substitution word-splits on whitespace; `$HOME` cache paths
+  under `~/.claude/plugins/` do not contain spaces in practice.

--- a/plugins/flow/references/skill-contracts.md
+++ b/plugins/flow/references/skill-contracts.md
@@ -57,7 +57,7 @@ Producers MUST validate inputs **before** invoking a skill. The pattern:
 
 ```bash
 PAYLOAD='{"selfReviewFindings": [...], "evidenceBundle": [...], "fileList": [...]}'
-if ! "${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/validate-skill-input.sh" holdout-validation "$PAYLOAD" >&2; then
+if ! "$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/validate-skill-input.sh" holdout-validation "$PAYLOAD" >&2; then
   echo "ERROR: holdout-validation input failed validation; refusing to invoke skill" >&2
   exit 1
 fi

--- a/plugins/flow/tests/commit-journal-churn.test.sh
+++ b/plugins/flow/tests/commit-journal-churn.test.sh
@@ -88,3 +88,25 @@ printf '{"tool_input":{"command":"git commit -m x"}}' \
   | ( cd "$R" && HOME="$FAKE_HOME" bash "$LOGCOMMITS" ) >/dev/null 2>&1 || true
 COUNT_AFTER=$(grep -c 'auto-log' "$R/.decisions/issue-1.md")
 assert_equal "$COUNT_BEFORE" "$COUNT_AFTER" "no new auto-log line appended after chore(decisions): commit"
+
+# --- Scenario F: wholly-untracked journal dir (fresh consumer repo) ----------
+# Regression for the -uall fix: when .decisions/ was never committed,
+# `git status --porcelain` collapses it to a single `?? .decisions/` entry that
+# would be misread as a non-journal change. The helper must use -uall so the
+# untracked journal files are seen individually and committed.
+_flow_test_begin "wholly-untracked .decisions/ is committed (the fresh-consumer-repo case)"
+RF=$(mktemp -d -t cjc.repo.XXXXXX); CLEANUP_PATHS+=("$RF")
+git -C "$RF" init -q
+git -C "$RF" checkout -q -B feature/issue-1-test
+git -C "$RF" config user.email "t@example.com"
+git -C "$RF" config user.name "Test"
+printf 'readme\n' > "$RF/README.md"
+git -C "$RF" add README.md
+git -C "$RF" commit -q -m "init (no journal yet)"
+mkdir -p "$RF/.decisions"
+printf -- '---\nissue: 1\n---\n<!-- auto-log: x -->\n' > "$RF/.decisions/issue-1.md"
+# Sanity: default porcelain would hide the per-file path (the bug condition).
+assert_equal "?? .decisions/" "$(git -C "$RF" status --porcelain)" "default porcelain collapses the untracked journal dir"
+_run_helper "$RF" >/dev/null
+assert_equal "chore(decisions): record session journal entries" "$(_subject "$RF")" "untracked journal dir committed"
+assert_equal "" "$(_porcelain "$RF")" "tree clean after committing untracked journal dir"

--- a/plugins/flow/tests/commit-journal-churn.test.sh
+++ b/plugins/flow/tests/commit-journal-churn.test.sh
@@ -110,3 +110,21 @@ assert_equal "?? .decisions/" "$(git -C "$RF" status --porcelain)" "default porc
 _run_helper "$RF" >/dev/null
 assert_equal "chore(decisions): record session journal entries" "$(_subject "$RF")" "untracked journal dir committed"
 assert_equal "" "$(_porcelain "$RF")" "tree clean after committing untracked journal dir"
+
+# --- Scenario G: nested journal .md → no-op (classifier matches staging) -----
+# The classifier `case` glob spans '/', but the staging glob is single-level.
+# A nested .md must therefore be treated as a non-journal change (no-op) rather
+# than classified-but-not-staged (a silent partial commit that exits 0 claiming
+# a clean tree). Journal is flat by contract.
+_flow_test_begin "nested journal .md → no-op, no partial commit"
+R=$(_new_repo)
+BEFORE=$(_subject "$R")
+printf '<!-- auto-log: edit -->\n' >> "$R/.decisions/issue-1.md"
+mkdir -p "$R/.decisions/sub"
+printf -- '---\nx\n---\n' > "$R/.decisions/sub/nested.md"
+_run_helper "$R" >/dev/null
+assert_equal "$BEFORE" "$(_subject "$R")" "no commit when a nested journal .md is present"
+# The flat churn + nested file both remain — nothing was partial-committed.
+# (Default porcelain collapses the untracked subdir to `?? .decisions/sub/`.)
+assert_match "issue-1.md" "$(_porcelain "$R")" "flat journal churn left uncommitted (no partial commit)"
+assert_match "\.decisions/sub" "$(_porcelain "$R")" "nested path left uncommitted"

--- a/plugins/flow/tests/commit-journal-churn.test.sh
+++ b/plugins/flow/tests/commit-journal-churn.test.sh
@@ -1,0 +1,90 @@
+# Tests for plugins/flow/bin/commit-journal-churn.sh.
+#
+# Contract (from the script header): commit trailing decision-journal churn as a
+# `chore(decisions):` commit, but ONLY when every pending change is inside the
+# journal dir. Non-journal changes → no-op. Lockfiles → ignored, never staged.
+# The `chore(decisions):` subject is skipped by log-commits.sh Guard 1, so it
+# does not trigger another auto-log append (no recursion).
+
+HELPER="$REPO_ROOT/plugins/flow/bin/commit-journal-churn.sh"
+LOGCOMMITS="$REPO_ROOT/plugins/flow/hooks/scripts/log-commits.sh"
+
+CLEANUP_PATHS=()
+_clean() { local p; for p in "${CLEANUP_PATHS[@]:-}"; do [ -n "$p" ] && rm -rf "$p" 2>/dev/null; done; }
+trap _clean EXIT
+
+FAKE_HOME=$(mktemp -d -t cjc.home.XXXXXX); CLEANUP_PATHS+=("$FAKE_HOME")
+
+# Build a fresh temp repo on a feature/issue-1 branch with a baseline journal.
+_new_repo() {
+  local r; r=$(mktemp -d -t cjc.repo.XXXXXX); CLEANUP_PATHS+=("$r")
+  git -C "$r" init -q
+  git -C "$r" checkout -q -b feature/issue-1-test 2>/dev/null || git -C "$r" checkout -q -B feature/issue-1-test
+  git -C "$r" config user.email "t@example.com"
+  git -C "$r" config user.name "Test"
+  mkdir -p "$r/.decisions"
+  printf -- '---\nissue: 1\n---\n\n<!-- auto-log: seed -->\n' > "$r/.decisions/issue-1.md"
+  git -C "$r" add -A
+  git -C "$r" commit -q -m "init"
+  printf '%s' "$r"
+}
+
+_run_helper() { ( cd "$1" && HOME="$FAKE_HOME" "$HELPER" ) 2>&1; }
+_subject() { git -C "$1" log -1 --format='%s'; }
+_porcelain() { git -C "$1" status --porcelain; }
+
+# --- Scenario A: journal-only modification → committed, tree clean -----------
+_flow_test_begin "journal-only churn is committed as chore(decisions):"
+R=$(_new_repo)
+printf '<!-- auto-log: edit 1 -->\n' >> "$R/.decisions/issue-1.md"
+_run_helper "$R" >/dev/null
+assert_equal "chore(decisions): record session journal entries" "$(_subject "$R")" "housekeeping commit created"
+assert_equal "" "$(_porcelain "$R")" "working tree clean after commit"
+
+# --- Scenario B: a non-journal change present → no-op -----------------------
+_flow_test_begin "non-journal change present → helper no-ops"
+R=$(_new_repo)
+BEFORE=$(_subject "$R")
+printf '<!-- auto-log: edit -->\n' >> "$R/.decisions/issue-1.md"
+printf 'code\n' > "$R/src.txt"
+OUT=$(_run_helper "$R")
+assert_equal "$BEFORE" "$(_subject "$R")" "no new commit when non-journal dirty"
+assert_contains "non-journal changes" "$OUT" "explains why it skipped"
+
+# --- Scenario C: brand-new untracked journal file → committed ---------------
+_flow_test_begin "new untracked journal .md is staged and committed"
+R=$(_new_repo)
+printf -- '---\nissue: 2\n---\n' > "$R/.decisions/issue-2.md"
+_run_helper "$R" >/dev/null
+assert_equal "chore(decisions): record session journal entries" "$(_subject "$R")" "new journal file committed"
+assert_equal "" "$(_porcelain "$R")" "tree clean (issue-2.md now tracked)"
+
+# --- Scenario D: lockfile alongside journal churn → .md committed, lock left -
+_flow_test_begin "journal lockfile is never staged"
+R=$(_new_repo)
+printf '<!-- auto-log: edit -->\n' >> "$R/.decisions/issue-1.md"
+: > "$R/.decisions/issue-1.md.lock"
+_run_helper "$R" >/dev/null
+assert_equal "chore(decisions): record session journal entries" "$(_subject "$R")" "journal .md committed"
+# Only the untracked lock remains dirty.
+assert_equal "?? .decisions/issue-1.md.lock" "$(_porcelain "$R")" "lock left untracked, not committed"
+
+# --- Scenario E: clean tree → no-op, exit 0 ---------------------------------
+_flow_test_begin "clean tree → no-op exit 0"
+R=$(_new_repo)
+BEFORE=$(_subject "$R")
+( cd "$R" && HOME="$FAKE_HOME" "$HELPER" ); RC=$?
+assert_exit 0 "$RC" "exit 0 on clean tree"
+assert_equal "$BEFORE" "$(_subject "$R")" "no commit on clean tree"
+
+# --- Recursion guard: log-commits.sh skips the chore(decisions): commit ------
+_flow_test_begin "chore(decisions): commit does not trigger a re-append (Guard 1)"
+R=$(_new_repo)
+printf '<!-- auto-log: edit -->\n' >> "$R/.decisions/issue-1.md"
+_run_helper "$R" >/dev/null
+COUNT_BEFORE=$(grep -c 'auto-log' "$R/.decisions/issue-1.md")
+# Simulate the PostToolUse Bash hook firing for the housekeeping commit.
+printf '{"tool_input":{"command":"git commit -m x"}}' \
+  | ( cd "$R" && HOME="$FAKE_HOME" bash "$LOGCOMMITS" ) >/dev/null 2>&1 || true
+COUNT_AFTER=$(grep -c 'auto-log' "$R/.decisions/issue-1.md")
+assert_equal "$COUNT_BEFORE" "$COUNT_AFTER" "no new auto-log line appended after chore(decisions): commit"

--- a/plugins/flow/tests/plugin-root-resolution.test.sh
+++ b/plugins/flow/tests/plugin-root-resolution.test.sh
@@ -1,0 +1,102 @@
+# Tests for the inline plugin-root resolver used by command !-bash blocks.
+#
+# Contract (see references/plugin-root-resolution.md): the inline resolver
+# yields the flow plugin root, probing in order — $CLAUDE_PLUGIN_ROOT, in-repo
+# plugins/flow, highest-semver marketplace cache install, marketplaces checkout
+# — and yields empty when none has an executable bin/cascade-resolve.sh.
+#
+# The resolver is extracted from the reference doc (the single source of truth)
+# so this test fails if the documented form drifts from a working resolver.
+
+CLEANUP_PATHS=()
+_clean() { local p; for p in "${CLEANUP_PATHS[@]:-}"; do [ -n "$p" ] && rm -rf "$p" 2>/dev/null; done; }
+trap _clean EXIT
+
+DOC="$REPO_ROOT/plugins/flow/references/plugin-root-resolution.md"
+
+# Extract the canonical inline form: "$(...)/bin/cascade-resolve.sh"
+RLINE=$(grep -m1 '^"\$(__fr=' "$DOC" 2>/dev/null)
+RESOLVER=${RLINE#\"}
+RESOLVER=${RESOLVER%/bin/cascade-resolve.sh\"}
+
+_flow_test_begin "resolver expression is extractable from the reference doc"
+if [ -n "$RESOLVER" ] && [ "$RESOLVER" != "$RLINE" ]; then
+  _flow_assert_pass "extracted \$(...) root expression"
+else
+  _flow_assert_fail "could not extract resolver from $DOC"
+fi
+
+# Helper: run the extracted resolver under a controlled cwd + HOME + env.
+# Usage: _resolve <cwd> <home> <cpr-or-empty>
+_resolve() {
+  local cwd="$1" home="$2" cpr="$3"
+  (
+    cd "$cwd" || exit 1
+    export HOME="$home"
+    if [ -n "$cpr" ]; then export CLAUDE_PLUGIN_ROOT="$cpr"; else unset CLAUDE_PLUGIN_ROOT; fi
+    eval "printf '%s' $RESOLVER"
+  )
+}
+
+# Make an executable stub bin/cascade-resolve.sh under <dir>.
+_stub_root() {
+  mkdir -p "$1/bin"
+  printf '#!/bin/sh\nexit 0\n' > "$1/bin/cascade-resolve.sh"
+  chmod +x "$1/bin/cascade-resolve.sh"
+}
+
+BASE=$(mktemp -d -t plugin-root.tests.XXXXXX)
+CLEANUP_PATHS+=("$BASE")
+
+# Scenario 1: CLAUDE_PLUGIN_ROOT set to a valid root → wins outright.
+_flow_test_begin "env CLAUDE_PLUGIN_ROOT wins when it has bin/cascade-resolve.sh"
+ENVROOT="$BASE/envroot"; _stub_root "$ENVROOT"
+CLEAN="$BASE/cwd-empty-1"; mkdir -p "$CLEAN"
+ROOT=$(_resolve "$CLEAN" "$BASE/home-empty" "$ENVROOT")
+assert_equal "$ENVROOT" "$ROOT" "env root selected"
+
+# Scenario 2: env unset, in-repo plugins/flow present (cwd-relative) → wins.
+_flow_test_begin "in-repo plugins/flow wins when env unset"
+INREPO="$BASE/repo"; mkdir -p "$INREPO"; _stub_root "$INREPO/plugins/flow"
+ROOT=$(_resolve "$INREPO" "$BASE/home-empty" "")
+assert_equal "plugins/flow" "$ROOT" "in-repo relative path selected"
+
+# Scenario 3: env unset, no in-repo, marketplace cache has 2.4.0 + 3.1.0 →
+# highest semver wins.
+_flow_test_begin "highest-semver marketplace cache install wins"
+H3="$BASE/home-cache"
+_stub_root "$H3/.claude/plugins/cache/synapti-marketplace/flow/2.4.0"
+_stub_root "$H3/.claude/plugins/cache/synapti-marketplace/flow/3.1.0"
+_stub_root "$H3/.claude/plugins/cache/synapti-marketplace/flow/2.10.0"
+CLEAN3="$BASE/cwd-empty-3"; mkdir -p "$CLEAN3"
+ROOT=$(_resolve "$CLEAN3" "$H3" "")
+assert_equal "$H3/.claude/plugins/cache/synapti-marketplace/flow/3.1.0" "$ROOT" "newest cache version selected (3.1.0 > 2.10.0 > 2.4.0)"
+
+# Scenario 4: env unset, no in-repo, no cache, marketplaces checkout present.
+_flow_test_begin "marketplaces checkout is the last-resort fallback"
+H4="$BASE/home-mkt"
+_stub_root "$H4/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"
+CLEAN4="$BASE/cwd-empty-4"; mkdir -p "$CLEAN4"
+ROOT=$(_resolve "$CLEAN4" "$H4" "")
+assert_equal "$H4/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow" "$ROOT" "marketplaces path selected"
+
+# Scenario 5: nothing resolvable → empty (drives the caller's loud-fail guard).
+_flow_test_begin "no candidate → empty result (loud-fail contract)"
+CLEAN5="$BASE/cwd-empty-5"; mkdir -p "$CLEAN5"
+ROOT=$(_resolve "$CLEAN5" "$BASE/home-empty" "")
+assert_equal "" "$ROOT" "empty when no root has bin/cascade-resolve.sh"
+# And the helper path a caller builds is non-executable → guard fires.
+_flow_test_begin "empty root yields a non-executable helper path"
+if [ ! -x "$ROOT/bin/cascade-resolve.sh" ]; then
+  _flow_assert_pass "/bin/cascade-resolve.sh is not executable when root empty"
+else
+  _flow_assert_fail "unexpectedly executable"
+fi
+
+# Scenario 6: env set but INVALID (no bin) falls through to other candidates.
+_flow_test_begin "invalid env root falls through to cache"
+H6="$BASE/home-cache6"
+_stub_root "$H6/.claude/plugins/cache/synapti-marketplace/flow/3.1.0"
+CLEAN6="$BASE/cwd-empty-6"; mkdir -p "$CLEAN6"
+ROOT=$(_resolve "$CLEAN6" "$H6" "$BASE/does-not-exist")
+assert_equal "$H6/.claude/plugins/cache/synapti-marketplace/flow/3.1.0" "$ROOT" "fell through invalid env to cache"

--- a/plugins/flow/tests/plugin-root-resolution.test.sh
+++ b/plugins/flow/tests/plugin-root-resolution.test.sh
@@ -100,3 +100,13 @@ _stub_root "$H6/.claude/plugins/cache/synapti-marketplace/flow/3.1.0"
 CLEAN6="$BASE/cwd-empty-6"; mkdir -p "$CLEAN6"
 ROOT=$(_resolve "$CLEAN6" "$H6" "$BASE/does-not-exist")
 assert_equal "$H6/.claude/plugins/cache/synapti-marketplace/flow/3.1.0" "$ROOT" "fell through invalid env to cache"
+
+# Scenario 7 (drift guard): every resolver embedded in the command/agent files
+# must be byte-identical to the canonical form in the reference doc. Catches a
+# future edit that hand-tweaks one site out of sync.
+_flow_test_begin "all embedded resolver sites match the canonical doc form (no drift)"
+UNIQ=$(grep -rhoE '\$\(__fr=.*;echo "\$__fr"\)' \
+  "$REPO_ROOT/plugins/flow/commands" "$REPO_ROOT/plugins/flow/agents" 2>/dev/null | sort -u)
+NFORMS=$(printf '%s\n' "$UNIQ" | grep -c .)
+assert_equal "1" "$NFORMS" "exactly one unique resolver form across all embedded sites"
+assert_equal "$RESOLVER" "$UNIQ" "embedded resolver is byte-identical to the reference-doc canonical form"

--- a/plugins/flow/tests/plugin-root-resolution.test.sh
+++ b/plugins/flow/tests/plugin-root-resolution.test.sh
@@ -106,7 +106,8 @@ assert_equal "$H6/.claude/plugins/cache/synapti-marketplace/flow/3.1.0" "$ROOT" 
 # future edit that hand-tweaks one site out of sync.
 _flow_test_begin "all embedded resolver sites match the canonical doc form (no drift)"
 UNIQ=$(grep -rhoE '\$\(__fr=.*;echo "\$__fr"\)' \
-  "$REPO_ROOT/plugins/flow/commands" "$REPO_ROOT/plugins/flow/agents" 2>/dev/null | sort -u)
+  "$REPO_ROOT/plugins/flow/commands" "$REPO_ROOT/plugins/flow/agents" \
+  "$REPO_ROOT/plugins/flow/references" 2>/dev/null | sort -u)
 NFORMS=$(printf '%s\n' "$UNIQ" | grep -c .)
 assert_equal "1" "$NFORMS" "exactly one unique resolver form across all embedded sites"
 assert_equal "$RESOLVER" "$UNIQ" "embedded resolver is byte-identical to the reference-doc canonical form"


### PR DESCRIPTION
## Problem

Flow command `!`/bash blocks located bundled `bin/` helpers via `${CLAUDE_PLUGIN_ROOT:-plugins/flow}/bin/…`. Per the official Claude Code docs, `CLAUDE_PLUGIN_ROOT` is set for **hooks, MCP, LSP, monitors, and skill/agent substitution** — but is **undocumented for slash-command bash blocks**, and is empirically **unset** when an agent runs the steps through its Bash tool. The `:-plugins/flow` fallback only resolves for an **in-repo checkout**, so on a **marketplace install** every bundled helper was unreachable.

Observed in a consumer repo running flow 3.1.0 with `flow.goals.requireGoalForStart: true`: `/flow:start` could not find `cascade-resolve.sh`, so the FlowGoal was never auto-created (`.flow/` never appeared) and the `/flow:merge` goal gate had nothing to check.

Separately, the tracked `.decisions/` journal is appended to by the auto-log hooks during normal work and never committed, so it shows dirty at PR time.

## Fix

- **Inline plugin-root resolver** across all command `!`/bash sites (and 2 bare `${CLAUDE_PLUGIN_ROOT}` uses in `goal.md`): probe `$CLAUDE_PLUGIN_ROOT` → in-repo `plugins/flow` → highest-semver marketplace cache install → marketplaces checkout. Existing `[ -x "$CASCADE" ]` guards preserve loud-fail. Documented in `references/plugin-root-resolution.md`; a drift-guard test asserts every embedded site is byte-identical to the canonical form. Hooks are unchanged (they receive `CLAUDE_PLUGIN_ROOT`).
- **`bin/commit-journal-churn.sh`** wired into `/flow:pr` before push: sweeps journal-only churn into a `chore(decisions):` commit. No-ops on any non-journal change, never stages lockfiles, scans with `-uall` so a fresh untracked journal dir is handled, and its subject is skipped by `log-commits.sh` Guard 1 (no re-append loop).
- **`.gitignore`** for `.decisions/*.lock`, `.trail/`, `.claude/scheduled_tasks.lock`.
- Applied the resolver to 3 user-facing quickstart/contract copy-paste snippets that carried the same idiom.

## Testing

- `bash plugins/flow/tests/run.sh` → **833 pass, 0 fail** (includes 2 new test files: `plugin-root-resolution.test.sh`, `commit-journal-churn.test.sh`).
- Verified end-to-end: the committed `start.md` resolver line, run from a marketplace-consumer repo with `CLAUDE_PLUGIN_ROOT` unset and no in-repo `plugins/flow/`, resolves `cascade-resolve.sh` to the real cache install.

## Review

Ran the 5-facet parallel review (code, security, conventions, error-handling, tests) + holdout. Caught and fixed one confirmed P2 (journal scan missed a wholly-untracked `.decisions/` — fixed with `-uall` + regression test) and P3 consistency nits. Security: 0 findings (resolver stays within the single-user `~/.claude` trust domain; helper commits only `.decisions/*.md`).

Bumps flow 3.1.0 → 3.1.1.