### PR TITLE
fix(flow): copy $ARGUMENTS before bash parameter-expansion in command blocks

### DIFF
--- a/.decisions/issue-120.md
+++ b/.decisions/issue-120.md
@@ -12,6 +12,12 @@ artifacts:
   result: achieved
   evidence_bundle: .flow/runs/20260525T1810Z-issue-120-eval
   failures: none
+- type: review-cycle
+  captured_at: '2026-05-25T16:35:50Z'
+  cycle: 1
+  path: B
+  findings_count: 2
+  pr: 121
 ---
 # Issue #120 — `${ARGUMENTS%% *}` in command !-blocks expands to empty
 
@@ -142,3 +148,5 @@ fixture fix + lint guard).
 <!-- auto-log: 2026-05-25 18:34 Edit /Users/danielbentes/synapti-marketplace/.gitignore -->
 
 <!-- auto-log: 2026-05-25 18:34 commit "chore(flow): add achieved FlowGoal contract for issue 120" -->
+
+<!-- auto-log: 2026-05-25 18:36 commit "chore(flow): link FlowGoal issue-120 to PR #121" -->

--- a/.decisions/issue-120.md
+++ b/.decisions/issue-120.md
@@ -18,6 +18,12 @@ artifacts:
   path: B
   findings_count: 2
   pr: 121
+- type: review-cycle
+  captured_at: '2026-05-25T16:44:49Z'
+  cycle: 2
+  path: B
+  findings_count: 1
+  pr: 121
 ---
 # Issue #120 — `${ARGUMENTS%% *}` in command !-blocks expands to empty
 
@@ -150,3 +156,13 @@ fixture fix + lint guard).
 <!-- auto-log: 2026-05-25 18:34 commit "chore(flow): add achieved FlowGoal contract for issue 120" -->
 
 <!-- auto-log: 2026-05-25 18:36 commit "chore(flow): link FlowGoal issue-120 to PR #121" -->
+
+<!-- auto-log: 2026-05-25 18:42 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/command-frontmatter.test.sh -->
+
+<!-- auto-log: 2026-05-25 18:43 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/command-frontmatter.test.sh -->
+
+<!-- auto-log: 2026-05-25 18:43 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/command-frontmatter.test.sh -->
+
+<!-- auto-log: 2026-05-25 18:43 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/command-frontmatter.test.sh -->
+
+<!-- auto-log: 2026-05-25 18:44 commit "test(flow): broaden $ARGUMENTS lint to length/indirection/array forms" -->

--- a/.decisions/issue-120.md
+++ b/.decisions/issue-120.md
@@ -1,0 +1,119 @@
+# Issue #120 — `${ARGUMENTS%% *}` in command !-blocks expands to empty
+
+**Branch**: `fix/issue-120-arguments-param-expansion`
+**Type**: bug (flow plugin self-fix)
+
+## Problem
+
+Claude Code's slash-command preprocessor substitutes bare `$ARGUMENTS` and
+`${ARGUMENTS}` (no operator), but NOT bash parameter expansions like
+`${ARGUMENTS%% *}`. The bash interpreter then sees an undefined `ARGUMENTS`
+variable and the expansion yields the empty string, so `ISSUE_NUM` ends up
+empty and downstream gates (`PREFLIGHT_STATE`, `FLOW_GOAL_STATE`) silently
+degrade to their no-issue paths even when the user passed a number.
+
+Self-demonstrated this session: invoking `/flow:start <120 URL>` rendered
+`ISSUE_NUM=` (empty), `PREFLIGHT_STATE=BLOCKED`, `RUN_ID=...issue-nonum`.
+
+## Why it was never caught
+
+The unit fixture `flow-start-onboarding.test.sh` ran the gate block as
+`ARGUMENTS="42" bash -c "$BLOCK"` — injecting `ARGUMENTS` as a real bash env
+var, so `${ARGUMENTS%% *}` expanded correctly *in the test*. The lint
+`command-frontmatter.test.sh` Test 3 only checked that `$ARGUMENTS` was
+*quoted* (word-split safety) and explicitly blessed `"${ARGUMENTS%% *}"` as
+the "case-validated form". Neither test modeled Claude Code's text-only
+substitution, so both stayed green while production was broken.
+
+## Specification
+
+### Non-goals
+- Not changing the first-token extraction *semantics* (still strip trailing
+  prose; still reject non-digit input where it was rejected before).
+- Not the documentation-only alternative from the issue — the code refactor
+  is definitive; docs alone leave the silent-degradation behavior.
+- Not touching bare `$ARGUMENTS` uses in prose / agent-prompt strings (those
+  are substituted correctly).
+
+### Failure modes
+- Lint over-matches and flags legitimate `${SOMEVAR%% *}` on non-ARGUMENTS
+  vars → anchor strictly to `${ARGUMENTS<op>`.
+- Refactor introduces an unquoted `$ARGUMENTS` → existing Test 3 still guards
+  quoting; keep it.
+- `_RAW` name collides with an existing var in a block → grep confirms no
+  prior `_RAW` usage.
+
+### Interface contract
+Replace `ARG1="${ARGUMENTS%% *}"` with:
+```bash
+_RAW="$ARGUMENTS"        # Claude Code substitutes bare $ARGUMENTS
+ARG1="${_RAW%% *}"       # bash parameter-expansion now hits a real var
+```
+Inline one-liner form (start.md:662) collapses to:
+`_RAW="$ARGUMENTS"; ARG1="${_RAW%% *}"; case "$ARG1" in ...`
+
+## Acceptance criteria (derived — issue had none)
+
+| # | Criterion | Verification command |
+|---|-----------|----------------------|
+| 1 | No `${ARGUMENTS<op>}` param-expansion remains in flow command !-blocks | `grep -rn '\${ARGUMENTS[%#/^,:+@]' plugins/flow/commands/` → zero |
+| 2 | Onboarding fixture simulates CC substitution, not env-var injection | `bash plugins/flow/tests/run.sh flow-start-onboarding.test.sh` |
+| 3 | Static lint rejects the broken form (regression guard) | `bash plugins/flow/tests/run.sh command-frontmatter.test.sh` |
+| 4 | Full flow test suite passes | `bash plugins/flow/tests/run.sh` |
+
+Scope confirmed with user: **Full fix + regression guard** (all 7 commands +
+fixture fix + lint guard).
+
+<!-- auto-log: 2026-05-25 17:29 Write /Users/danielbentes/synapti-marketplace/.decisions/issue-120.md -->
+
+<!-- auto-log: 2026-05-25 17:29 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/command-frontmatter.test.sh -->
+
+<!-- auto-log: 2026-05-25 17:30 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/command-frontmatter.test.sh -->
+
+<!-- auto-log: 2026-05-25 17:32 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/start.md -->
+
+<!-- auto-log: 2026-05-25 17:32 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/start.md -->
+
+<!-- auto-log: 2026-05-25 17:32 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/address.md -->
+
+<!-- auto-log: 2026-05-25 17:32 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/merge.md -->
+
+<!-- auto-log: 2026-05-25 17:32 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/review.md -->
+
+<!-- auto-log: 2026-05-25 17:32 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/resolve.md -->
+
+<!-- auto-log: 2026-05-25 17:32 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/design.md -->
+
+<!-- auto-log: 2026-05-25 17:32 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/brainstorm.md -->
+
+<!-- auto-log: 2026-05-25 17:34 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/resume.md -->
+
+<!-- auto-log: 2026-05-25 17:34 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/command-frontmatter.test.sh -->
+
+<!-- auto-log: 2026-05-25 17:35 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/command-frontmatter.test.sh -->
+
+<!-- auto-log: 2026-05-25 17:36 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/flow-start-onboarding.test.sh -->
+
+<!-- auto-log: 2026-05-25 17:42 Write /Users/danielbentes/synapti-marketplace/.claude/agent-memory/flow-code-reviewer/comment_strip_hash_operator.md -->
+
+<!-- auto-log: 2026-05-25 17:42 Edit /Users/danielbentes/synapti-marketplace/.claude/agent-memory/flow-code-reviewer/MEMORY.md -->
+
+<!-- auto-log: 2026-05-25 17:44 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/command-frontmatter.test.sh -->
+
+<!-- auto-log: 2026-05-25 17:46 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/command-frontmatter.test.sh -->
+
+<!-- auto-log: 2026-05-25 17:46 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/command-frontmatter.test.sh -->
+
+<!-- auto-log: 2026-05-25 17:46 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/command-frontmatter.test.sh -->
+
+<!-- auto-log: 2026-05-25 17:46 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/command-frontmatter.test.sh -->
+
+<!-- auto-log: 2026-05-25 17:46 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/command-frontmatter.test.sh -->
+
+<!-- auto-log: 2026-05-25 17:46 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/command-frontmatter.test.sh -->
+
+<!-- auto-log: 2026-05-25 17:47 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/flow-start-onboarding.test.sh -->
+
+<!-- auto-log: 2026-05-25 17:47 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/flow-start-onboarding.test.sh -->
+
+<!-- auto-log: 2026-05-25 17:47 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/flow-start-onboarding.test.sh -->

