### PR TITLE
chore(flow): enable v3 FlowGoal gating

### DIFF
--- a/.claude/settings.flow.json
+++ b/.claude/settings.flow.json
@@ -80,5 +80,10 @@
     ],
     "maxIterations": 3,
     "requireVisualVerification": false
+  },
+  "flow": {
+    "goals": {
+      "requireGoalForStart": true
+    }
   }
 }


### PR DESCRIPTION
Enables v3 mode for this repo by setting `flow.goals.requireGoalForStart: true` in `.claude/settings.flow.json`.

Now that #118 makes command-bash plugin-root resolution work on marketplace installs, v3 goal auto-creation is safe to require here:
- `/flow:start <issue>` auto-creates `.flow/goals/issue-N.goal.yaml` after the spec gate.
- `/flow:pr` and `/flow:merge` enforce an *achieved* FlowGoal.
- `stopHookEnforcement` left at the default `warn` (non-blocking); `executeVerificationCommands` left default (off).

**Merge note:** this PR flips the goal gate on, so `/flow:merge` would self-block (no goal exists for this config-only branch). Merging with a plain squash is intentional — it's a config change with no review findings.