--- a/.decisions/issue-120.md
+++ b/.decisions/issue-120.md
@@ -1,3 +1,18 @@
+---
+issue: 120
+created: '2026-05-25T16:04:58Z'
+artifacts:
+- type: goal-created
+  captured_at: '2026-05-25T16:04:58Z'
+  goal_id: issue-120
+  source: issue
+- type: goal-evaluation
+  captured_at: '2026-05-25T16:11:30Z'
+  goal_id: issue-120
+  result: achieved
+  evidence_bundle: .flow/runs/20260525T1810Z-issue-120-eval
+  failures: none
+---
 # Issue #120 — `${ARGUMENTS%% *}` in command !-blocks expands to empty
 
 **Branch**: `fix/issue-120-arguments-param-expansion`
@@ -117,3 +132,13 @@ fixture fix + lint guard).
 <!-- auto-log: 2026-05-25 17:47 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/flow-start-onboarding.test.sh -->
 
 <!-- auto-log: 2026-05-25 17:47 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/flow-start-onboarding.test.sh -->
+
+<!-- auto-log: 2026-05-25 17:48 commit "fix(flow): copy $ARGUMENTS into a local before bash parameter-expansion in command blocks" -->
+
+<!-- auto-log: 2026-05-25 18:06 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/resume.md -->
+
+<!-- auto-log: 2026-05-25 18:07 commit "fix(flow): copy $ARGUMENTS into a local before bash parameter-expansion in command blocks" -->
+
+<!-- auto-log: 2026-05-25 18:34 Edit /Users/danielbentes/synapti-marketplace/.gitignore -->
+
+<!-- auto-log: 2026-05-25 18:34 commit "chore(flow): add achieved FlowGoal contract for issue 120" -->

--- a/.flow/goals/issue-120.goal.yaml
+++ b/.flow/goals/issue-120.goal.yaml
@@ -1,0 +1,99 @@
+apiVersion: flow.synapti.ai/v1
+kind: FlowGoal
+metadata:
+  id: issue-120
+  created_at: '2026-05-25T16:04:45Z'
+  created_by: /flow:goal
+  owner: daniel.bentes@gmail.com
+scope:
+  repo: synaptiai/synapti-marketplace
+  branch: fix/issue-120-arguments-param-expansion
+  issue: 120
+  pr: null
+  journal: .decisions/issue-120.md
+objective:
+  outcome: 'Issue #120 is implemented and verified: command !-blocks extract the first
+    $ARGUMENTS token correctly under Claude Code''s bare-only substitution.'
+  source:
+    issue_title: 'flow: ${ARGUMENTS%% *} in command !-blocks expands to empty (Claude
+      Code substitutes bare $NAME only)'
+  acceptance_criteria:
+  - id: AC1
+    text: No bash parameter-expansion on $ARGUMENTS remains in any flow command executable
+      block.
+    verification_command: '! grep -rqE ''[$][{]ARGUMENTS[%#/:^,@+-]'' plugins/flow/commands/'
+    must_pass: true
+    status: pending
+    evidence_ref: null
+    last_evaluated_at: null
+    last_result: null
+  - id: AC2
+    text: The onboarding gate fixture models Claude Code text-substitution (not env-var
+      injection) and asserts the old form degrades to skip while the fixed form produces
+      create.
+    verification_command: bash plugins/flow/tests/run.sh flow-start-onboarding.test.sh
+    must_pass: true
+    status: pending
+    evidence_ref: null
+    last_evaluated_at: null
+    last_result: null
+  - id: AC3
+    text: A static lint rejects parameter-expansion on $ARGUMENTS in !/bash/sh fences
+      and self-guards full operator coverage with no false positives.
+    verification_command: bash plugins/flow/tests/run.sh command-frontmatter.test.sh
+    must_pass: true
+    status: pending
+    evidence_ref: null
+    last_evaluated_at: null
+    last_result: null
+  - id: AC4
+    text: The full flow test suite passes.
+    verification_command: bash plugins/flow/tests/run.sh
+    must_pass: true
+    status: pending
+    evidence_ref: null
+    last_evaluated_at: null
+    last_result: null
+specification:
+  non_goals:
+  - Not changing first-token extraction semantics (still strip trailing prose; still
+    reject non-digit input where rejected before).
+  - Not the documentation-only alternative; the code refactor is definitive.
+  - Not touching bare $ARGUMENTS uses in prose / agent-prompt strings (substituted
+    correctly).
+  failure_modes:
+  - Lint over-matches and flags legitimate ${SOMEVAR%% *} on non-ARGUMENTS vars ->
+    anchored strictly to ${ARGUMENTS<op>.
+  - Refactor introduces an unquoted $ARGUMENTS -> existing Test 3 still guards quoting.
+  - 'Comment-strip eats the # in ${ARGUMENTS#foo} -> word-boundary strip preserves
+    operator #; self-guard asserts coverage.'
+  interface_contracts:
+  - Replace ARG1="${ARGUMENTS%% *}" with _RAW="$ARGUMENTS" then ARG1="${_RAW%% *}";
+    bare $ARGUMENTS is what Claude Code substitutes.
+constraints:
+  tdd_required: true
+  require_all_pass: true
+  no_calendar_estimates: true
+  no_tier3_without_confirmation: true
+evaluator:
+  type: deterministic
+  command: /flow:goal evaluate
+  judge_agent: goal-evaluator-judge
+  evidence_bundle_format: plugins/flow/references/evidence-bundle-format.md
+  denied_context:
+  - implementation_rationale
+  - self_review_findings
+continuation:
+  mode: flow_managed
+  on_incomplete: continue_next_activity
+  on_blocked: six_field_escalation
+  on_complete: mark_achieved
+  max_iterations: 20
+lifecycle:
+  status: achieved
+  turns_evaluated: 1
+  last_evaluation:
+    result: pass
+    reason: All 4 acceptance criteria pass deterministically (AC1 no broken forms;
+      AC2 onboarding fixture 73/73; AC3 lint 10/10; AC4 full suite 840/840).
+    at: '2026-05-25T16:34:25Z'

--- a/.flow/goals/issue-120.goal.yaml
+++ b/.flow/goals/issue-120.goal.yaml
@@ -9,7 +9,7 @@ scope:
   repo: synaptiai/synapti-marketplace
   branch: fix/issue-120-arguments-param-expansion
   issue: 120
-  pr: null
+  pr: 121
   journal: .decisions/issue-120.md
 objective:
   outcome: 'Issue #120 is implemented and verified: command !-blocks extract the first

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ docs/flow-team-session/*.pdf
 # flock is released), session audit trail, and scheduler lock — all ephemeral
 # per-developer runtime state, never committed.
 .decisions/*.lock
+.flow/goals/*.lock
 .trail/
 .claude/scheduled_tasks.lock
 

--- a/plugins/flow/commands/address.md
+++ b/plugins/flow/commands/address.md
@@ -38,7 +38,8 @@ Systematic feedback resolution. Follows Explore > Plan > Code > Verify loop.
 #
 # Output: `###`-headed sections + KEY=value per
 # `references/command-output-format.md`. STATE=blocked on bad input.
-ARG1="${ARGUMENTS%% *}"
+_RAW="$ARGUMENTS"  # Claude Code substitutes the bare arg token, not bash parameter-expansion
+ARG1="${_RAW%% *}"
 case "$ARG1" in
   ''|*[!0-9]*) PR_NUM="" ;;
   *) PR_NUM="$ARG1" ;;
@@ -160,7 +161,8 @@ When `FLOW_RUN_STATE=create`, invoke `Skill(run-state-management)` to create `.f
 
 ```!
 # Digit-validate PR_NUM (matches Phase 1 block).
-ARG1="${ARGUMENTS%% *}"
+_RAW="$ARGUMENTS"  # Claude Code substitutes the bare arg token, not bash parameter-expansion
+ARG1="${_RAW%% *}"
 case "$ARG1" in
   ''|*[!0-9]*) PR_NUM="" ;;
   *) PR_NUM="$ARG1" ;;

--- a/plugins/flow/commands/brainstorm.md
+++ b/plugins/flow/commands/brainstorm.md
@@ -37,7 +37,8 @@ Understand the goal before generating options. Execute in parallel:
 #
 # Output: `###`-headed sections + KEY=value per
 # `references/command-output-format.md`.
-ARG1="${ARGUMENTS%% *}"
+_RAW="$ARGUMENTS"  # Claude Code substitutes the bare arg token, not bash parameter-expansion
+ARG1="${_RAW%% *}"
 case "$ARG1" in
   ''|*[!0-9]*) ISSUE_NUM="" ;;
   *) ISSUE_NUM="$ARG1" ;;

--- a/plugins/flow/commands/design.md
+++ b/plugins/flow/commands/design.md
@@ -37,7 +37,8 @@ Map existing architecture before proposing anything. Execute in parallel:
 #
 # Output: `###`-headed sections + KEY=value per
 # `references/command-output-format.md`.
-ARG1="${ARGUMENTS%% *}"
+_RAW="$ARGUMENTS"  # Claude Code substitutes the bare arg token, not bash parameter-expansion
+ARG1="${_RAW%% *}"
 case "$ARG1" in
   ''|*[!0-9]*) ISSUE_NUM="" ;;
   *) ISSUE_NUM="$ARG1" ;;

--- a/plugins/flow/commands/merge.md
+++ b/plugins/flow/commands/merge.md
@@ -29,7 +29,8 @@ Tier 3 operation — **always requires human confirmation**. This is non-negotia
 # Output: `###`-headed sections + KEY=value per
 # `references/command-output-format.md`. STATE=blocked on bad input;
 # downstream Phase 2 reads each named field directly.
-ARG1="${ARGUMENTS%% *}"
+_RAW="$ARGUMENTS"  # Claude Code substitutes the bare arg token, not bash parameter-expansion
+ARG1="${_RAW%% *}"
 case "$ARG1" in
   ''|*[!0-9]*) PR_NUM="" ;;
   *) PR_NUM="$ARG1" ;;
@@ -140,7 +141,8 @@ Parse the latest `FLOW_RESOLUTION_CYCLE` and `FLOW_REVIEW_CYCLE` comments to ver
 # Capture gh exit code: a silent gh failure (auth, network) must fail the gate
 # CLOSED, not pass it open. PR_NUM is digit-validated (matches Phase 1 block);
 # a non-digit token rejects rather than reaching downstream shell or echo.
-ARG1="${ARGUMENTS%% *}"
+_RAW="$ARGUMENTS"  # Claude Code substitutes the bare arg token, not bash parameter-expansion
+ARG1="${_RAW%% *}"
 case "$ARG1" in
   ''|*[!0-9]*) PR_NUM="" ;;
   *) PR_NUM="$ARG1" ;;
@@ -416,7 +418,8 @@ if [ ! -x "$CASCADE" ]; then
   true; exit 0
 fi
 RUNTIME_ENABLED=$("$CASCADE" --default "true" '.flow.runtime.enabled' 2>/dev/null)
-ARG1="${ARGUMENTS%% *}"
+_RAW="$ARGUMENTS"  # Claude Code substitutes the bare arg token, not bash parameter-expansion
+ARG1="${_RAW%% *}"
 case "$ARG1" in
   ''|*[!0-9]*) PR_NUM="" ;;
   *) PR_NUM="$ARG1" ;;

--- a/plugins/flow/commands/resolve.md
+++ b/plugins/flow/commands/resolve.md
@@ -44,7 +44,8 @@ Determine invocation mode from `$ARGUMENTS`:
 #
 # Output: `###`-headed sections + KEY=value per
 # `references/command-output-format.md`.
-ARG1="${ARGUMENTS%% *}"
+_RAW="$ARGUMENTS"  # Claude Code substitutes the bare arg token, not bash parameter-expansion
+ARG1="${_RAW%% *}"
 case "$ARG1" in
   ''|*[!a-zA-Z0-9._/-]*) RESOLVE_TARGET="" ;;
   *) RESOLVE_TARGET="$ARG1" ;;

--- a/plugins/flow/commands/resume.md
+++ b/plugins/flow/commands/resume.md
@@ -36,7 +36,7 @@ If `$ARGUMENTS` is supplied: use it as the run-id directly. Verify `.flow/runs/<
 If no arguments: find the most-recently-modified `run.yaml` with `state.status` in `{active, blocked}`.
 
 ```bash
-RUN_ID="${ARGUMENTS:-}"
+RUN_ID="$ARGUMENTS"  # bare form so Claude Code substitutes it (a default-operator form would NOT be substituted); empty when no arg passed
 if [ -z "$RUN_ID" ]; then
   RUN_ID=$(python3 - <<'PYEOF'
 import os, glob, sys, yaml

--- a/plugins/flow/commands/review.md
+++ b/plugins/flow/commands/review.md
@@ -30,7 +30,8 @@ Multi-faceted code review with parallel analysis. Follows Explore > Plan > Code 
 #
 # Output: `###`-headed sections + KEY=value per
 # `references/command-output-format.md`. STATE=blocked on bad input.
-ARG1="${ARGUMENTS%% *}"
+_RAW="$ARGUMENTS"  # Claude Code substitutes the bare arg token, not bash parameter-expansion
+ARG1="${_RAW%% *}"
 case "$ARG1" in
   ''|*[!0-9]*) PR_NUM="" ;;
   *) PR_NUM="$ARG1" ;;
@@ -114,7 +115,8 @@ Check for previous reviews — if this is a follow-up review, focus on changes s
 ```!
 # Parse previous review findings + resolution outcomes. PR_NUM is digit-validated
 # (matches Phase 1 block); a non-digit token rejects rather than reaching shell.
-ARG1="${ARGUMENTS%% *}"
+_RAW="$ARGUMENTS"  # Claude Code substitutes the bare arg token, not bash parameter-expansion
+ARG1="${_RAW%% *}"
 case "$ARG1" in
   ''|*[!0-9]*) PR_NUM="" ;;
   *) PR_NUM="$ARG1" ;;

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -52,7 +52,8 @@ Pure bash validation — fails fast before any agent reasoning.
 # Output: `### Pre-Flight` heading + PREFLIGHT_FAIL=/PREFLIGHT_WARN= lines
 # per check + final PREFLIGHT_STATE=PASSED|BLOCKED sentinel. See
 # `references/command-output-format.md`.
-ARG1="${ARGUMENTS%% *}"
+_RAW="$ARGUMENTS"  # Claude Code substitutes the bare arg token, not bash parameter-expansion
+ARG1="${_RAW%% *}"
 case "$ARG1" in
   ''|*[!0-9]*) ISSUE_NUM="" ;;
   *) ISSUE_NUM="$ARG1" ;;
@@ -367,7 +368,8 @@ Gather all context before planning.
 
 ```!
 # Digit-validate ISSUE_NUM (matches Phase 0 block).
-ARG1="${ARGUMENTS%% *}"
+_RAW="$ARGUMENTS"  # Claude Code substitutes the bare arg token, not bash parameter-expansion
+ARG1="${_RAW%% *}"
 case "$ARG1" in
   ''|*[!0-9]*) ISSUE_NUM="" ;;
   *) ISSUE_NUM="$ARG1" ;;
@@ -536,7 +538,8 @@ if [ ! -x "$CASCADE" ]; then
 fi
 REQUIRE_GOAL=$("$CASCADE" --default "false" '.flow.goals.requireGoalForStart' 2>/dev/null)
 
-ARG1="${ARGUMENTS%% *}"
+_RAW="$ARGUMENTS"  # Claude Code substitutes the bare arg token, not bash parameter-expansion
+ARG1="${_RAW%% *}"
 case "$ARG1" in
   ''|*[!0-9]*) ISSUE_NUM="" ;;
   *) ISSUE_NUM="$ARG1" ;;
@@ -633,7 +636,8 @@ if [ ! -x "$CASCADE" ]; then
   true; exit 0
 fi
 RUNTIME_ENABLED=$("$CASCADE" --default "true" '.flow.runtime.enabled' 2>/dev/null)
-ARG1="${ARGUMENTS%% *}"
+_RAW="$ARGUMENTS"  # Claude Code substitutes the bare arg token, not bash parameter-expansion
+ARG1="${_RAW%% *}"
 case "$ARG1" in
   ''|*[!0-9]*) ISSUE_NUM="" ;;
   *) ISSUE_NUM="$ARG1" ;;
@@ -659,7 +663,7 @@ When `FLOW_RUN_STATE=create`, invoke `Skill(run-state-management)` to create `.f
 ```bash
 # Self-contained: re-derive the issue from $ARGUMENTS (the entry !-block's vars
 # do not persist here). RUN_ID is the value emitted by the FlowRun entry block.
-ARG1="${ARGUMENTS%% *}"; case "$ARG1" in ''|*[!0-9]*) ISSUE_NUM="" ;; *) ISSUE_NUM="$ARG1" ;; esac
+_RAW="$ARGUMENTS"; ARG1="${_RAW%% *}"; case "$ARG1" in ''|*[!0-9]*) ISSUE_NUM="" ;; *) ISSUE_NUM="$ARG1" ;; esac
 if [ -n "$ISSUE_NUM" ]; then
   "$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/journal-record.sh" \
     --issue "$ISSUE_NUM" --type workflow-run \

--- a/plugins/flow/tests/command-frontmatter.test.sh
+++ b/plugins/flow/tests/command-frontmatter.test.sh
@@ -143,16 +143,21 @@ for FILE in "$COMMANDS_DIR"/*.md; do
 done
 [ "$PASS" = "1" ] && _flow_assert_pass "no destructive verbs in any ! block"
 
-# --- Test 3: $ARGUMENTS inside ! blocks is quoted or extracted via case
+# --- Test 3: $ARGUMENTS inside ! blocks is quoted
 # Acceptable forms inside an ! block:
 #   - "$ARGUMENTS"           (double-quoted scalar)
-#   - "${ARGUMENTS%% *}"     (first-token extraction; the case-validated form)
-#   - assigned to a var then used: ARG1="${ARGUMENTS%% *}"; then "$ARG1"
-# Unacceptable: any unquoted form including bare $ARGUMENTS, ${ARGUMENTS},
-# or ${ARGUMENTS%% *} outside of double quotes. The previous "char-before"
-# regex over-accepted ${ARGUMENTS} because `$` was in the negative class to
-# permit `${...}` braces — but unquoted braces are still word-split-vulnerable.
-# Fix: strip all quoted spans first, then flag any remaining $ARGUMENTS form.
+#   - "${ARGUMENTS}"         (double-quoted, braces, no operator)
+#   - copied to a local then expanded: _RAW="$ARGUMENTS"; ARG1="${_RAW%% *}"
+# Unacceptable here: any unquoted form including bare $ARGUMENTS or ${ARGUMENTS}.
+# The previous "char-before" regex over-accepted ${ARGUMENTS} because `$` was
+# in the negative class to permit `${...}` braces — but unquoted braces are
+# still word-split-vulnerable. Fix: strip all quoted spans first, then flag
+# any remaining $ARGUMENTS form.
+#
+# NOTE: this test only guards QUOTING (word-split safety). It does NOT catch
+# bash parameter-expansion applied to $ARGUMENTS (e.g. "${ARGUMENTS%% *}"),
+# which is quoted-and-safe but still BROKEN because Claude Code never
+# substitutes it (see Test 6).
 _flow_test_begin "\$ARGUMENTS in ! blocks is inside double quotes"
 PASS=1
 for FILE in "$COMMANDS_DIR"/*.md; do
@@ -286,3 +291,88 @@ for FILE in "$COMMANDS_DIR"/*.md; do
   done <<< "$PATTERNS"
 done
 [ "$PASS" = "1" ] && _flow_assert_pass "allowed-tools Bash() prefix linter handles synthetic fixtures correctly"
+
+# --- Test 6: no bash parameter-expansion applied directly to $ARGUMENTS.
+# Claude Code's slash-command preprocessor textually substitutes
+# bare $ARGUMENTS and ${ARGUMENTS} (no operator), but NOT parameter-expansion
+# forms like ${ARGUMENTS%% *}, ${ARGUMENTS#foo}, ${ARGUMENTS:0:3}. The bash
+# interpreter then sees an undefined ARGUMENTS var and the expansion yields
+# the empty string — every downstream guard silently degrades to its no-arg
+# path even when the user passed an argument.
+#
+# The correct pattern copies the substituted bare form into a line-local var
+# first, then applies parameter-expansion to THAT var:
+#   _RAW="$ARGUMENTS"        # Claude Code substitutes bare $ARGUMENTS
+#   ARG1="${_RAW%% *}"       # bash now operates on a real env var
+#
+# This check scans RAW block bodies (NOT quote-stripped): "${ARGUMENTS%% *}"
+# is quoted-and-safe per Test 3 but still broken, so quoting is irrelevant.
+# The operator class [%#/:^,@+-] covers every bash parameter-expansion
+# operator that can follow the variable name (%/%% suffix, #/## prefix,
+# / substitution, : substring/default, ^/, case, @ operator, +/- default).
+#
+# Scope covers `!`, `bash`, and `sh` executable fences — not just `!` blocks.
+# Claude Code's $ARGUMENTS substitution is a template-wide preprocessing pass,
+# so a `${ARGUMENTS:-}` in a ```bash block fed to the Bash tool is just as
+# broken as one in a ```! block (a ```bash fence was the second affected site). Only
+# `!` and `bash` fences exist today; `sh` is included so a future ```sh fence
+# is covered the moment it lands rather than slipping through.
+#
+# Comment-strip subtlety: the strip must remove a TRAILING shell comment (so a
+# doc comment like `# the ${ARGUMENTS:-} form is broken` is not flagged) WITHOUT
+# eating the `#`/`##` prefix-removal operators inside `${ARGUMENTS#foo}`. A
+# naive `s/[[:space:]]*#.*$//` truncates at the operator `#` (zero-space match)
+# and silently loses those two operators. Anchoring the strip to a word
+# boundary — `#` at line-start or preceded by whitespace — keeps real comments
+# stripped while preserving operator `#`, which is never space-preceded.
+_strip_arg_comment() { sed -E 's/(^|[[:space:]])#.*$/\1/'; }
+_flow_test_begin "no bash parameter-expansion on \$ARGUMENTS in executable blocks"
+PASS=1
+for FILE in "$COMMANDS_DIR"/*.md; do
+  CMD=$(basename "$FILE" .md)
+  BODY=$(awk '
+    /^```(!|bash|sh)$/ { in_block=1; next }
+    /^```$/ && in_block { in_block=0; next }
+    in_block { print }
+  ' "$FILE")
+  [ -z "$BODY" ] && continue
+  BAD=$(printf '%s\n' "$BODY" | _strip_arg_comment \
+        | grep -nE '\$\{ARGUMENTS[%#/:^,@+-]' || true)
+  if [ -n "$BAD" ]; then
+    _flow_assert_fail "$CMD.md applies bash parameter-expansion to \$ARGUMENTS in an executable block (Claude Code won't substitute it; copy to a local var first): $BAD"
+    PASS=0
+  fi
+done
+[ "$PASS" = "1" ] && _flow_assert_pass "no executable block applies bash parameter-expansion directly to \$ARGUMENTS"
+
+# Self-guard for Test 6: the strip+grep pipeline
+# is the line of defense, so prove it actually catches every operator it claims
+# — including the `#`/`##` prefix forms that a naive comment-strip would lose —
+# and that it does NOT false-positive on a trailing doc comment that merely
+# *mentions* a broken form.
+_flow_test_begin "Test 6 strip+grep catches all \$ARGUMENTS operators, ignores doc mentions"
+PASS=1
+for FORM in '${ARGUMENTS#foo}' '${ARGUMENTS##*/}' '${ARGUMENTS%% *}' '${ARGUMENTS:-}' \
+            '${ARGUMENTS/a/b}' '${ARGUMENTS^^}' '${ARGUMENTS,,}' '${ARGUMENTS:0:3}' '${ARGUMENTS@Q}'; do
+  HIT=$(printf 'X="%s"\n' "$FORM" | _strip_arg_comment | grep -nE '\$\{ARGUMENTS[%#/:^,@+-]' || true)
+  if [ -z "$HIT" ]; then
+    _flow_assert_fail "Test 6 pipeline failed to flag broken form: $FORM"
+    PASS=0
+  fi
+done
+# Bare forms Claude Code DOES substitute must NOT be flagged.
+for OK in '$ARGUMENTS' '${ARGUMENTS}' '"$ARGUMENTS"'; do
+  HIT=$(printf 'X="%s"\n' "$OK" | _strip_arg_comment | grep -nE '\$\{ARGUMENTS[%#/:^,@+-]' || true)
+  if [ -n "$HIT" ]; then
+    _flow_assert_fail "Test 6 pipeline false-positived on a CC-substituted bare form: $OK"
+    PASS=0
+  fi
+done
+# Trailing doc comment mentioning a broken form must be stripped, not flagged.
+FP=$(printf '%s\n' 'RUN_ID="$ARGUMENTS"  # the ${ARGUMENTS:-} form is NOT substituted' \
+     | _strip_arg_comment | grep -nE '\$\{ARGUMENTS[%#/:^,@+-]' || true)
+if [ -n "$FP" ]; then
+  _flow_assert_fail "Test 6 pipeline false-positived on a doc-comment mention: $FP"
+  PASS=0
+fi
+[ "$PASS" = "1" ] && _flow_assert_pass "Test 6 strip+grep covers all operators with no false positives"

--- a/plugins/flow/tests/command-frontmatter.test.sh
+++ b/plugins/flow/tests/command-frontmatter.test.sh
@@ -307,9 +307,15 @@ done
 #
 # This check scans RAW block bodies (NOT quote-stripped): "${ARGUMENTS%% *}"
 # is quoted-and-safe per Test 3 but still broken, so quoting is irrelevant.
-# The operator class [%#/:^,@+-] covers every bash parameter-expansion
-# operator that can follow the variable name (%/%% suffix, #/## prefix,
-# / substitution, : substring/default, ^/, case, @ operator, +/- default).
+# The pattern covers three broken shapes, all of which CC leaves unsubstituted:
+#   1. trailing operator after the name — ${ARGUMENTS<op>} where <op> is one of
+#      [%#/:^,@+-] (%/%% suffix, #/## prefix, / substitution, : substring/default,
+#      ^/, case, @ operator, +/- default) — plus [ for array subscript
+#      (${ARGUMENTS[0]}).
+#   2. leading length sigil — ${#ARGUMENTS}.
+#   3. leading indirection sigil — ${!ARGUMENTS}.
+# Only the bare ${ARGUMENTS} (no sigil, no operator) and bare $ARGUMENTS are
+# substituted by CC, so those are the ONLY accepted braced forms.
 #
 # Scope covers `!`, `bash`, and `sh` executable fences — not just `!` blocks.
 # Claude Code's $ARGUMENTS substitution is a template-wide preprocessing pass,
@@ -326,6 +332,11 @@ done
 # boundary — `#` at line-start or preceded by whitespace — keeps real comments
 # stripped while preserving operator `#`, which is never space-preceded.
 _strip_arg_comment() { sed -E 's/(^|[[:space:]])#.*$/\1/'; }
+# Single source of truth for the broken-form pattern (used by the main scan AND
+# the self-guard below, so they can never drift). Branch 1: leading #/! sigil
+# (length / indirection). Branch 2: trailing operator or [ array subscript.
+# Bare ${ARGUMENTS} (next char }) matches neither branch — correctly accepted.
+_ARGEXP_RE='\$\{([#!]ARGUMENTS|ARGUMENTS[%#/:^,@+[-])'
 _flow_test_begin "no bash parameter-expansion on \$ARGUMENTS in executable blocks"
 PASS=1
 for FILE in "$COMMANDS_DIR"/*.md; do
@@ -337,7 +348,7 @@ for FILE in "$COMMANDS_DIR"/*.md; do
   ' "$FILE")
   [ -z "$BODY" ] && continue
   BAD=$(printf '%s\n' "$BODY" | _strip_arg_comment \
-        | grep -nE '\$\{ARGUMENTS[%#/:^,@+-]' || true)
+        | grep -nE "$_ARGEXP_RE" || true)
   if [ -n "$BAD" ]; then
     _flow_assert_fail "$CMD.md applies bash parameter-expansion to \$ARGUMENTS in an executable block (Claude Code won't substitute it; copy to a local var first): $BAD"
     PASS=0
@@ -353,8 +364,9 @@ done
 _flow_test_begin "Test 6 strip+grep catches all \$ARGUMENTS operators, ignores doc mentions"
 PASS=1
 for FORM in '${ARGUMENTS#foo}' '${ARGUMENTS##*/}' '${ARGUMENTS%% *}' '${ARGUMENTS:-}' \
-            '${ARGUMENTS/a/b}' '${ARGUMENTS^^}' '${ARGUMENTS,,}' '${ARGUMENTS:0:3}' '${ARGUMENTS@Q}'; do
-  HIT=$(printf 'X="%s"\n' "$FORM" | _strip_arg_comment | grep -nE '\$\{ARGUMENTS[%#/:^,@+-]' || true)
+            '${ARGUMENTS/a/b}' '${ARGUMENTS^^}' '${ARGUMENTS,,}' '${ARGUMENTS:0:3}' '${ARGUMENTS@Q}' \
+            '${#ARGUMENTS}' '${!ARGUMENTS}' '${ARGUMENTS[0]}'; do
+  HIT=$(printf 'X="%s"\n' "$FORM" | _strip_arg_comment | grep -nE "$_ARGEXP_RE" || true)
   if [ -z "$HIT" ]; then
     _flow_assert_fail "Test 6 pipeline failed to flag broken form: $FORM"
     PASS=0
@@ -362,7 +374,7 @@ for FORM in '${ARGUMENTS#foo}' '${ARGUMENTS##*/}' '${ARGUMENTS%% *}' '${ARGUMENT
 done
 # Bare forms Claude Code DOES substitute must NOT be flagged.
 for OK in '$ARGUMENTS' '${ARGUMENTS}' '"$ARGUMENTS"'; do
-  HIT=$(printf 'X="%s"\n' "$OK" | _strip_arg_comment | grep -nE '\$\{ARGUMENTS[%#/:^,@+-]' || true)
+  HIT=$(printf 'X="%s"\n' "$OK" | _strip_arg_comment | grep -nE "$_ARGEXP_RE" || true)
   if [ -n "$HIT" ]; then
     _flow_assert_fail "Test 6 pipeline false-positived on a CC-substituted bare form: $OK"
     PASS=0
@@ -370,7 +382,7 @@ for OK in '$ARGUMENTS' '${ARGUMENTS}' '"$ARGUMENTS"'; do
 done
 # Trailing doc comment mentioning a broken form must be stripped, not flagged.
 FP=$(printf '%s\n' 'RUN_ID="$ARGUMENTS"  # the ${ARGUMENTS:-} form is NOT substituted' \
-     | _strip_arg_comment | grep -nE '\$\{ARGUMENTS[%#/:^,@+-]' || true)
+     | _strip_arg_comment | grep -nE "$_ARGEXP_RE" || true)
 if [ -n "$FP" ]; then
   _flow_assert_fail "Test 6 pipeline false-positived on a doc-comment mention: $FP"
   PASS=0

--- a/plugins/flow/tests/flow-start-onboarding.test.sh
+++ b/plugins/flow/tests/flow-start-onboarding.test.sh
@@ -135,11 +135,30 @@ assert_equal "FLOW_V3_ONBOARDING=skip" "$OUT" "skip arm: re-detection returns sk
 
 _flow_test_begin "goal auto-creation gate: requireGoal=true + ISSUE_NUM -> create"
 
+# Model Claude Code's slash-command preprocessor. It textually substitutes the
+# bare `$ARGUMENTS` and `${ARGUMENTS}` (braces, no operator) tokens with the
+# literal argument string, and leaves bash parameter-expansion forms like
+# `${ARGUMENTS%% *}` UNTOUCHED. Crucially it does NOT export ARGUMENTS into the
+# runtime environment — so a block that survives only because `${ARGUMENTS%% *}`
+# expanded against a real env var is broken in production. Earlier this fixture
+# ran `ARGUMENTS=42 bash -c "$BLOCK"`, which injected that env var and thereby
+# HID the bug: the broken `${ARGUMENTS%% *}` form "worked" in the test and
+# shipped degraded.
+cc_substitute() {
+  local block="$1" arg="${2-}"
+  block="${block//\$\{ARGUMENTS\}/$arg}"   # ${ARGUMENTS} (braces, no operator)
+  block="${block//\$ARGUMENTS/$arg}"        # bare $ARGUMENTS
+  printf '%s' "$block"
+}
+
 # Lift the gate logic from start.md and exercise it without invoking
 # cascade-resolve.sh — we pre-set REQUIRE_GOAL directly so this test is
-# hermetic and doesn't depend on the cascade implementation.
+# hermetic and doesn't depend on the cascade implementation. The arg parse
+# uses the correct pattern: copy the bare (substituted) form into a local,
+# THEN apply parameter-expansion to the local.
 GOAL_GATE_BLOCK='
-ARG1="${ARGUMENTS%% *}"
+_RAW="$ARGUMENTS"
+ARG1="${_RAW%% *}"
 case "$ARG1" in
   ""|*[!0-9]*) ISSUE_NUM="" ;;
   *) ISSUE_NUM="$ARG1" ;;
@@ -161,9 +180,11 @@ else
 fi
 '
 
+# Each arm substitutes the arg into the block the way Claude Code would, then
+# runs it WITHOUT ARGUMENTS in the env (production never sets it).
 CREATE_DIR="$TMP_DIR/create-arm"
 mkdir -p "$CREATE_DIR"
-OUT=$(cd "$CREATE_DIR" && REQUIRE_GOAL=true ARGUMENTS="42" bash -c "$GOAL_GATE_BLOCK")
+OUT=$(cd "$CREATE_DIR" && REQUIRE_GOAL=true bash -c "$(cc_substitute "$GOAL_GATE_BLOCK" "42")")
 assert_contains "FLOW_GOAL_STATE=create" "$OUT" "create arm: state=create"
 assert_contains "GOAL_ID=issue-42" "$OUT" "create arm: GOAL_ID=issue-42"
 assert_contains "GOAL_PATH=.flow/goals/issue-42.goal.yaml" "$OUT" "create arm: GOAL_PATH set"
@@ -174,27 +195,54 @@ _flow_test_begin "goal auto-creation gate: existing goal -> exists (no overwrite
 EXISTS_DIR="$TMP_DIR/exists-arm"
 mkdir -p "$EXISTS_DIR/.flow/goals"
 echo "apiVersion: flow.synapti.ai/v1" > "$EXISTS_DIR/.flow/goals/issue-42.goal.yaml"
-OUT=$(cd "$EXISTS_DIR" && REQUIRE_GOAL=true ARGUMENTS="42" bash -c "$GOAL_GATE_BLOCK")
+OUT=$(cd "$EXISTS_DIR" && REQUIRE_GOAL=true bash -c "$(cc_substitute "$GOAL_GATE_BLOCK" "42")")
 assert_contains "FLOW_GOAL_STATE=exists" "$OUT" "exists arm: state=exists"
 assert_not_contains "FLOW_GOAL_STATE=create" "$OUT" "exists arm: not flagged for creation"
 
 
 _flow_test_begin "goal auto-creation gate: requireGoal=false -> skip"
 
-OUT=$(cd "$TMP_DIR" && REQUIRE_GOAL=false ARGUMENTS="42" bash -c "$GOAL_GATE_BLOCK")
+OUT=$(cd "$TMP_DIR" && REQUIRE_GOAL=false bash -c "$(cc_substitute "$GOAL_GATE_BLOCK" "42")")
 assert_equal "FLOW_GOAL_STATE=skip" "$OUT" "requireGoal=false -> skip"
 
 
 _flow_test_begin "goal auto-creation gate: missing ISSUE_NUM -> skip"
 
-OUT=$(cd "$TMP_DIR" && REQUIRE_GOAL=true ARGUMENTS="" bash -c "$GOAL_GATE_BLOCK")
+OUT=$(cd "$TMP_DIR" && REQUIRE_GOAL=true bash -c "$(cc_substitute "$GOAL_GATE_BLOCK" "")")
 assert_equal "FLOW_GOAL_STATE=skip" "$OUT" "missing ISSUE_NUM -> skip"
 
 
 _flow_test_begin "goal auto-creation gate: non-digit ARGUMENTS -> skip"
 
-OUT=$(cd "$TMP_DIR" && REQUIRE_GOAL=true ARGUMENTS="abc" bash -c "$GOAL_GATE_BLOCK")
+OUT=$(cd "$TMP_DIR" && REQUIRE_GOAL=true bash -c "$(cc_substitute "$GOAL_GATE_BLOCK" "abc")")
 assert_equal "FLOW_GOAL_STATE=skip" "$OUT" "non-digit ARGUMENTS -> skip (matches Phase 0 validation)"
+
+
+_flow_test_begin "regression: old \${ARGUMENTS%% *} form degrades to skip under CC substitution"
+
+# The fixture's whole point: prove the bug now, so a revert to the broken form
+# fails here. Under faithful CC substitution (bare-only, no env var), the old
+# parameter-expansion form expands empty and the gate silently skips — even
+# with requireGoal=true and a valid issue number passed.
+OLD_BROKEN_BLOCK='
+ARG1="${ARGUMENTS%% *}"
+case "$ARG1" in
+  ""|*[!0-9]*) ISSUE_NUM="" ;;
+  *) ISSUE_NUM="$ARG1" ;;
+esac
+if [ "$REQUIRE_GOAL" = "true" ] && [ -n "$ISSUE_NUM" ]; then
+  echo "FLOW_GOAL_STATE=create"
+else
+  echo "FLOW_GOAL_STATE=skip"
+fi
+'
+OUT=$(cd "$TMP_DIR" && REQUIRE_GOAL=true bash -c "$(cc_substitute "$OLD_BROKEN_BLOCK" "42")")
+assert_equal "FLOW_GOAL_STATE=skip" "$OUT" "old form expands empty under CC substitution (this IS the bug; env-injection fixture hid it)"
+
+# Sanity: the SAME arg through the SAME substitution model, but the fixed
+# block, must produce create — proving the fix, not just the bug.
+OUT=$(cd "$TMP_DIR" && REQUIRE_GOAL=true bash -c "$(cc_substitute "$GOAL_GATE_BLOCK" "42")")
+assert_contains "FLOW_GOAL_STATE=create" "$OUT" "fixed _RAW form produces create under the identical substitution model"
 
 
 # ────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## FlowGoal Status

- **Goal**: `issue-120` (`.flow/goals/issue-120.goal.yaml`)
- **Lifecycle**: `achieved` — all 4 acceptance criteria pass deterministically
- **Evidence**: per-criterion FlowEvidence sidecars under `.flow/runs/20260525T1810Z-issue-120-eval/evidence/` (local; `.flow/runs/` is gitignored)

## Summary

Claude Code's slash-command preprocessor textually substitutes only the bare `$ARGUMENTS` and `${ARGUMENTS}` tokens into command markdown — it does **not** substitute bash parameter-expansion forms like `${ARGUMENTS%% *}` or `${ARGUMENTS:-}`. Those left bash to expand an undefined `ARGUMENTS` var to the empty string, so first-token extraction yielded `""` and downstream gates (`PREFLIGHT_STATE`, `FLOW_GOAL_STATE`) silently degraded to their no-arg paths even when an argument was passed.

This bug self-demonstrated while starting work on the issue: `/flow:start` rendered `ISSUE_NUM=` (empty), `PREFLIGHT_STATE=BLOCKED`, `RUN_ID=...issue-nonum`.

### Why it was never caught

- The onboarding fixture ran the gate block as `ARGUMENTS="42" bash -c "$BLOCK"` — injecting `ARGUMENTS` as a real env var, so `${ARGUMENTS%% *}` expanded correctly *in the test*. Production never sets that env var.
- The lint (`command-frontmatter` Test 3) only checked that `$ARGUMENTS` was *quoted* and explicitly blessed `"${ARGUMENTS%% *}"` as the "case-validated form" — it never modeled the text-only substitution.

Both stayed green while production was broken.

## Fix

Replace the parameter-expansion-on-`$ARGUMENTS` pattern with a bare-substitution-first copy:

```bash
_RAW="$ARGUMENTS"   # Claude Code substitutes the bare arg token
ARG1="${_RAW%% *}"  # bash parameter-expansion now hits a real var
```

Applied to **16 sites across 8 command files**: `start.md` (5), `merge.md` (3), `address.md`/`review.md` (2 each), `resolve.md`/`design.md`/`brainstorm.md` (1 each), plus `resume.md`'s `RUN_ID="${ARGUMENTS:-}"` (same bug class in a ```bash fence, caught during the sweep). `workflow.md`'s `${ARGUMENTS}` (bare braces) is correctly left alone — that form *is* substituted.

## Regression guards

- **`command-frontmatter` Test 6** (new): rejects bash parameter-expansion on `$ARGUMENTS` in `!`/`bash`/`sh` fences, with a comment-strip anchored to word boundaries so it covers every operator (including the `#`/`##` prefix forms) and a self-guard asserting that coverage with no false positives.
- **`flow-start-onboarding` fixture** (rewritten): a `cc_substitute` helper models Claude Code's bare-only text substitution instead of env-var injection. A regression assertion proves the old form degrades to `skip` while the fixed `_RAW` form produces `create` under the identical substitution model — so a revert fails loudly.

## Acceptance criteria (derived — issue had none)

| # | Criterion | Verification | Result |
|---|-----------|--------------|--------|
| AC1 | No `${ARGUMENTS<op>}` param-expansion in any command executable block | `! grep -rqE '\$\{ARGUMENTS[%#/:^,@+-]' plugins/flow/commands/` | exit 0 |
| AC2 | Onboarding fixture models CC substitution and proves bug + fix | `run.sh flow-start-onboarding.test.sh` | 73 pass |
| AC3 | Static lint rejects the broken form, self-guards operator coverage | `run.sh command-frontmatter.test.sh` | 10 pass |
| AC4 | Full flow test suite passes | `run.sh` | 840 pass |

## Review

Independent code-review pass (6-facet): **0 P1, 1 P2, 1 P3 — both fixed in-PR**.
- **P2 (F1)**: the lint's comment-strip would have truncated `${ARGUMENTS#foo}`/`${ARGUMENTS##*/}` at the `#`, silently dropping 2 of the 9 operators it advertised. Fixed with a word-boundary strip + synthetic self-guard.
- **P3 (F2)**: clarified the `sh`-fence coverage comment (deliberate forward-coverage).

Closes #120