### PR TITLE
feat(flow): v3.1 invisible-by-default runtime (#111) + achieved-goal gate fix (#122)

### DIFF
--- a/.decisions/issue-111.md
+++ b/.decisions/issue-111.md
@@ -1,0 +1,189 @@
+---
+issue: 111
+created: '2026-05-26T12:00:00Z'
+artifacts:
+- type: plan
+  captured_at: '2026-05-26T12:00:00Z'
+  by: flow-start-interview
+  mode: lock-the-plan-only
+  status: awaiting-implementation
+---
+# Issue #111 — v3.1 UX layer (invisible-by-default runtime)
+
+**Session mode:** interview-driven planning. Deliverable is this locked plan; **no code this
+session**. Implementation happens in a follow-up `/flow:start 111`.
+
+**State (audited against repo source, post-#114):** AC-3 shipped in #114. 6 ACs remain:
+AC-1, AC-2, AC-4, AC-5, AC-6, AC-7. Full plugin suite green at 840 tests today; every step
+below must keep it green.
+
+**Codebase facts established this session (corrections to the issue):**
+- Command count = **23** (`commands/*.md`, all with valid frontmatter). README says `(17)` and
+  lists 17, omitting the 6 runtime commands.
+- `FILE_COUNT_FLOOR` in `tests/command-frontmatter.test.sh:26` is **15** (not 17), with a stale
+  "17 as of this writing" comment at `:23`.
+- Goal schema: ACs require `id, text, status`; `verification_command` is **optional**
+  (`schemas/v1/goal.schema.json:104`). "Verifiable AC" = AC with a non-empty `verification_command`.
+- `flow-active-goal.sh --ac-summary` emits `id|status|evidence_ref|last_result` — it does **not**
+  expose a verifiable-AC count today.
+- `cascade-resolve.sh` passes any jq expression through (`:88`) — compound `if/elif` exprs work but
+  are **untested** (`tests/cascade-resolve.test.sh` only exercises `.journal.dir // empty`).
+- A live active goal already exists in the repo: `.flow/goals/issue-120.goal.yaml`. Under the
+  *current* `flow-active-goal.sh`, creating a second active goal would trip exit 3 (the AC-4 bug, live).
+
+---
+
+## Decisions (locked this session)
+
+| # | Decision | Resolution | Rationale |
+|---|----------|-----------|-----------|
+| D0 | Session scope | **Lock the plan only** | Implement in a follow-up session. |
+| D-A2 | `auto` predicate when spec-free-labeled but has verifiable ACs | **Verifiable ACs win** | Rule collapses to "create iff ≥1 AC has a `verification_command`." Spec-free label is purely the upstream Spec-Gate relaxation. #111 itself (documentation-labeled, 7 verifiable ACs) → gets a goal. No silent loss of tracking. |
+| D-A1 | AC-1 settings migration mechanism | **Compound jq, `else null`** + `--default auto` | `.flow.goals.goalCreation // (if .flow.goals.requireGoalForStart == true then "always" elif .flow.goals.requireGoalForStart == false then "off" else null end)`. `else null` (not `else "auto"`) lets a settings source with *neither* key fall through to the next cascade source — fixes a precedence-leak in the pinned-comment sketch where an unrelated `settings.flow.local.json` would mask a project-level `requireGoalForStart`. Add a cascade-resolve compound-expr test. |
+| D-A3 | Phase 0.5 onboarding | **Full deletion** | Delete `FLOW_V3_ONBOARDING` detection, the `AskUserQuestion`, and `set_flow_goals()` (`start.md:114-358`). `workflows.enabled`/`triggers` have plugin defaults in `settings.json`; deletion loses nothing. Migration is read-only → configured projects never re-prompted. |
+| D-GATE | pr.md/merge.md FlowGoal gate behavior | **Gate on goal existence** | Gate arms when an active goal exists and blocks merge unless `achieved`. **PRs/merges with no goal are NOT blocked** — remove the current exit-1 fail-closed (`merge.md:358-363`, `pr.md` equivalent). Goal state stays load-bearing at merge (per issue Risks) without breaking default-install merges. |
+| D-B2 | Verifiable-AC count source (AC-2 + AC-5) | **Extend the shared helper** | Add a discrete `--verifiable-count` mode to `flow-active-goal.sh` (not a 5th `--ac-summary` column — that contract's pipe/newline sanitization is tied to 4 columns). One source of truth; needs its own test. |
+| D-OFF | `goalCreation: off` vs `goals.enabled: false` | **Distinct meanings** | `enabled:false` = whole feature off (Stop hook fast-paths, `/flow:goal` disabled). `goalCreation:off` = feature on, `/flow:start` won't auto-create, manual `/flow:goal create` still works. Document in schema + migration docs. |
+| D-WORD | AC-1 wording reconciliation | **Draft revised text here** (below); user pastes into issue | Keeps the issue and the implementation-session verdict-judge aligned with "verifiable ACs win." |
+| D-E1 | `/flow:resume` linkage detection | **Simple** | Any tracked working-tree change outside `.flow/` and `.decisions/` counts as unlinked → surface + ask before suggesting continuation. Informational-only. |
+
+### Derived semantics — flag for sign-off at implementation start
+- **Gate arming key:** the pr/merge gate is **disabled entirely when `goalCreation == off`** (honors the explicit opt-out and preserves the v2 `requireGoalForStart:false` behavior) **or** `goals.enabled == false`. For `auto`/`always`, the gate is armed and follows D-GATE (block iff a goal exists and is not `achieved`; no goal → pass). _This is a derivation from D-GATE + D-OFF, not an explicit user choice — confirm before coding._
+- **Degenerate definition (AC-2):** degenerate = `0 ACs` **or** `0 ACs carrying a verification_command`. Note: under `auto` a degenerate goal can no longer be auto-created (auto requires ≥1 verifiable AC), so the `⚠ degenerate / needs-attention` marker is a safety net for `always` mode and `/flow:goal create --manual` only.
+- **`requireGoalForStart` retirement:** kept as **deprecated-accepted indefinitely** (read-only migration); no removal timeline, to avoid breaking configured projects.
+- **Stop hook:** unchanged. It keys off `goals.enabled` + `stopHookEnforcement`, not `goalCreation`.
+- **AC-5 `--json` shape:** `{ goal: {id, lifecycle, ac_summary, verifiable_count}, run: {id, workflow, phase, status}, findings: [...] }`. No existing consumer constrains it.
+
+---
+
+## Revised AC-1 wording (paste into the issue)
+
+> ### AC-1 — `/flow:start` conditional-auto goal creation
+> - [ ] Replace the binary `flow.goals.requireGoalForStart` with a 3-state `flow.goals.goalCreation: auto | always | off`, default `auto`.
+> - [ ] `auto`: create a FlowGoal **iff the captured goal has ≥1 acceptance criterion carrying a `verification_command`**, regardless of issue labels. The spec-free path (`specFirst.allowSpecFreeLabels`, e.g. `documentation`/`chore`) is solely an *upstream Spec-Gate relaxation* — it lets an issue pass with zero verifiable ACs. When that results in zero verifiable ACs, goal creation is skipped **silently** (no prompt, no error). A spec-free-labeled issue that nonetheless carries verifiable ACs **does** get a goal.
+> - [ ] `always`: create a goal unconditionally (a degenerate goal is allowed but flagged per AC-2). `off`: never auto-create; manual `/flow:goal create` still works.
+> - [ ] Backward-compatible **read-only** migration: `requireGoalForStart: true` → `always`; `false` → `off`; absence → `auto`. Never rewrites the user's settings file; no configured project is re-prompted or silently changed.
+> - [ ] The Phase 0.5 onboarding `AskUserQuestion` is retired (invisible-auto is the default; no consent prompt needed for writing local `.flow/` artifacts).
+> - [ ] **Observable:** `/flow:start <issue-with-≥1-verification_command-AC>` on a fresh project creates `.flow/goals/issue-<N>.goal.yaml` with `lifecycle.status: active` and prints **no** `FlowGoal created:` line — only the compact summary (AC-2). `/flow:start` on an issue with **zero** verifiable ACs creates **no** goal and prints no goal line, independent of label.
+
+---
+
+## Per-AC implementation plan (locked approach; sequence low-risk → wide-blast → docs-last)
+
+### 1. AC-4 — branch-first active-goal/run detection (`bin/flow-active-goal.sh`, embedded Python `:65-137`)
+- Read current branch (`git branch --show-current`, tolerate failure → `""`); add a test-only `--branch <name>` override for hermetic tests.
+- Partition `active` goals by `data["scope"]["branch"]`: if ≥1 matches current branch → that subset is the candidate set; else fall back to most-recently-modified active (`os.path.getmtime`) — covers legacy goals authored before `scope.branch` existed.
+- Exit 3 **only** when the current-branch candidate set has `>1`.
+- Keep symlink defenses, tolerate-unparseable loop, and all 5 output modes unchanged. `scope.branch` is already required in `goal.schema.json` — no schema change.
+- **Tests:** extend `tests/flow-active-goal.test.sh` — two active goals on different branches each resolve their own (exit 0); two on same branch → exit 3.
+
+### 2. AC-1 — conditional-auto `goalCreation` (widest blast radius)
+- **Resolve** via `cascade-resolve.sh` with the D-A1 compound expr (`else null`, `--default auto`).
+- **Readers (all currently branch on `requireGoalForStart == true`):**
+  - `commands/start.md` gate (`:539,548`): `always`→create; `off`→skip; `auto`→create iff `SPEC_HAS_VERIFIABLE_AC` (≥1 AC with `verification_command`). Thread `SPEC_HAS_VERIFIABLE_AC` into the `FLOW_GOAL_STATE` block.
+  - `commands/pr.md:124`, `commands/merge.md:330`: retie to D-GATE + derived arming key (off/`enabled:false` → disabled; auto/always → armed, gate-on-existence). **Remove the exit-1 fail-closed.**
+  - `schema.json:295`: add `goalCreation` enum `[auto,always,off]` default `auto`; keep `requireGoalForStart` as deprecated-accepted; document D-OFF distinction.
+  - `settings.json:97`: replace `requireGoalForStart` with `goalCreation: auto`.
+- **Retire Phase 0.5 onboarding** (`start.md:114-358`): delete detection, `AskUserQuestion`, `set_flow_goals()`.
+- **Docs:** `references/flow-goals.md`, `flow-goals-quickstart.md`, `migration-v2-to-v3.md`, README — document the 3-state model, migration mapping, and D-OFF.
+- **Tests:** `start-v3-integration.test.sh`, `flow-start-onboarding.test.sh` (replace onboarding cases with migration-mapping assertions: `true`→`always`, `false`→`off`, absent→`auto`, explicit wins), `flow-pr-merge-goal-gate.test.sh` (gate-on-existence: goal-present-not-achieved → block; no-goal → pass; off → disabled), `status-triggers-v3-integration.test.sh`, plus a new `cascade-resolve.test.sh` compound-expr case. Add conditional-auto: ≥1-verifiable-AC issue → goal; zero-verifiable / documentation → no goal, no prompt.
+
+### 3. AC-2 — compact runtime summary + degenerate marker (`commands/start.md:621-624`)
+- Replace `FlowGoal created: <ID> at <PATH> (status: active)` with a compact block: **Goal id (+ "N ACs / M verifiable"), Workflow, Run id, Branch**, and a one-line "I'll work until the goal is achieved, blocked, or needs your decision." Suppress the old dump line.
+- **Truthfulness gate:** degenerate (per D-derived definition) or unevaluated goal renders `⚠ degenerate / needs-attention`, never a clean `active` line. Compute verifiable count via the new `flow-active-goal.sh --verifiable-count`.
+- **Tests:** `start-v3-integration.test.sh` — compact format + degenerate marker for a goal with no verification commands.
+
+### 4. AC-5 — `/flow:status` compact dashboard + deep modes (`commands/status.md`)
+- Parse mode arg with the **bare-`$ARGUMENTS`-first** pattern (`_RAW="$ARGUMENTS"; ARG1="${_RAW%% *}"`) per the #120 fix — never `${ARGUMENTS%% *}` directly.
+- Default → compact dashboard (Active work / Goal AC-evidence summary / Workflow phase+activity / Evidence state / Next safe action). `--full` → current verbose. `--json` → D-derived shape. `--evidence` → per-AC sidecar (reuse `--ac-summary` + `.flow/runs/<id>/evidence/`). Unknown arg → compact fallback.
+- Keep the existing `(v3 not enabled)` gating line (`status.md:425`), which keys off `goals.enabled`.
+- **Tests:** `flow-status-learn-v3.test.sh` — each mode's distinct shape; unknown arg → compact.
+
+### 5. AC-6 — `/flow:resume` conservatism (`commands/resume.md:30-169`)
+- After resolving the active run, run `git status --porcelain`; treat any tracked change outside `.flow/` and `.decisions/` as unlinked. If unlinked changes exist, surface them and **ask before suggesting continuation** via `AskUserQuestion`. Informational-only; never auto-execute.
+- **Tests:** dirty tree with unrelated change → warning; clean/run-linked → none.
+
+### 6. AC-7 — README reframe + count fix (`README.md`, `tests/command-frontmatter.test.sh`)
+- Lead with a **Work** section ("/flow:start creates a goal, selects a workflow, records evidence, prevents premature completion — inspect with /flow:status; you don't manage it manually"). Move the six runtime primitives (`goal`, `workflow`, `trigger`, `run`, `resume`, `watch`) to an **Advanced / runtime internals** subsection; reframe `/flow:goal create` as `--manual`-only.
+- Fix `README.md:180` `COMMANDS (17)` → **23**; reconcile the table to list all 23.
+- Bump `FILE_COUNT_FLOOR` 15 → 20 and fix the stale "17 as of this writing" comment (`:23`).
+
+---
+
+## Verification (each AC + end)
+- `bash plugins/flow/tests/run.sh` stays green (840 today) + the per-AC tests above.
+- Manual smoke: fresh-project `/flow:start <≥1-verifiable-AC issue>` → goal created, compact summary, no `FlowGoal created:` line, no onboarding prompt; zero-verifiable issue → no goal, no prompt; goal w/o verification commands (`always`) → degenerate marker. Two-branch worktrees → `flow-active-goal.sh --status` returns each branch's goal (exit 0). `/flow:status --full|--json|--evidence` distinct. Dirty unrelated tree → `/flow:resume` warns. `/flow:review <pr>` then `/flow:resume` → run exists, no goal (AC-3 regression guard). Merge gate: goal-present-not-achieved → block; no-goal PR → not blocked.
+
+## Out of scope (per #111 non-goals)
+No native `/loop`/`/goal`/`/schedule` path; don't delete runtime commands (only demote in docs); no change to `/flow:review` auto-by-severity posting; don't add FlowGoals to review/address.
+
+## Housekeeping note (not part of #111)
+The live `.flow/goals/issue-120.goal.yaml` is the running AC-4 bug instance. AC-4 tests must be
+hermetic (temp dirs + `--branch` override) so they don't depend on it. Optionally clear/finalize
+issue-120's goal separately; not required by this plan.
+
+<!-- auto-log: 2026-05-26 14:24 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-active-goal.sh -->
+
+<!-- auto-log: 2026-05-26 14:24 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-active-goal.sh -->
+
+<!-- auto-log: 2026-05-26 14:24 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-active-goal.sh -->
+
+<!-- auto-log: 2026-05-26 14:24 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-active-goal.sh -->
+
+<!-- auto-log: 2026-05-26 14:25 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/flow-active-goal.test.sh -->
+
+<!-- auto-log: 2026-05-26 14:25 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/flow-active-goal.test.sh -->
+
+<!-- auto-log: 2026-05-26 14:27 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/flow-active-goal.test.sh -->
+
+<!-- auto-log: 2026-05-26 14:27 commit "feat(flow): branch-first active-goal detection + --verifiable-count (#111 AC-4)" -->
+
+<!-- auto-log: 2026-05-26 14:28 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/start.md -->
+
+<!-- auto-log: 2026-05-26 14:29 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/start.md -->
+
+<!-- auto-log: 2026-05-26 14:29 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/settings.json -->
+
+<!-- auto-log: 2026-05-26 14:29 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/schema.json -->
+
+<!-- auto-log: 2026-05-26 14:30 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/merge.md -->
+
+<!-- auto-log: 2026-05-26 14:30 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/merge.md -->
+
+<!-- auto-log: 2026-05-26 14:31 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/pr.md -->
+
+<!-- auto-log: 2026-05-26 14:31 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/pr.md -->
+
+<!-- auto-log: 2026-05-26 14:31 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/pr.md -->
+
+<!-- auto-log: 2026-05-26 14:33 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/flow-cycle14-behavioral.test.sh -->
+
+<!-- auto-log: 2026-05-26 14:33 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/status-triggers-v3-integration.test.sh -->
+
+<!-- auto-log: 2026-05-26 14:35 Write /tmp/rewrite_onboarding.py -->
+
+<!-- auto-log: 2026-05-26 14:37 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/flow-pr-merge-goal-gate.test.sh -->
+
+<!-- auto-log: 2026-05-26 14:37 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/flow-pr-merge-goal-gate.test.sh -->
+
+<!-- auto-log: 2026-05-26 14:43 commit "feat(flow): conditional-auto goalCreation + retire onboarding (#111 AC-1)" -->
+
+<!-- auto-log: 2026-05-26 14:44 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/start.md -->
+
+<!-- auto-log: 2026-05-26 14:44 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/start.md -->
+
+<!-- auto-log: 2026-05-26 14:46 commit "feat(flow): compact runtime summary + degenerate marker (#111 AC-2)" -->
+
+<!-- auto-log: 2026-05-26 14:49 commit "feat(flow): /flow:status compact dashboard + deep modes (#111 AC-5)" -->
+
+<!-- auto-log: 2026-05-26 14:50 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/resume.md -->
+
+<!-- auto-log: 2026-05-26 14:50 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/resume.md -->
+
+<!-- auto-log: 2026-05-26 14:50 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/resume.md -->
+
+<!-- auto-log: 2026-05-26 14:52 commit "feat(flow): /flow:resume guards against unlinked changes (#111 AC-6)" -->
+
+<!-- auto-log: 2026-05-26 14:55 commit "docs(flow): README work-first reframe + command-count fix (#111 AC-7)" -->
+
+<!-- auto-log: 2026-05-26 14:57 commit "docs(flow): changelog entry for #111 v3.1 UX layer + fix stale test comment" -->

--- a/.decisions/issue-111.md
+++ b/.decisions/issue-111.md
@@ -187,3 +187,21 @@ issue-120's goal separately; not required by this plan.
 <!-- auto-log: 2026-05-26 14:55 commit "docs(flow): README work-first reframe + command-count fix (#111 AC-7)" -->
 
 <!-- auto-log: 2026-05-26 14:57 commit "docs(flow): changelog entry for #111 v3.1 UX layer + fix stale test comment" -->
+
+<!-- auto-log: 2026-05-26 15:01 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-active-goal.sh -->
+
+<!-- auto-log: 2026-05-26 15:01 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-active-goal.sh -->
+
+<!-- auto-log: 2026-05-26 15:01 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-active-goal.sh -->
+
+<!-- auto-log: 2026-05-26 15:02 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-active-goal.sh -->
+
+<!-- auto-log: 2026-05-26 15:02 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-active-goal.sh -->
+
+<!-- auto-log: 2026-05-26 15:04 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/CHANGELOG.md -->
+
+<!-- auto-log: 2026-05-26 15:05 commit "fix(flow): FlowGoal gate can observe achieved goals via --allow-terminal (#122)" -->
+
+<!-- auto-log: 2026-05-26 15:12 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/resume.md -->
+
+<!-- auto-log: 2026-05-26 15:13 commit "fix(flow): resume unlinked-detection handles git-quoted paths (PR review F1)" -->

--- a/.decisions/issue-111.md
+++ b/.decisions/issue-111.md
@@ -261,3 +261,23 @@ issue-120's goal separately; not required by this plan.
 <!-- auto-log: 2026-05-26 17:26 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/setup.md -->
 
 <!-- auto-log: 2026-05-26 17:29 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/CHANGELOG.md -->
+
+<!-- auto-log: 2026-05-26 17:29 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-migrate-settings.sh -->
+
+<!-- auto-log: 2026-05-26 17:30 commit "fix(flow): flow-migrate-settings writes its tmpfile in the target dir (atomic rename)" -->
+
+<!-- auto-log: 2026-05-26 17:40 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-migrate-settings.sh -->
+
+<!-- auto-log: 2026-05-26 17:40 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-migrate-settings.sh -->
+
+<!-- auto-log: 2026-05-26 17:40 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-migrate-settings.sh -->
+
+<!-- auto-log: 2026-05-26 17:40 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-migrate-settings.sh -->
+
+<!-- auto-log: 2026-05-26 17:40 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-migrate-settings.sh -->
+
+<!-- auto-log: 2026-05-26 17:41 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/setup.md -->
+
+<!-- auto-log: 2026-05-26 17:42 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/flow-setup-migrate.test.sh -->
+
+<!-- auto-log: 2026-05-26 17:44 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/setup.md -->

--- a/.decisions/issue-111.md
+++ b/.decisions/issue-111.md
@@ -235,3 +235,5 @@ issue-120's goal separately; not required by this plan.
 <!-- auto-log: 2026-05-26 15:40 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/pr.md -->
 
 <!-- auto-log: 2026-05-26 15:46 commit "fix(flow): address self-review findings on the v3.1 UX layer" -->
+
+<!-- auto-log: 2026-05-26 15:46 Write /tmp/pr-123-review.md -->

--- a/.decisions/issue-111.md
+++ b/.decisions/issue-111.md
@@ -237,3 +237,7 @@ issue-120's goal separately; not required by this plan.
 <!-- auto-log: 2026-05-26 15:46 commit "fix(flow): address self-review findings on the v3.1 UX layer" -->
 
 <!-- auto-log: 2026-05-26 15:46 Write /tmp/pr-123-review.md -->
+
+<!-- auto-log: 2026-05-26 15:56 Edit /Users/danielbentes/synapti-marketplace/README.md -->
+
+<!-- auto-log: 2026-05-26 15:56 commit "docs(flow): strip remaining finding/AC refs from comments + fix main README count" -->

--- a/.decisions/issue-111.md
+++ b/.decisions/issue-111.md
@@ -7,6 +7,12 @@ artifacts:
   by: flow-start-interview
   mode: lock-the-plan-only
   status: awaiting-implementation
+- type: review-cycle
+  captured_at: '2026-05-26T13:14:59Z'
+  cycle: 1
+  path: B
+  findings_count: 1
+  pr: 123
 ---
 # Issue #111 — v3.1 UX layer (invisible-by-default runtime)
 
@@ -205,3 +211,27 @@ issue-120's goal separately; not required by this plan.
 <!-- auto-log: 2026-05-26 15:12 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/resume.md -->
 
 <!-- auto-log: 2026-05-26 15:13 commit "fix(flow): resume unlinked-detection handles git-quoted paths (PR review F1)" -->
+
+<!-- auto-log: 2026-05-26 15:14 Write /tmp/pr-111-body.md -->
+
+<!-- auto-log: 2026-05-26 15:34 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-active-goal.sh -->
+
+<!-- auto-log: 2026-05-26 15:34 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-active-goal.sh -->
+
+<!-- auto-log: 2026-05-26 15:34 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-active-goal.sh -->
+
+<!-- auto-log: 2026-05-26 15:35 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-active-goal.sh -->
+
+<!-- auto-log: 2026-05-26 15:36 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/flow-active-goal.test.sh -->
+
+<!-- auto-log: 2026-05-26 15:37 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/resume.md -->
+
+<!-- auto-log: 2026-05-26 15:37 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/resume.md -->
+
+<!-- auto-log: 2026-05-26 15:39 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/tests/flow-resume-unlinked.test.sh -->
+
+<!-- auto-log: 2026-05-26 15:39 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/merge.md -->
+
+<!-- auto-log: 2026-05-26 15:40 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/pr.md -->
+
+<!-- auto-log: 2026-05-26 15:46 commit "fix(flow): address self-review findings on the v3.1 UX layer" -->

--- a/.decisions/issue-111.md
+++ b/.decisions/issue-111.md
@@ -241,3 +241,13 @@ issue-120's goal separately; not required by this plan.
 <!-- auto-log: 2026-05-26 15:56 Edit /Users/danielbentes/synapti-marketplace/README.md -->
 
 <!-- auto-log: 2026-05-26 15:56 commit "docs(flow): strip remaining finding/AC refs from comments + fix main README count" -->
+
+<!-- auto-log: 2026-05-26 16:37 commit "docs(flow): comment-discipline sweep across the plugin" -->
+
+<!-- auto-log: 2026-05-26 16:50 Edit /Users/danielbentes/synapti-marketplace/.claude/agent-memory/flow-test-runner/project_flow_test_suite.md -->
+
+<!-- auto-log: 2026-05-26 16:50 Edit /Users/danielbentes/synapti-marketplace/.claude/agent-memory/flow-test-runner/MEMORY.md -->
+
+<!-- auto-log: 2026-05-26 17:02 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-active-goal.sh -->
+
+<!-- auto-log: 2026-05-26 17:02 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-active-goal.sh -->

--- a/.decisions/issue-111.md
+++ b/.decisions/issue-111.md
@@ -253,3 +253,11 @@ issue-120's goal separately; not required by this plan.
 <!-- auto-log: 2026-05-26 17:02 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-active-goal.sh -->
 
 <!-- auto-log: 2026-05-26 17:06 Write /tmp/pr-123-review-c2.md -->
+
+<!-- auto-log: 2026-05-26 17:19 Write /tmp/pr-123-review-c3.md -->
+
+<!-- auto-log: 2026-05-26 17:26 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/setup.md -->
+
+<!-- auto-log: 2026-05-26 17:26 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/commands/setup.md -->
+
+<!-- auto-log: 2026-05-26 17:29 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/CHANGELOG.md -->

--- a/.decisions/issue-111.md
+++ b/.decisions/issue-111.md
@@ -251,3 +251,5 @@ issue-120's goal separately; not required by this plan.
 <!-- auto-log: 2026-05-26 17:02 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-active-goal.sh -->
 
 <!-- auto-log: 2026-05-26 17:02 Edit /Users/danielbentes/synapti-marketplace/plugins/flow/bin/flow-active-goal.sh -->
+
+<!-- auto-log: 2026-05-26 17:06 Write /tmp/pr-123-review-c2.md -->

--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ synapti-marketplace/
     │   │   └── plugin.json
     │   ├── README.md
     │   ├── agents/                   # 8 specialized agents
-    │   ├── commands/                 # 17 workflow commands
+    │   ├── commands/                 # 23 workflow commands (17 work + 6 runtime/admin)
     │   ├── hooks/                    # Safety hook definitions
     │   ├── skills/                   # 22 composable skills (3 foundation + 19 domain)
     │   ├── templates/                # PR, issue, skill proposal templates

--- a/plugins/flow/CHANGELOG.md
+++ b/plugins/flow/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+### v3.1 UX layer — invisible-by-default runtime (#111)
+
+"User intent in, runtime artifacts out." Goals/runs/evidence are now managed for you rather than gated behind opt-in.
+
+- **Conditional-auto goal creation (AC-1)** — replaced the binary `flow.goals.requireGoalForStart` with a 3-state `flow.goals.goalCreation: auto | always | off` (default `auto`). `auto` creates a FlowGoal iff the Spec Validation Gate passed with ≥1 acceptance criterion carrying a `verification_command` (labels do not veto; zero-verifiable/spec-free issues skip silently). `always` creates unconditionally; `off` never auto-creates (manual `/flow:goal create` still works). Read-only migration: `requireGoalForStart: true`→`always`, `false`→`off`, absent→`auto` (settings files are never rewritten). The Phase 0.5 onboarding `AskUserQuestion` and the `set_flow_goals` helper are retired.
+- **Compact runtime summary (AC-2)** — `/flow:start` replaces the `FlowGoal created: …` dump with a compact Goal/Workflow/Run/Branch summary. A degenerate goal (0 ACs, or 0 ACs carrying a `verification_command`) is flagged `⚠ degenerate / needs-attention`, never shown as a clean `active` line; a skipped goal omits the goal line entirely.
+- **Gate on goal existence (AC-1 D-GATE)** — `/flow:pr` and `/flow:merge` now block only when an active goal exists and isn't `achieved`; a branch with **no** goal is no longer blocked (the prior exit-1 fail-closed is removed), preserving v2 merge UX for default installs. The gate is disabled under `goalCreation: off` or `goals.enabled: false`.
+- **Branch-first active-goal detection (AC-4)** — `bin/flow-active-goal.sh` resolves the active goal branch-first (`scope.branch == current branch`, falling back to most-recently-modified active). Exit 3 (degenerate) now fires only when >1 active goal share the current branch, so concurrent goals on different branches/worktrees stop colliding. Adds a test-only `--branch` override and a `--verifiable-count` mode.
+- **`/flow:status` compact dashboard + deep modes (AC-5)** — default output is a 5-line operational dashboard; `--full`, `--json`, and `--evidence` modes added (bare-`$ARGUMENTS`-first parse; unknown arg → compact fallback). `(v3 not enabled)` gating preserved for v2 users.
+- **`/flow:resume` conservatism (AC-6)** — detects uncommitted changes outside `.flow/` and `.decisions/` and asks before suggesting continuation, so a resumed run never silently absorbs unrelated work. Remains informational-only.
+- **Docs reframe + count fix (AC-7)** — README leads with work-first framing; the six runtime primitives (`goal`, `workflow`, `trigger`, `run`, `resume`, `watch`) moved to an "Advanced / runtime internals" section, with `/flow:goal create` reframed as the `--manual` path. Fixed `COMMANDS (17)` → `(23)` and added a test that keeps the README count in sync with the actual command-file count.
+- **`/flow:review` + `/flow:address` record a FlowRun only, no user-facing FlowGoal (AC-3)** — shipped in #114.
+
 ## 3.1.2 (2026-05-26)
 
 ### Fixed: `${ARGUMENTS%% *}` in command `!`-blocks expanded to empty (#121)

--- a/plugins/flow/CHANGELOG.md
+++ b/plugins/flow/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### v3.1 UX layer — invisible-by-default runtime (#111)
+### Added: v3.1 UX layer — invisible-by-default runtime (#111)
 
 "User intent in, runtime artifacts out." Goals/runs/evidence are now managed for you rather than gated behind opt-in.
 

--- a/plugins/flow/CHANGELOG.md
+++ b/plugins/flow/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **`/flow:resume` conservatism (AC-6)** — detects uncommitted changes outside `.flow/` and `.decisions/` and asks before suggesting continuation, so a resumed run never silently absorbs unrelated work. Remains informational-only.
 - **Docs reframe + count fix (AC-7)** — README leads with work-first framing; the six runtime primitives (`goal`, `workflow`, `trigger`, `run`, `resume`, `watch`) moved to an "Advanced / runtime internals" section, with `/flow:goal create` reframed as the `--manual` path. Fixed `COMMANDS (17)` → `(23)` and added a test that keeps the README count in sync with the actual command-file count.
 - **`/flow:review` + `/flow:address` record a FlowRun only, no user-facing FlowGoal (AC-3)** — shipped in #114.
+- **`/flow:setup` upgrades deprecated settings on re-run** — new `bin/flow-migrate-settings.sh` detects a committed `flow.goals.requireGoalForStart` and, behind an `AskUserQuestion` confirmation, rewrites it to `goalCreation` (`true`→`always`, `false`→`off`) atomically, preserving all other keys. Optional hygiene only — the runtime already honors the deprecated key read-only, so declining changes nothing. The v3 runtime settings blocks stay governed by plugin defaults (not written into the team file).
 
 ### Fixed: FlowGoal gate could never observe an `achieved` goal (#122)
 

--- a/plugins/flow/CHANGELOG.md
+++ b/plugins/flow/CHANGELOG.md
@@ -15,6 +15,10 @@
 - **Docs reframe + count fix (AC-7)** — README leads with work-first framing; the six runtime primitives (`goal`, `workflow`, `trigger`, `run`, `resume`, `watch`) moved to an "Advanced / runtime internals" section, with `/flow:goal create` reframed as the `--manual` path. Fixed `COMMANDS (17)` → `(23)` and added a test that keeps the README count in sync with the actual command-file count.
 - **`/flow:review` + `/flow:address` record a FlowRun only, no user-facing FlowGoal (AC-3)** — shipped in #114.
 
+### Fixed: FlowGoal gate could never observe an `achieved` goal (#122)
+
+`bin/flow-active-goal.sh` filtered goals to `active`-only, so a goal that had correctly transitioned to terminal `achieved` returned exit 1 (no active goal) and the gate's `if [ "$GOAL_STATUS" = "achieved" ]` success branch in `merge.md`/`pr.md` was unreachable dead code. Combined with the #111 gate-on-existence change this no longer hard-blocked the merge, but it mislabeled an achieved goal as "no active FlowGoal — gate not applicable," losing the audit trail. Added an opt-in `--allow-terminal` flag to the helper (surfaces `achieved` goals as a branch-first fallback, only when no active goal exists, never trips the degenerate exit 3) and wired it into both gate invocations in `merge.md` and `pr.md`. The Stop hook and `/flow:status` keep their narrow active-only semantics by omitting the flag. Closes the test-coverage gap with an end-to-end `achieved`-path test in `flow-active-goal.test.sh`.
+
 ## 3.1.2 (2026-05-26)
 
 ### Fixed: `${ARGUMENTS%% *}` in command `!`-blocks expanded to empty (#121)

--- a/plugins/flow/README.md
+++ b/plugins/flow/README.md
@@ -177,7 +177,8 @@ AGENTS (8)
   ├── integration-verifier (integration validation)
   └── verdict-judge (independent acceptance criteria evaluation)
 
-COMMANDS (17)
+COMMANDS (23)
+  Work / intent (17) — the commands you drive:
   ├── flow (universal dispatcher)
   ├── start, commit, pr, issue
   ├── review, address
@@ -185,6 +186,8 @@ COMMANDS (17)
   ├── status, learn
   ├── setup, explain
   └── brainstorm, debug, design
+  Runtime / admin (6) — inspect & debug the layer Flow manages for you:
+  └── goal, workflow, trigger, run, resume, watch
 
 HOOKS (8 scripts)
   ├── Safety: block-force-push, block-destructive, block-secrets
@@ -274,6 +277,10 @@ Per-command tier tables make the safety boundary explicit at the point of use. R
 
 ## Commands
 
+**You work in outcomes; Flow manages the runtime.** `/flow:start` creates a goal, selects a workflow, records evidence, and prevents premature completion — you inspect it with `/flow:status`, you don't manage it by hand. Reach for the intent commands below; the runtime primitives (`goal`, `workflow`, `trigger`, `run`, `resume`, `watch`) are admin/debug surface documented under [Advanced / runtime internals](#advanced--runtime-internals).
+
+### Work (intent) commands
+
 | Command | Purpose |
 |---------|---------|
 | `/flow:start <issue>` | Assign issue, create branch, decompose tasks, implement |
@@ -291,6 +298,19 @@ Per-command tier tables make the safety boundary explicit at the point of use. R
 | `/flow:brainstorm [topic]` | Explore approaches before implementation |
 | `/flow:debug [error]` | Structured debugging with root cause analysis |
 | `/flow:design [feature]` | Architecture discussion and design validation |
+
+### Advanced / runtime internals
+
+These commands expose the v3 runtime layer Flow normally manages for you. You rarely invoke them directly — the intent commands above create and advance goals, workflows, runs, and evidence automatically. Reach for these to inspect, debug, or hand-drive the runtime.
+
+| Command | Purpose |
+|---------|---------|
+| `/flow:goal` | Inspect/evaluate FlowGoals. **`/flow:goal create` is the `--manual` path** — the normal way a goal is created is automatically by `/flow:start` (`goalCreation: auto`), not by hand. |
+| `/flow:workflow` | Inspect workflow definitions and phase/activity state |
+| `/flow:trigger` | Manage FlowTriggers (opt-in automation; `flow.triggers.enabled`) |
+| `/flow:run` | Inspect FlowRun records and their event ledgers |
+| `/flow:resume` | Read an interrupted run and propose the next safe action (informational-only) |
+| `/flow:watch` | Generate a `/loop` prompt file for hands-off iteration (user invokes the loop) |
 
 ## Safety Model
 

--- a/plugins/flow/README.md
+++ b/plugins/flow/README.md
@@ -14,7 +14,7 @@ Flow v3 introduces a **runtime layer** at `.flow/` on top of the existing skill 
 
 Flow does NOT invoke native Claude Code `/goal` or `/loop` — those are session-only built-ins and not exposed to plugins. Flow implements its own file-backed goal layer and uses Stop hooks for post-turn enforcement. The `/flow:watch` command generates a `/loop` prompt file the user invokes manually.
 
-**Default behavior is preserved**: `flow.goals.requireGoalForStart` defaults to `false`, so `/flow:start` does NOT auto-create goals. The onboarding prompt fires on the first `/flow:start` in a project that has no `.flow/` directory AND whose `.claude/settings.flow.json` (if present) lacks a `flow.goals` block. v2 projects whose settings file already contains a `flow.goals` block (any contents) skip the prompt — only projects that have never answered the v3 question see it. See the CHANGELOG for the full settings matrix.
+**Goals are invisible-by-default**: `flow.goals.goalCreation` defaults to `auto`, so `/flow:start` records a FlowGoal whenever the issue has ≥1 acceptance criterion carrying a `verification_command` — no consent prompt (the v3.0 onboarding `AskUserQuestion` was retired in v3.1). Issues with zero verifiable ACs (e.g. spec-free `documentation`/`chore`) create no goal, silently. Set `goalCreation: off` to suppress auto-creation, or `flow.goals.enabled: false` to disable the feature. The deprecated `requireGoalForStart` is migrated read-only (`true`→`always`, `false`→`off`). See `references/migration-v2-to-v3.md`.
 
 ### Get started with v3
 

--- a/plugins/flow/bin/cascade-resolve.sh
+++ b/plugins/flow/bin/cascade-resolve.sh
@@ -96,7 +96,7 @@ for SETTINGS in "$LOCAL_SETTINGS" "$PROJECT_SETTINGS" "$USER_SETTINGS" "$PLUGIN_
   fi
   rm -f "$STDERR_TMP" 2>/dev/null
 
-  # treat jq's "null" output as not-found so callers can use
+  # Treat jq's "null" output as not-found so callers can use
   # `.flow.workflows.enabled // null` (recognizes explicit false) instead of
   # `// empty` (which swallows false alongside null). Backward compatible:
   # callers still using `// empty` produce "" and fall through as before.

--- a/plugins/flow/bin/cascade-resolve.sh
+++ b/plugins/flow/bin/cascade-resolve.sh
@@ -96,7 +96,7 @@ for SETTINGS in "$LOCAL_SETTINGS" "$PROJECT_SETTINGS" "$USER_SETTINGS" "$PLUGIN_
   fi
   rm -f "$STDERR_TMP" 2>/dev/null
 
-  # Cycle-14 SEC-V4: treat jq's "null" output as not-found so callers can use
+  # treat jq's "null" output as not-found so callers can use
   # `.flow.workflows.enabled // null` (recognizes explicit false) instead of
   # `// empty` (which swallows false alongside null). Backward compatible:
   # callers still using `// empty` produce "" and fall through as before.

--- a/plugins/flow/bin/flow-active-goal.sh
+++ b/plugins/flow/bin/flow-active-goal.sh
@@ -206,7 +206,7 @@ elif mode == "--status":
 elif mode == "--json":
     print(json.dumps(data, sort_keys=True))
 elif mode == "--ac-summary":
-    # Cycle-14 F1 (code-reviewer skeptic): sanitize ALL emitted fields for
+    # sanitize ALL emitted fields for
     # both newlines (line-break contract) and pipes (column-separator
     # contract). A goal YAML with a pipe character in any field would
     # silently inject extra columns into the documented
@@ -223,7 +223,7 @@ elif mode == "--ac-summary":
         acs = []
     for ac in acs:
         if not isinstance(ac, dict):
-            # Cycle-14 F7 (code-reviewer verifier): tolerate malformed AC
+            # tolerate malformed AC
             # shapes (string instead of dict) rather than crashing with
             # AttributeError outside the try/except in the search loop.
             continue

--- a/plugins/flow/bin/flow-active-goal.sh
+++ b/plugins/flow/bin/flow-active-goal.sh
@@ -104,7 +104,7 @@ allow_terminal = (sys.argv[3] if len(sys.argv) > 3 else "0") == "1"
 if not os.path.isdir(".flow/goals"):
     sys.exit(1)
 
-# Determine the current branch for branch-first selection (#111 AC-4). An
+# Determine the current branch for branch-first selection. An
 # explicit --branch override wins (test-only / scripting); otherwise ask git,
 # tolerating any failure (not a repo, detached HEAD, git missing) by treating
 # the branch as unknown ("").

--- a/plugins/flow/bin/flow-active-goal.sh
+++ b/plugins/flow/bin/flow-active-goal.sh
@@ -205,8 +205,9 @@ elif active and (not branch_strict or not current_branch):
     # alphabetically-first path). This fires for lenient callers (status/learn
     # run from main, legacy goals without scope.branch), AND for --branch-strict
     # callers when the current branch is UNKNOWN ("" — detached HEAD / CI / not a
-    # repo): with no branch to discriminate on, a single/most-recent active goal
-    # is the only sensible resolution and matches pre-branch-scoping behavior.
+    # repo): with no branch to discriminate on, the most-recently-modified
+    # active goal is the only sensible resolution (a more principled pick than
+    # the pre-branch-scoping scan, which returned the alphabetically-first).
     # --branch-strict only bites when the branch IS known and no goal owns it —
     # that is the case where grabbing a cross-branch goal would be wrong (the
     # gate would false-block; the evaluator would mutate another branch's goal).

--- a/plugins/flow/bin/flow-active-goal.sh
+++ b/plugins/flow/bin/flow-active-goal.sh
@@ -31,6 +31,15 @@
 #                      window. Active goals on the current branch still take
 #                      precedence. Stop hook + /flow:status omit the flag to keep
 #                      their narrow active-only semantics.
+#   --branch-strict    when the current branch is KNOWN and owns no goal, exit 1
+#                      (not applicable) instead of falling back to a goal on
+#                      another branch. Used by callers that must act on the
+#                      current branch's goal and never a stale goal elsewhere
+#                      (the merge/pr gate, the Stop-hook evaluator). When the
+#                      branch is UNKNOWN (detached HEAD / CI / not a repo) there
+#                      is nothing to discriminate on, so it still falls back to
+#                      the most-recent active goal. Lenient callers (status/learn)
+#                      omit the flag.
 #
 # Exit codes:
 #   0  active goal found; output on stdout
@@ -48,6 +57,7 @@ MODE="--status"
 SAW_MODE=0
 OVERRIDE_BRANCH=""
 ALLOW_TERMINAL=0
+BRANCH_STRICT=0
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -66,8 +76,12 @@ while [ $# -gt 0 ]; do
       ALLOW_TERMINAL=1
       shift
       ;;
+    --branch-strict)
+      BRANCH_STRICT=1
+      shift
+      ;;
     -h|--help)
-      sed -n '2,40p' "$0" | sed 's/^# \?//'
+      sed -n '2,51p' "$0" | sed 's/^# \?//'
       exit 0
       ;;
     *)
@@ -92,7 +106,7 @@ if [ -L ".flow/goals" ]; then
   exit 2
 fi
 
-python3 - "$MODE" "${OVERRIDE_BRANCH:-}" "$ALLOW_TERMINAL" <<'PYEOF'
+python3 - "$MODE" "${OVERRIDE_BRANCH:-}" "$ALLOW_TERMINAL" "$BRANCH_STRICT" <<'PYEOF'
 import sys, glob, os, json, subprocess
 sys.path[:] = [p for p in sys.path if p not in ("", ".")]
 import yaml
@@ -100,6 +114,7 @@ import yaml
 mode = sys.argv[1]
 override_branch = sys.argv[2] if len(sys.argv) > 2 else ""
 allow_terminal = (sys.argv[3] if len(sys.argv) > 3 else "0") == "1"
+branch_strict = (sys.argv[4] if len(sys.argv) > 4 else "0") == "1"
 
 if not os.path.isdir(".flow/goals"):
     sys.exit(1)
@@ -185,14 +200,21 @@ elif terminal_here:
     # Most-recent wins; equal mtime -> alphabetically-first path (sorted glob
     # order), deterministic across re-runs.
     chosen = max(terminal_here, key=lambda t: t[3])
-elif active:
-    # No goal owns the current branch: fall back to the most-recently-modified
-    # ACTIVE goal so single-goal callers (status/learn run from main, or legacy
-    # goals without scope.branch) still resolve. Equal mtime -> alphabetically-
-    # first path.
+elif active and (not branch_strict or not current_branch):
+    # Fall back to the most-recently-modified ACTIVE goal (equal mtime ->
+    # alphabetically-first path). This fires for lenient callers (status/learn
+    # run from main, legacy goals without scope.branch), AND for --branch-strict
+    # callers when the current branch is UNKNOWN ("" — detached HEAD / CI / not a
+    # repo): with no branch to discriminate on, a single/most-recent active goal
+    # is the only sensible resolution and matches pre-branch-scoping behavior.
+    # --branch-strict only bites when the branch IS known and no goal owns it —
+    # that is the case where grabbing a cross-branch goal would be wrong (the
+    # gate would false-block; the evaluator would mutate another branch's goal).
     chosen = max(active, key=lambda t: t[3])
 else:
-    # Only terminal goals exist and none own the current branch -> not applicable.
+    # Either only terminal goals exist and none own the current branch, or
+    # --branch-strict with a KNOWN current branch that owns no goal -> the
+    # caller must treat this as "no applicable goal for this branch".
     sys.exit(1)
 
 path, data = chosen[0], chosen[1]

--- a/plugins/flow/bin/flow-active-goal.sh
+++ b/plugins/flow/bin/flow-active-goal.sh
@@ -7,17 +7,28 @@
 # schema only touch one reader.
 #
 # Output modes (exactly one allowed, default --status):
-#   --path        absolute-or-relative path to .flow/goals/<id>.goal.yaml
-#   --id          metadata.id
-#   --status      lifecycle.status (e.g., active, waiting_for_user)
-#   --json        full goal as JSON, sorted keys (jq-compatible)
-#   --ac-summary  one line per AC: <id>|<status>|<evidence_ref>|<last_result>
+#   --path             absolute-or-relative path to .flow/goals/<id>.goal.yaml
+#   --id               metadata.id
+#   --status           lifecycle.status (e.g., active, waiting_for_user)
+#   --json             full goal as JSON, sorted keys (jq-compatible)
+#   --ac-summary       one line per AC: <id>|<status>|<evidence_ref>|<last_result>
+#   --verifiable-count <total>/<verifiable> — AC count and the subset carrying a
+#                      non-empty verification_command (used by the AC-2 degenerate marker)
+#
+# Branch scoping (#111 AC-4):
+#   Selection is branch-first. The active goal whose scope.branch matches the
+#   current git branch is preferred; if none matches (or the branch is unknown,
+#   e.g. detached HEAD / legacy goals predating scope.branch), the most-recently-
+#   modified active goal is returned. Exit 3 (degenerate) fires ONLY when >1
+#   active goal share the current branch — concurrent goals on *different*
+#   branches/worktrees each resolve cleanly.
+#   --branch <name>    override the detected current branch (test-only / scripting)
 #
 # Exit codes:
 #   0  active goal found; output on stdout
 #   1  no active goal (caller decides whether this is OK)
 #   2  infrastructure error (python3 / PyYAML missing; symlink rejected)
-#   3  degenerate state (>1 active goal — should never happen)
+#   3  degenerate state (>1 active goal on the current branch)
 #
 # Symlink defense: refuses to read if .flow/goals/ or any *.goal.yaml is a
 # symlink. Matches bin/journal-record.sh and bin/flow-record-verdict.sh.
@@ -27,17 +38,23 @@ export PYTHONSAFEPATH=1
 
 MODE="--status"
 SAW_MODE=0
+OVERRIDE_BRANCH=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --path|--id|--status|--json|--ac-summary)
+    --path|--id|--status|--json|--ac-summary|--verifiable-count)
       [ "$SAW_MODE" = "1" ] && { echo "flow-active-goal.sh: only one mode flag allowed (got both $MODE and $1)" >&2; exit 2; }
       MODE="$1"
       SAW_MODE=1
       shift
       ;;
+    --branch)
+      [ $# -lt 2 ] && { echo "flow-active-goal.sh: --branch requires a value" >&2; exit 2; }
+      OVERRIDE_BRANCH="$2"
+      shift 2
+      ;;
     -h|--help)
-      sed -n '2,24p' "$0" | sed 's/^# \?//'
+      sed -n '2,34p' "$0" | sed 's/^# \?//'
       exit 0
       ;;
     *)
@@ -62,15 +79,32 @@ if [ -L ".flow/goals" ]; then
   exit 2
 fi
 
-python3 - "$MODE" <<'PYEOF'
-import sys, glob, os, json
+python3 - "$MODE" "${OVERRIDE_BRANCH:-}" <<'PYEOF'
+import sys, glob, os, json, subprocess
 sys.path[:] = [p for p in sys.path if p not in ("", ".")]
 import yaml
 
 mode = sys.argv[1]
+override_branch = sys.argv[2] if len(sys.argv) > 2 else ""
 
 if not os.path.isdir(".flow/goals"):
     sys.exit(1)
+
+# Determine the current branch for branch-first selection (#111 AC-4). An
+# explicit --branch override wins (test-only / scripting); otherwise ask git,
+# tolerating any failure (not a repo, detached HEAD, git missing) by treating
+# the branch as unknown ("").
+current_branch = override_branch
+if not current_branch:
+    try:
+        r = subprocess.run(
+            ["git", "branch", "--show-current"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if r.returncode == 0:
+            current_branch = r.stdout.strip()
+    except Exception:
+        current_branch = ""
 
 active = []
 for path in sorted(glob.glob(".flow/goals/*.goal.yaml")):
@@ -81,7 +115,12 @@ for path in sorted(glob.glob(".flow/goals/*.goal.yaml")):
         with open(path, "r", encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
         if (data.get("lifecycle") or {}).get("status") == "active":
-            active.append((path, data))
+            branch = (data.get("scope") or {}).get("branch") or ""
+            try:
+                mtime = os.path.getmtime(path)
+            except OSError:
+                mtime = 0.0
+            active.append((path, data, branch, mtime))
     except Exception:
         # Tolerate unparseable goals — they would block lookup of a sibling
         # legitimate active goal. The Stop hook + status subcommand follow
@@ -90,15 +129,27 @@ for path in sorted(glob.glob(".flow/goals/*.goal.yaml")):
 
 if not active:
     sys.exit(1)
-if len(active) > 1:
-    paths = [p for p, _ in active]
-    print(
-        f"flow-active-goal.sh: degenerate state — {len(active)} active goals: {', '.join(paths)}",
-        file=sys.stderr,
-    )
-    sys.exit(3)
 
-path, data = active[0]
+# Branch-first selection (#111 AC-4): prefer goals whose scope.branch matches
+# the current branch. Exit 3 (degenerate) fires ONLY when >1 active goal share
+# the current branch — concurrent goals on different branches no longer collide.
+candidates = [t for t in active if current_branch and t[2] == current_branch]
+if candidates:
+    if len(candidates) > 1:
+        paths = [t[0] for t in candidates]
+        print(
+            f"flow-active-goal.sh: degenerate state — {len(candidates)} active goals "
+            f"on branch '{current_branch}': {', '.join(paths)}",
+            file=sys.stderr,
+        )
+        sys.exit(3)
+    path, data = candidates[0][0], candidates[0][1]
+else:
+    # No active goal owns the current branch (or the branch is unknown / legacy
+    # goals predate scope.branch): fall back to the most-recently-modified
+    # active goal so single-goal callers (e.g. run from main) still resolve.
+    best = max(active, key=lambda t: t[3])
+    path, data = best[0], best[1]
 
 if mode == "--path":
     print(path)
@@ -131,6 +182,22 @@ elif mode == "--ac-summary":
         evidence_ref = _sanitize(ac.get("evidence_ref") or "-")
         last_result = _sanitize(ac.get("last_result") or "-")
         print(f"{ac_id}|{status}|{evidence_ref}|{last_result}")
+elif mode == "--verifiable-count":
+    # #111 AC-2: emit "<total>/<verifiable>" so the compact summary can flag a
+    # degenerate goal (0 ACs, or 0 ACs carrying a non-empty verification_command)
+    # without re-parsing the YAML. A verification_command of "" or whitespace is
+    # not verifiable.
+    acs = ((data.get("objective") or {}).get("acceptance_criteria") or [])
+    total = 0
+    verifiable = 0
+    for ac in acs:
+        if not isinstance(ac, dict):
+            continue
+        total += 1
+        vc = ac.get("verification_command")
+        if isinstance(vc, str) and vc.strip():
+            verifiable += 1
+    print(f"{total}/{verifiable}")
 else:
     print(f"flow-active-goal.sh: unknown mode {mode}", file=sys.stderr)
     sys.exit(2)

--- a/plugins/flow/bin/flow-active-goal.sh
+++ b/plugins/flow/bin/flow-active-goal.sh
@@ -23,6 +23,12 @@
 #   active goal share the current branch — concurrent goals on *different*
 #   branches/worktrees each resolve cleanly.
 #   --branch <name>    override the detected current branch (test-only / scripting)
+#   --allow-terminal   also consider terminal `achieved` goals as a fallback when
+#                      no active goal exists, so the merge/pr gate can observe a
+#                      goal that already reached `achieved` (#122). Active goals
+#                      always take precedence; the achieved fallback never trips
+#                      exit 3. Stop hook + /flow:status omit the flag to keep
+#                      their narrow active-only semantics.
 #
 # Exit codes:
 #   0  active goal found; output on stdout
@@ -39,6 +45,7 @@ export PYTHONSAFEPATH=1
 MODE="--status"
 SAW_MODE=0
 OVERRIDE_BRANCH=""
+ALLOW_TERMINAL=0
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -53,8 +60,12 @@ while [ $# -gt 0 ]; do
       OVERRIDE_BRANCH="$2"
       shift 2
       ;;
+    --allow-terminal)
+      ALLOW_TERMINAL=1
+      shift
+      ;;
     -h|--help)
-      sed -n '2,34p' "$0" | sed 's/^# \?//'
+      sed -n '2,40p' "$0" | sed 's/^# \?//'
       exit 0
       ;;
     *)
@@ -79,13 +90,14 @@ if [ -L ".flow/goals" ]; then
   exit 2
 fi
 
-python3 - "$MODE" "${OVERRIDE_BRANCH:-}" <<'PYEOF'
+python3 - "$MODE" "${OVERRIDE_BRANCH:-}" "$ALLOW_TERMINAL" <<'PYEOF'
 import sys, glob, os, json, subprocess
 sys.path[:] = [p for p in sys.path if p not in ("", ".")]
 import yaml
 
 mode = sys.argv[1]
 override_branch = sys.argv[2] if len(sys.argv) > 2 else ""
+allow_terminal = (sys.argv[3] if len(sys.argv) > 3 else "0") == "1"
 
 if not os.path.isdir(".flow/goals"):
     sys.exit(1)
@@ -107,6 +119,10 @@ if not current_branch:
         current_branch = ""
 
 active = []
+# Terminal-achieved goals, collected only when --allow-terminal is set. Used as
+# a fallback so the merge/pr gate can observe a goal that already reached
+# `achieved` (#122) — active goals always take precedence over this set.
+terminal = []
 for path in sorted(glob.glob(".flow/goals/*.goal.yaml")):
     if os.path.islink(path):
         print(f"flow-active-goal.sh: refusing — {path} is a symlink", file=sys.stderr)
@@ -114,41 +130,52 @@ for path in sorted(glob.glob(".flow/goals/*.goal.yaml")):
     try:
         with open(path, "r", encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
-        if (data.get("lifecycle") or {}).get("status") == "active":
-            branch = (data.get("scope") or {}).get("branch") or ""
-            try:
-                mtime = os.path.getmtime(path)
-            except OSError:
-                mtime = 0.0
+        status = (data.get("lifecycle") or {}).get("status")
+        branch = (data.get("scope") or {}).get("branch") or ""
+        try:
+            mtime = os.path.getmtime(path)
+        except OSError:
+            mtime = 0.0
+        if status == "active":
             active.append((path, data, branch, mtime))
+        elif allow_terminal and status == "achieved":
+            terminal.append((path, data, branch, mtime))
     except Exception:
         # Tolerate unparseable goals — they would block lookup of a sibling
         # legitimate active goal. The Stop hook + status subcommand follow
         # the same tolerate-and-continue pattern.
         continue
 
-if not active:
+if not active and not terminal:
     sys.exit(1)
 
 # Branch-first selection (#111 AC-4): prefer goals whose scope.branch matches
-# the current branch. Exit 3 (degenerate) fires ONLY when >1 active goal share
+# the current branch. Exit 3 (degenerate) fires ONLY when >1 ACTIVE goal share
 # the current branch — concurrent goals on different branches no longer collide.
-candidates = [t for t in active if current_branch and t[2] == current_branch]
-if candidates:
-    if len(candidates) > 1:
-        paths = [t[0] for t in candidates]
-        print(
-            f"flow-active-goal.sh: degenerate state — {len(candidates)} active goals "
-            f"on branch '{current_branch}': {', '.join(paths)}",
-            file=sys.stderr,
-        )
-        sys.exit(3)
-    path, data = candidates[0][0], candidates[0][1]
+if active:
+    candidates = [t for t in active if current_branch and t[2] == current_branch]
+    if candidates:
+        if len(candidates) > 1:
+            paths = [t[0] for t in candidates]
+            print(
+                f"flow-active-goal.sh: degenerate state — {len(candidates)} active goals "
+                f"on branch '{current_branch}': {', '.join(paths)}",
+                file=sys.stderr,
+            )
+            sys.exit(3)
+        path, data = candidates[0][0], candidates[0][1]
+    else:
+        # No active goal owns the current branch (or the branch is unknown /
+        # legacy goals predate scope.branch): fall back to the most-recently-
+        # modified active goal so single-goal callers (e.g. run from main) resolve.
+        best = max(active, key=lambda t: t[3])
+        path, data = best[0], best[1]
 else:
-    # No active goal owns the current branch (or the branch is unknown / legacy
-    # goals predate scope.branch): fall back to the most-recently-modified
-    # active goal so single-goal callers (e.g. run from main) still resolve.
-    best = max(active, key=lambda t: t[3])
+    # No active goal anywhere — fall back to a terminal `achieved` goal (#122,
+    # only reachable under --allow-terminal). Branch-first, then most-recent;
+    # never degenerate (multiple achieved goals on a branch is normal history).
+    t_candidates = [t for t in terminal if current_branch and t[2] == current_branch] or terminal
+    best = max(t_candidates, key=lambda t: t[3])
     path, data = best[0], best[1]
 
 if mode == "--path":

--- a/plugins/flow/bin/flow-active-goal.sh
+++ b/plugins/flow/bin/flow-active-goal.sh
@@ -13,21 +13,23 @@
 #   --json             full goal as JSON, sorted keys (jq-compatible)
 #   --ac-summary       one line per AC: <id>|<status>|<evidence_ref>|<last_result>
 #   --verifiable-count <total>/<verifiable> — AC count and the subset carrying a
-#                      non-empty verification_command (used by the AC-2 degenerate marker)
+#                      non-empty verification_command (feeds the compact-summary
+#                      degenerate marker)
 #
-# Branch scoping (#111 AC-4):
-#   Selection is branch-first. The active goal whose scope.branch matches the
-#   current git branch is preferred; if none matches (or the branch is unknown,
-#   e.g. detached HEAD / legacy goals predating scope.branch), the most-recently-
-#   modified active goal is returned. Exit 3 (degenerate) fires ONLY when >1
-#   active goal share the current branch — concurrent goals on *different*
-#   branches/worktrees each resolve cleanly.
+# Branch scoping:
+#   Selection is branch-first — a goal that owns the current git branch always
+#   wins over a cross-branch goal regardless of lifecycle status. If no goal owns
+#   the current branch (or the branch is unknown, e.g. detached HEAD / legacy
+#   goals predating scope.branch), the most-recently-modified ACTIVE goal is
+#   returned. Exit 3 (degenerate) fires ONLY when >1 active goal share the
+#   current branch — concurrent goals on different branches/worktrees each
+#   resolve cleanly.
 #   --branch <name>    override the detected current branch (test-only / scripting)
-#   --allow-terminal   also consider terminal `achieved` goals as a fallback when
-#                      no active goal exists, so the merge/pr gate can observe a
-#                      goal that already reached `achieved` (#122). Active goals
-#                      always take precedence; the achieved fallback never trips
-#                      exit 3. Stop hook + /flow:status omit the flag to keep
+#   --allow-terminal   also consider a terminal `achieved` goal, but ONLY when it
+#                      owns the current branch (never cross-branch) — lets the
+#                      merge/pr gate observe a goal that already left the active
+#                      window. Active goals on the current branch still take
+#                      precedence. Stop hook + /flow:status omit the flag to keep
 #                      their narrow active-only semantics.
 #
 # Exit codes:
@@ -119,9 +121,13 @@ if not current_branch:
         current_branch = ""
 
 active = []
-# Terminal-achieved goals, collected only when --allow-terminal is set. Used as
-# a fallback so the merge/pr gate can observe a goal that already reached
-# `achieved` (#122) — active goals always take precedence over this set.
+# Terminal `achieved` goals, collected only when --allow-terminal is set, so the
+# merge/pr gate can observe a goal that already left the `active` window. They
+# are only ever selected when their scope.branch matches the current branch —
+# never via a cross-branch fallback. The sole --allow-terminal caller (the gate)
+# always runs on the goal's own branch, and a cross-branch terminal pick would
+# both answer the gate with an unrelated goal and be influenceable through file
+# mtime.
 terminal = []
 for path in sorted(glob.glob(".flow/goals/*.goal.yaml")):
     if os.path.islink(path):
@@ -142,41 +148,54 @@ for path in sorted(glob.glob(".flow/goals/*.goal.yaml")):
             terminal.append((path, data, branch, mtime))
     except Exception:
         # Tolerate unparseable goals — they would block lookup of a sibling
-        # legitimate active goal. The Stop hook + status subcommand follow
-        # the same tolerate-and-continue pattern.
+        # legitimate goal. The Stop hook + status subcommand follow the same
+        # tolerate-and-continue pattern.
         continue
 
 if not active and not terminal:
     sys.exit(1)
 
-# Branch-first selection (#111 AC-4): prefer goals whose scope.branch matches
-# the current branch. Exit 3 (degenerate) fires ONLY when >1 ACTIVE goal share
-# the current branch — concurrent goals on different branches no longer collide.
-if active:
-    candidates = [t for t in active if current_branch and t[2] == current_branch]
-    if candidates:
-        if len(candidates) > 1:
-            paths = [t[0] for t in candidates]
-            print(
-                f"flow-active-goal.sh: degenerate state — {len(candidates)} active goals "
-                f"on branch '{current_branch}': {', '.join(paths)}",
-                file=sys.stderr,
-            )
-            sys.exit(3)
-        path, data = candidates[0][0], candidates[0][1]
-    else:
-        # No active goal owns the current branch (or the branch is unknown /
-        # legacy goals predate scope.branch): fall back to the most-recently-
-        # modified active goal so single-goal callers (e.g. run from main) resolve.
-        best = max(active, key=lambda t: t[3])
-        path, data = best[0], best[1]
+# Branch-first selection. A goal that owns the current branch always wins over a
+# cross-branch goal, regardless of lifecycle status. Priority:
+#   1. active goal(s) on the current branch  (>1 -> exit 3, degenerate)
+#   2. achieved goal on the current branch    (only with --allow-terminal)
+#   3. most-recently-modified ACTIVE goal on any branch (legacy goals predating
+#      scope.branch, detached HEAD, or a caller run from main)
+# Terminal goals are never selected cross-branch (no tier-3 equivalent): if only
+# achieved goals exist and none own the current branch, there is no applicable
+# goal for this caller.
+def _branch_matches(t):
+    return bool(current_branch) and t[2] == current_branch
+
+active_here = [t for t in active if _branch_matches(t)]
+terminal_here = [t for t in terminal if _branch_matches(t)]
+
+if active_here:
+    if len(active_here) > 1:
+        paths = [t[0] for t in active_here]
+        print(
+            f"flow-active-goal.sh: degenerate state — {len(active_here)} active goals "
+            f"on branch '{current_branch}': {', '.join(paths)}",
+            file=sys.stderr,
+        )
+        sys.exit(3)
+    chosen = active_here[0]
+elif terminal_here:
+    # Achieved goal on the current branch (e.g. the gate after evaluation).
+    # Most-recent wins; equal mtime -> alphabetically-first path (sorted glob
+    # order), deterministic across re-runs.
+    chosen = max(terminal_here, key=lambda t: t[3])
+elif active:
+    # No goal owns the current branch: fall back to the most-recently-modified
+    # ACTIVE goal so single-goal callers (status/learn run from main, or legacy
+    # goals without scope.branch) still resolve. Equal mtime -> alphabetically-
+    # first path.
+    chosen = max(active, key=lambda t: t[3])
 else:
-    # No active goal anywhere — fall back to a terminal `achieved` goal (#122,
-    # only reachable under --allow-terminal). Branch-first, then most-recent;
-    # never degenerate (multiple achieved goals on a branch is normal history).
-    t_candidates = [t for t in terminal if current_branch and t[2] == current_branch] or terminal
-    best = max(t_candidates, key=lambda t: t[3])
-    path, data = best[0], best[1]
+    # Only terminal goals exist and none own the current branch -> not applicable.
+    sys.exit(1)
+
+path, data = chosen[0], chosen[1]
 
 if mode == "--path":
     print(path)
@@ -198,6 +217,10 @@ elif mode == "--ac-summary":
         s = " ".join(str(value).split())  # collapse all whitespace incl. newlines
         return s.replace("|", "│")
     acs = ((data.get("objective") or {}).get("acceptance_criteria") or [])
+    if not isinstance(acs, list):
+        # A non-list acceptance_criteria (e.g. a scalar in malformed user YAML)
+        # would raise TypeError on iteration — outside the parse loop's try.
+        acs = []
     for ac in acs:
         if not isinstance(ac, dict):
             # Cycle-14 F7 (code-reviewer verifier): tolerate malformed AC
@@ -210,11 +233,13 @@ elif mode == "--ac-summary":
         last_result = _sanitize(ac.get("last_result") or "-")
         print(f"{ac_id}|{status}|{evidence_ref}|{last_result}")
 elif mode == "--verifiable-count":
-    # #111 AC-2: emit "<total>/<verifiable>" so the compact summary can flag a
-    # degenerate goal (0 ACs, or 0 ACs carrying a non-empty verification_command)
-    # without re-parsing the YAML. A verification_command of "" or whitespace is
-    # not verifiable.
+    # Emit "<total>/<verifiable>" so the compact summary can flag a degenerate
+    # goal (0 ACs, or 0 ACs carrying a non-empty verification_command) without
+    # re-parsing the YAML. A verification_command of "" or whitespace is not
+    # verifiable.
     acs = ((data.get("objective") or {}).get("acceptance_criteria") or [])
+    if not isinstance(acs, list):
+        acs = []   # non-list (scalar) acceptance_criteria -> treat as zero ACs
     total = 0
     verifiable = 0
     for ac in acs:

--- a/plugins/flow/bin/flow-goal-record.sh
+++ b/plugins/flow/bin/flow-goal-record.sh
@@ -118,9 +118,9 @@ LIFECYCLE_TRANSITIONS = {
 }
 TERMINAL_STATES = {"achieved", "failed", "cancelled"}
 
-# F11 (cycle-13) + cycle-14 F11-SENTINEL fix: when jsonschema is unavailable,
+# when jsonschema is unavailable,
 # emit a stderr WARN dedup'd PER DAY via a sentinel file. The original
-# cycle-13 implementation used a module-level Python sentinel that reset on
+# implementation used a module-level Python sentinel that reset on
 # every bash invocation (because each bash call spawns a fresh Python), so
 # the WARN fired on every /flow:goal command — noise that drowned out real
 # diagnostics.

--- a/plugins/flow/bin/flow-goal-record.sh
+++ b/plugins/flow/bin/flow-goal-record.sh
@@ -118,8 +118,8 @@ LIFECYCLE_TRANSITIONS = {
 }
 TERMINAL_STATES = {"achieved", "failed", "cancelled"}
 
-# when jsonschema is unavailable,
-# emit a stderr WARN dedup'd PER DAY via a sentinel file. The original
+# When jsonschema is unavailable, emit a stderr WARN dedup'd PER DAY via a
+# sentinel file. The original
 # implementation used a module-level Python sentinel that reset on
 # every bash invocation (because each bash call spawns a fresh Python), so
 # the WARN fired on every /flow:goal command — noise that drowned out real

--- a/plugins/flow/bin/flow-migrate-settings.sh
+++ b/plugins/flow/bin/flow-migrate-settings.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# flow-migrate-settings.sh — upgrade a flow settings file to the current schema.
+#
+# Applies deprecated-key migrations to a `.claude/settings.flow.json`-style file
+# so a project that committed an older-schema settings file can be brought
+# forward. The runtime already honors deprecated keys read-only (via
+# cascade-resolve), so this is a HYGIENE upgrade, not a correctness fix —
+# nothing breaks if it is never run.
+#
+# Migrations applied (extend the jq filter below as new deprecations land):
+#   - flow.goals.requireGoalForStart  ->  flow.goals.goalCreation
+#       true -> "always", false -> "off", any other value -> "auto".
+#       If goalCreation is already set, it WINS and the legacy key is dropped.
+#
+# Usage:
+#   flow-migrate-settings.sh [--apply] [<settings-file>]
+#
+#   default file: .claude/settings.flow.json
+#   without --apply: dry-run — prints `MIGRATE=...` lines describing pending
+#                    changes (or `MIGRATE=none`) and exits 0 without writing.
+#   with --apply:    rewrites the file atomically (tmpfile + validate + mv),
+#                    preserving every other key.
+#
+# Exit:
+#   0  success (dry-run reported, or --apply wrote / had nothing to do)
+#   2  infrastructure error (jq missing, file missing, symlink rejected,
+#      malformed JSON, atomic write failed)
+#
+# Safety: refuses to operate through a symlinked settings file or .claude dir
+# (matches bin/journal-record.sh / bin/flow-active-goal.sh). The --apply write
+# is atomic and validates the produced JSON before replacing the original, so a
+# jq failure can never leave a truncated settings file.
+
+set -uo pipefail
+
+APPLY=0
+SETTINGS=".claude/settings.flow.json"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --apply) APPLY=1; shift ;;
+    -h|--help) sed -n '2,33p' "$0" | sed 's/^# \?//'; exit 0 ;;
+    -*) echo "flow-migrate-settings.sh: unknown flag: $1" >&2; exit 2 ;;
+    *) SETTINGS="$1"; shift ;;
+  esac
+done
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "flow-migrate-settings.sh: jq required but not installed" >&2
+  exit 2
+fi
+
+if [ ! -f "$SETTINGS" ]; then
+  echo "flow-migrate-settings.sh: settings file not found: $SETTINGS" >&2
+  exit 2
+fi
+
+# Symlink defense — refuse to read/write through a symlinked file or .claude dir.
+SETTINGS_DIR=$(dirname "$SETTINGS")
+if [ -L "$SETTINGS" ]; then
+  echo "flow-migrate-settings.sh: refusing — $SETTINGS is a symlink" >&2
+  exit 2
+fi
+if [ -L "$SETTINGS_DIR" ]; then
+  echo "flow-migrate-settings.sh: refusing — $SETTINGS_DIR is a symlink" >&2
+  exit 2
+fi
+
+# The migration filter. Pure, idempotent: a file with no deprecated keys passes
+# through unchanged. New deprecations extend this single expression.
+MIGRATE_FILTER='
+  if (.flow.goals | type) == "object" and (.flow.goals | has("requireGoalForStart")) then
+    .flow.goals.goalCreation = (
+      .flow.goals.goalCreation //
+      (if .flow.goals.requireGoalForStart == true then "always"
+       elif .flow.goals.requireGoalForStart == false then "off"
+       else "auto" end)
+    )
+    | .flow.goals = (.flow.goals | del(.requireGoalForStart))
+  else . end
+'
+
+ORIGINAL=$(cat "$SETTINGS")
+if ! MIGRATED=$(printf '%s' "$ORIGINAL" | jq "$MIGRATE_FILTER" 2>/dev/null); then
+  echo "flow-migrate-settings.sh: $SETTINGS is not valid JSON — refusing to migrate" >&2
+  exit 2
+fi
+
+# Compare canonically (sorted keys) so formatting differences don't masquerade
+# as changes.
+ORIG_CANON=$(printf '%s' "$ORIGINAL" | jq -S . 2>/dev/null)
+MIG_CANON=$(printf '%s' "$MIGRATED" | jq -S . 2>/dev/null)
+
+if [ "$ORIG_CANON" = "$MIG_CANON" ]; then
+  echo "MIGRATE=none"
+  exit 0
+fi
+
+# Describe the concrete change (requireGoalForStart -> goalCreation).
+OLD_VAL=$(printf '%s' "$ORIGINAL" | jq -r '.flow.goals.requireGoalForStart // "absent"' 2>/dev/null)
+NEW_VAL=$(printf '%s' "$MIGRATED" | jq -r '.flow.goals.goalCreation // "absent"' 2>/dev/null)
+echo "MIGRATE=requireGoalForStart->goalCreation"
+echo "MIGRATE_FROM=requireGoalForStart=$OLD_VAL"
+echo "MIGRATE_TO=goalCreation=$NEW_VAL"
+
+if [ "$APPLY" != "1" ]; then
+  echo "MIGRATE_MODE=dry-run (re-run with --apply to write)"
+  exit 0
+fi
+
+# Atomic write: tmpfile in the same dir, validate, then mv. flock guards the
+# read-modify-write window against concurrent writers.
+TMP=$(mktemp -t flow-migrate-settings.XXXXXX 2>/dev/null) || {
+  echo "flow-migrate-settings.sh: mktemp failed" >&2; exit 2; }
+LOCK="${SETTINGS}.lock"
+trap 'rm -f "$TMP"' EXIT INT TERM
+(
+  flock -x 9 || { echo "flow-migrate-settings.sh: failed to acquire $LOCK" >&2; exit 2; }
+  # Re-read under the lock and re-apply so a concurrent writer's change isn't lost.
+  if ! jq "$MIGRATE_FILTER" "$SETTINGS" > "$TMP" 2>/dev/null; then
+    echo "flow-migrate-settings.sh: jq migration failed under lock" >&2; exit 2
+  fi
+  if [ ! -s "$TMP" ] || ! jq empty "$TMP" >/dev/null 2>&1; then
+    echo "flow-migrate-settings.sh: produced empty/invalid JSON — $SETTINGS unchanged" >&2; exit 2
+  fi
+  if ! mv "$TMP" "$SETTINGS"; then
+    echo "flow-migrate-settings.sh: mv failed — $SETTINGS unchanged" >&2; exit 2
+  fi
+) 9>"$LOCK"
+RC=$?
+trap - EXIT INT TERM
+rm -f "$TMP"
+[ "$RC" -ne 0 ] && exit 2
+
+echo "MIGRATE_APPLIED=1"
+exit 0

--- a/plugins/flow/bin/flow-migrate-settings.sh
+++ b/plugins/flow/bin/flow-migrate-settings.sh
@@ -108,10 +108,11 @@ if [ "$APPLY" != "1" ]; then
   exit 0
 fi
 
-# Atomic write: tmpfile in the same dir, validate, then mv. flock guards the
-# read-modify-write window against concurrent writers.
-TMP=$(mktemp -t flow-migrate-settings.XXXXXX 2>/dev/null) || {
-  echo "flow-migrate-settings.sh: mktemp failed" >&2; exit 2; }
+# Atomic write: tmpfile in the SAME directory as the target (so the final mv is
+# a same-filesystem atomic rename, not a cross-FS copy+unlink), validate, then
+# mv. flock guards the read-modify-write window against concurrent writers.
+TMP=$(mktemp "${SETTINGS_DIR}/.flow-migrate-settings.XXXXXX" 2>/dev/null) || {
+  echo "flow-migrate-settings.sh: mktemp failed in $SETTINGS_DIR" >&2; exit 2; }
 LOCK="${SETTINGS}.lock"
 trap 'rm -f "$TMP"' EXIT INT TERM
 (

--- a/plugins/flow/bin/flow-migrate-settings.sh
+++ b/plugins/flow/bin/flow-migrate-settings.sh
@@ -67,7 +67,9 @@ if [ -L "$SETTINGS_DIR" ]; then
 fi
 
 # The migration filter. Pure, idempotent: a file with no deprecated keys passes
-# through unchanged. New deprecations extend this single expression.
+# through unchanged. New deprecations extend this single expression. The `//`
+# is falsy-safe by design: a pre-existing goalCreation of `false`/`null` is not a
+# valid enum value, so substituting the migrated value in that case is correct.
 MIGRATE_FILTER='
   if (.flow.goals | type) == "object" and (.flow.goals | has("requireGoalForStart")) then
     .flow.goals.goalCreation = (
@@ -82,7 +84,7 @@ MIGRATE_FILTER='
 
 ORIGINAL=$(cat "$SETTINGS")
 if ! MIGRATED=$(printf '%s' "$ORIGINAL" | jq "$MIGRATE_FILTER" 2>/dev/null); then
-  echo "flow-migrate-settings.sh: $SETTINGS is not valid JSON — refusing to migrate" >&2
+  echo "flow-migrate-settings.sh: $SETTINGS is not a JSON object (or not valid JSON) — refusing to migrate" >&2
   exit 2
 fi
 
@@ -96,8 +98,10 @@ if [ "$ORIG_CANON" = "$MIG_CANON" ]; then
   exit 0
 fi
 
-# Describe the concrete change (requireGoalForStart -> goalCreation).
-OLD_VAL=$(printf '%s' "$ORIGINAL" | jq -r '.flow.goals.requireGoalForStart // "absent"' 2>/dev/null)
+# Describe the concrete change (requireGoalForStart -> goalCreation). Report the
+# real old value (true/false/null/...) when the key is present, distinguishing an
+# explicit `null` from an absent key.
+OLD_VAL=$(printf '%s' "$ORIGINAL" | jq -r 'if (.flow.goals | type) == "object" and (.flow.goals | has("requireGoalForStart")) then (.flow.goals.requireGoalForStart | tostring) else "absent" end' 2>/dev/null)
 NEW_VAL=$(printf '%s' "$MIGRATED" | jq -r '.flow.goals.goalCreation // "absent"' 2>/dev/null)
 echo "MIGRATE=requireGoalForStart->goalCreation"
 echo "MIGRATE_FROM=requireGoalForStart=$OLD_VAL"
@@ -114,9 +118,22 @@ fi
 TMP=$(mktemp "${SETTINGS_DIR}/.flow-migrate-settings.XXXXXX" 2>/dev/null) || {
   echo "flow-migrate-settings.sh: mktemp failed in $SETTINGS_DIR" >&2; exit 2; }
 LOCK="${SETTINGS}.lock"
-trap 'rm -f "$TMP"' EXIT INT TERM
+# Refuse a symlinked lock path: the `9>"$LOCK"` redirect below would otherwise
+# open (and truncate) the symlink's target — a write-through-symlink vector to
+# an out-of-tree file.
+if [ -L "$LOCK" ]; then
+  echo "flow-migrate-settings.sh: refusing — $LOCK is a symlink" >&2; exit 2
+fi
+trap 'rm -f "$TMP" "$LOCK"' EXIT INT TERM
 (
-  flock -x 9 || { echo "flow-migrate-settings.sh: failed to acquire $LOCK" >&2; exit 2; }
+  flock -x -w 10 9 || { echo "flow-migrate-settings.sh: failed to acquire $LOCK (timeout)" >&2; exit 2; }
+  # Re-check the symlink under the lock, immediately before the read+rename, to
+  # close the TOCTOU window since the initial check. `mv` replaces the name via
+  # rename(2) (it does NOT write through a symlink), but a symlink swapped in
+  # here would still taint the jq read — refuse it.
+  if [ -L "$SETTINGS" ]; then
+    echo "flow-migrate-settings.sh: refusing — $SETTINGS became a symlink" >&2; exit 2
+  fi
   # Re-read under the lock and re-apply so a concurrent writer's change isn't lost.
   if ! jq "$MIGRATE_FILTER" "$SETTINGS" > "$TMP" 2>/dev/null; then
     echo "flow-migrate-settings.sh: jq migration failed under lock" >&2; exit 2
@@ -130,7 +147,7 @@ trap 'rm -f "$TMP"' EXIT INT TERM
 ) 9>"$LOCK"
 RC=$?
 trap - EXIT INT TERM
-rm -f "$TMP"
+rm -f "$TMP" "$LOCK"
 [ "$RC" -ne 0 ] && exit 2
 
 echo "MIGRATE_APPLIED=1"

--- a/plugins/flow/bin/flow-record-activity.sh
+++ b/plugins/flow/bin/flow-record-activity.sh
@@ -155,11 +155,11 @@ try:
         print(f"flow-record-activity.sh: activity does not match schema: {e.message}", file=sys.stderr)
         sys.exit(1)
 except ImportError:
-    # Cycle-14 F11-INCONSISTENCY (error-handler verifier): apply the same
+    # apply the same
     # per-day WARN as flow-goal-record.sh so the jsonschema-degraded state
     # is surfaced uniformly across all three FlowRunArtifact writers (goal,
     # activity, evidence). Previous behavior was silent skip — diverged
-    # from F11's "surface the degradation" rationale.
+    # following the same "surface the degradation" rationale.
     import datetime, tempfile, getpass
     today = datetime.date.today().isoformat()
     try:

--- a/plugins/flow/bin/flow-record-activity.sh
+++ b/plugins/flow/bin/flow-record-activity.sh
@@ -155,11 +155,10 @@ try:
         print(f"flow-record-activity.sh: activity does not match schema: {e.message}", file=sys.stderr)
         sys.exit(1)
 except ImportError:
-    # apply the same
-    # per-day WARN as flow-goal-record.sh so the jsonschema-degraded state
-    # is surfaced uniformly across all three FlowRunArtifact writers (goal,
-    # activity, evidence). Previous behavior was silent skip — diverged
-    # following the same "surface the degradation" rationale.
+    # Apply the same per-day WARN as flow-goal-record.sh so the
+    # jsonschema-degraded state is surfaced uniformly across all three
+    # FlowRunArtifact writers (goal, activity, evidence). The previous silent
+    # skip diverged from this "surface the degradation" rationale.
     import datetime, tempfile, getpass
     today = datetime.date.today().isoformat()
     try:

--- a/plugins/flow/bin/flow-record-evidence.sh
+++ b/plugins/flow/bin/flow-record-evidence.sh
@@ -121,7 +121,7 @@ try:
         print(f"flow-record-evidence.sh: evidence does not match schema: {e.message}", file=sys.stderr)
         sys.exit(1)
 except ImportError:
-    # Cycle-14 F11-INCONSISTENCY (error-handler verifier): mirror the per-day
+    # mirror the per-day
     # WARN from flow-goal-record.sh and flow-record-activity.sh.
     import datetime, tempfile, getpass
     today = datetime.date.today().isoformat()

--- a/plugins/flow/bin/flow-record-evidence.sh
+++ b/plugins/flow/bin/flow-record-evidence.sh
@@ -121,8 +121,7 @@ try:
         print(f"flow-record-evidence.sh: evidence does not match schema: {e.message}", file=sys.stderr)
         sys.exit(1)
 except ImportError:
-    # mirror the per-day
-    # WARN from flow-goal-record.sh and flow-record-activity.sh.
+    # Mirror the per-day WARN from flow-goal-record.sh and flow-record-activity.sh.
     import datetime, tempfile, getpass
     today = datetime.date.today().isoformat()
     try:

--- a/plugins/flow/commands/merge.md
+++ b/plugins/flow/commands/merge.md
@@ -269,10 +269,10 @@ if [ $GH_EXIT_RES -ne 0 ] || [ $GH_EXIT_REV -ne 0 ]; then
 fi
 
 # Surface "untrusted-only" markers as a block reason rather than silently
-# treating them as no markers at all. This is the #92 forgery defense.
+# treating them as no markers at all. This is the marker-forgery defense.
 # Render the trust list as a comma-separated string for the user-facing
 # message — the `$TRUST_REGEX` variable used to appear here was a leftover
-# from PR #93 and never assigned, producing the empty-parens string
+# from an earlier revision and never assigned, producing the empty-parens string
 # "trusted authors ()" in messages or aborting under `set -u`.
 #
 # Derive the fallback from $TRUST_DEFAULT rather than hard-coding the value:
@@ -360,8 +360,8 @@ else
         else
           # Active goal exists but is not achieved — fail closed.
           # The "no incomplete shipments" hard boundary applies: merging a
-          # PR whose own contract reports incomplete is exactly what F1 is
-          # designed to prevent.
+          # PR whose own contract reports incomplete is exactly what the
+          # "no incomplete shipments" boundary is designed to prevent.
           echo "FLOW_GOAL_GATE_STATE=blocked"
           echo "FLOW_GOAL_BLOCK_REASON=FlowGoal $GOAL_ID lifecycle is '$GOAL_STATUS' — run /flow:goal evaluate $GOAL_ID to advance"
         fi

--- a/plugins/flow/commands/merge.md
+++ b/plugins/flow/commands/merge.md
@@ -345,14 +345,15 @@ else
     echo "FLOW_GOAL_GATE_STATE=blocked"
     echo "FLOW_GOAL_BLOCK_REASON=flow-active-goal.sh missing or non-executable"
   else
-    # --allow-terminal: surface a goal that already reached `achieved` so
-    # the success branch below is reachable. Without it the helper filters
-    # achieved goals out (active-only), exit 1, and an achieved goal would be
-    # mislabeled "no active FlowGoal" instead of passing the gate.
-    GOAL_STATUS=$("$ACTIVE_GOAL_HELPER" --status --allow-terminal 2>/dev/null); GOAL_EXIT=$?
+    # --allow-terminal: surface a goal that already reached `achieved` so the
+    # success branch below is reachable (without it the helper is active-only,
+    # exits 1, and an achieved goal is mislabeled "no active FlowGoal").
+    # --branch-strict: resolve ONLY a goal owning the current branch — never a
+    # stale active goal on another branch, which would falsely block this merge.
+    GOAL_STATUS=$("$ACTIVE_GOAL_HELPER" --status --allow-terminal --branch-strict 2>/dev/null); GOAL_EXIT=$?
     case "$GOAL_EXIT" in
       0)
-        GOAL_ID=$("$ACTIVE_GOAL_HELPER" --id --allow-terminal 2>/dev/null)
+        GOAL_ID=$("$ACTIVE_GOAL_HELPER" --id --allow-terminal --branch-strict 2>/dev/null)
         echo "FLOW_GOAL_ID=$GOAL_ID"
         echo "FLOW_GOAL_LIFECYCLE=$GOAL_STATUS"
         if [ "$GOAL_STATUS" = "achieved" ]; then

--- a/plugins/flow/commands/merge.md
+++ b/plugins/flow/commands/merge.md
@@ -321,16 +321,20 @@ fi  # /if [ -z "$PR_NUM" ]
 true
 ```
 
-### FlowGoal Gate (v3, opt-in)
+### FlowGoal Gate (v3)
 
-Independent of the finding-ledger gate, the FlowGoal gate verifies the active goal has reached `lifecycle.status == achieved`. Gated behind `flow.goals.requireGoalForStart` — when false (v2 mode), this block emits `FLOW_GOAL_GATE_STATE=disabled` and the gate is skipped silently.
+Independent of the finding-ledger gate, the FlowGoal gate **gates on goal existence** (#111 D-GATE): when an active goal exists for this branch it must have reached `lifecycle.status == achieved` to merge; when **no** active goal exists the gate is **not applicable** and merge proceeds (a PR without a FlowGoal is not blocked). The gate is disabled entirely when `flow.goals.enabled` is `false` or `flow.goals.goalCreation` is `off` — preserving the v2 `requireGoalForStart: false` UX (no merge gating).
 
 ```!
 HELPER="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh"
-REQUIRE_GOAL=$("$HELPER" --default "false" '.flow.goals.requireGoalForStart' 2>/dev/null)
+# Migration-aware (#111 AC-1): goalCreation wins; else map legacy
+# requireGoalForStart (true→always, false→off); else null → cascade default auto.
+GOAL_MODE=$("$HELPER" --default "auto" '.flow.goals.goalCreation // (if .flow.goals.requireGoalForStart == true then "always" elif .flow.goals.requireGoalForStart == false then "off" else null end)' 2>/dev/null)
+case "$GOAL_MODE" in auto|always|off) ;; *) GOAL_MODE="auto" ;; esac
+ENABLED=$("$HELPER" --default "true" '.flow.goals.enabled' 2>/dev/null)
 
 echo "### FlowGoal Gate"
-if [ "$REQUIRE_GOAL" != "true" ]; then
+if [ "$ENABLED" != "true" ] || [ "$GOAL_MODE" = "off" ]; then
   echo "FLOW_GOAL_GATE_STATE=disabled"
 else
   ACTIVE_GOAL_HELPER="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/flow-active-goal.sh"
@@ -356,15 +360,18 @@ else
         fi
         ;;
       1)
-        # v3 enabled but no active goal — caller policy. Fail closed by
-        # default; the user can override via the Tier 3 confirm prompt in
-        # Phase 3 with explicit rationale.
-        echo "FLOW_GOAL_GATE_STATE=blocked"
-        echo "FLOW_GOAL_BLOCK_REASON=requireGoalForStart=true but no active FlowGoal — run /flow:goal create issue or set requireGoalForStart=false"
+        # No active goal on this branch — gate not applicable (#111 D-GATE:
+        # gate on existence). A PR without a FlowGoal is not blocked; the PR's
+        # own review state remains the durable record. This intentionally
+        # replaces the prior fail-closed so default installs (goalCreation:auto)
+        # do not start blocking goal-less merges.
+        echo "FLOW_GOAL_GATE_STATE=ok"
+        echo "FLOW_GOAL_GATE_NOTE=no active FlowGoal for this branch — gate not applicable"
         ;;
       3)
+        # >1 active goal on the current branch (after #111 AC-4 branch-scoping).
         echo "FLOW_GOAL_GATE_STATE=blocked"
-        echo "FLOW_GOAL_BLOCK_REASON=degenerate state — multiple active FlowGoals"
+        echo "FLOW_GOAL_BLOCK_REASON=degenerate state — multiple active FlowGoals on the current branch"
         ;;
       *)
         echo "FLOW_GOAL_GATE_STATE=blocked"

--- a/plugins/flow/commands/merge.md
+++ b/plugins/flow/commands/merge.md
@@ -342,10 +342,14 @@ else
     echo "FLOW_GOAL_GATE_STATE=blocked"
     echo "FLOW_GOAL_BLOCK_REASON=flow-active-goal.sh missing or non-executable"
   else
-    GOAL_STATUS=$("$ACTIVE_GOAL_HELPER" --status 2>/dev/null); GOAL_EXIT=$?
+    # --allow-terminal (#122): surface a goal that already reached `achieved` so
+    # the success branch below is reachable. Without it the helper filters
+    # achieved goals out (active-only), exit 1, and an achieved goal would be
+    # mislabeled "no active FlowGoal" instead of passing the gate.
+    GOAL_STATUS=$("$ACTIVE_GOAL_HELPER" --status --allow-terminal 2>/dev/null); GOAL_EXIT=$?
     case "$GOAL_EXIT" in
       0)
-        GOAL_ID=$("$ACTIVE_GOAL_HELPER" --id 2>/dev/null)
+        GOAL_ID=$("$ACTIVE_GOAL_HELPER" --id --allow-terminal 2>/dev/null)
         echo "FLOW_GOAL_ID=$GOAL_ID"
         echo "FLOW_GOAL_LIFECYCLE=$GOAL_STATUS"
         if [ "$GOAL_STATUS" = "achieved" ]; then

--- a/plugins/flow/commands/merge.md
+++ b/plugins/flow/commands/merge.md
@@ -323,15 +323,18 @@ true
 
 ### FlowGoal Gate (v3)
 
-Independent of the finding-ledger gate, the FlowGoal gate **gates on goal existence** (#111 D-GATE): when an active goal exists for this branch it must have reached `lifecycle.status == achieved` to merge; when **no** active goal exists the gate is **not applicable** and merge proceeds (a PR without a FlowGoal is not blocked). The gate is disabled entirely when `flow.goals.enabled` is `false` or `flow.goals.goalCreation` is `off` — preserving the v2 `requireGoalForStart: false` UX (no merge gating).
+Independent of the finding-ledger gate, the FlowGoal gate **gates on goal existence**: when an active goal exists for this branch it must have reached `lifecycle.status == achieved` to merge; when **no** active goal exists the gate is **not applicable** and merge proceeds (a PR without a FlowGoal is not blocked). The gate is disabled entirely when `flow.goals.enabled` is `false` or `flow.goals.goalCreation` is `off` — preserving the v2 `requireGoalForStart: false` UX (no merge gating).
 
 ```!
 HELPER="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh"
-# Migration-aware (#111 AC-1): goalCreation wins; else map legacy
-# requireGoalForStart (true→always, false→off); else null → cascade default auto.
+# Migration-aware: goalCreation wins; else map legacy requireGoalForStart
+# (true->always, false->off); else null so the cascade default (auto) applies.
 GOAL_MODE=$("$HELPER" --default "auto" '.flow.goals.goalCreation // (if .flow.goals.requireGoalForStart == true then "always" elif .flow.goals.requireGoalForStart == false then "off" else null end)' 2>/dev/null)
 case "$GOAL_MODE" in auto|always|off) ;; *) GOAL_MODE="auto" ;; esac
 ENABLED=$("$HELPER" --default "true" '.flow.goals.enabled' 2>/dev/null)
+# Empty means cascade-resolve itself failed (missing/non-exec) — honor the
+# enabled-by-default intent rather than fail-open to a silently disabled gate.
+[ -z "$ENABLED" ] && ENABLED="true"
 
 echo "### FlowGoal Gate"
 if [ "$ENABLED" != "true" ] || [ "$GOAL_MODE" = "off" ]; then
@@ -342,7 +345,7 @@ else
     echo "FLOW_GOAL_GATE_STATE=blocked"
     echo "FLOW_GOAL_BLOCK_REASON=flow-active-goal.sh missing or non-executable"
   else
-    # --allow-terminal (#122): surface a goal that already reached `achieved` so
+    # --allow-terminal: surface a goal that already reached `achieved` so
     # the success branch below is reachable. Without it the helper filters
     # achieved goals out (active-only), exit 1, and an achieved goal would be
     # mislabeled "no active FlowGoal" instead of passing the gate.
@@ -364,8 +367,8 @@ else
         fi
         ;;
       1)
-        # No active goal on this branch — gate not applicable (#111 D-GATE:
-        # gate on existence). A PR without a FlowGoal is not blocked; the PR's
+        # No active goal on this branch — gate not applicable: the gate keys
+        # on goal existence. A PR without a FlowGoal is not blocked; the PR's
         # own review state remains the durable record. This intentionally
         # replaces the prior fail-closed so default installs (goalCreation:auto)
         # do not start blocking goal-less merges.
@@ -373,7 +376,7 @@ else
         echo "FLOW_GOAL_GATE_NOTE=no active FlowGoal for this branch — gate not applicable"
         ;;
       3)
-        # >1 active goal on the current branch (after #111 AC-4 branch-scoping).
+        # >1 active goal on the current branch (after branch-scoping).
         echo "FLOW_GOAL_GATE_STATE=blocked"
         echo "FLOW_GOAL_BLOCK_REASON=degenerate state — multiple active FlowGoals on the current branch"
         ;;

--- a/plugins/flow/commands/pr.md
+++ b/plugins/flow/commands/pr.md
@@ -139,12 +139,14 @@ else
       echo "STATE=unavailable"
       echo "REASON=flow-active-goal.sh missing or non-executable"
     else
-      # --allow-terminal: surface an already-`achieved` goal so the
-      # GATE=pass branch below is reachable (the helper is active-only otherwise).
-      GOAL_STATUS=$("$ACTIVE_GOAL_HELPER" --status --allow-terminal 2>/dev/null); GOAL_EXIT=$?
+      # --allow-terminal: surface an already-`achieved` goal so the GATE=pass
+      # branch below is reachable (the helper is active-only otherwise).
+      # --branch-strict: resolve ONLY a goal owning the current branch, never a
+      # stale active goal on another branch.
+      GOAL_STATUS=$("$ACTIVE_GOAL_HELPER" --status --allow-terminal --branch-strict 2>/dev/null); GOAL_EXIT=$?
       case "$GOAL_EXIT" in
         0)
-          GOAL_ID=$("$ACTIVE_GOAL_HELPER" --id --allow-terminal 2>/dev/null)
+          GOAL_ID=$("$ACTIVE_GOAL_HELPER" --id --allow-terminal --branch-strict 2>/dev/null)
           echo "STATE=ok"
           echo "GOAL_ID=$GOAL_ID"
           echo "GOAL_LIFECYCLE=$GOAL_STATUS"

--- a/plugins/flow/commands/pr.md
+++ b/plugins/flow/commands/pr.md
@@ -114,7 +114,7 @@ else
     echo "STATE=empty"
   fi
 
-  # Section: FlowGoal State (v3) — gate on goal existence (#111 D-GATE).
+  # Section: FlowGoal State (v3) — gate on goal existence.
   # Surface the active goal's lifecycle so Phase 4 can gate PR creation on goal
   # achievement WHEN a goal exists; a branch with no goal is not blocked. The
   # gate is disabled when flow.goals.enabled is false or goalCreation is off,
@@ -122,11 +122,14 @@ else
   echo ""
   echo "### FlowGoal State"
   HELPER="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh"
-  # Migration-aware (#111 AC-1): goalCreation wins; else map legacy
-  # requireGoalForStart (true→always, false→off); else null → cascade default auto.
+  # Migration-aware: goalCreation wins; else map legacy requireGoalForStart
+  # (true->always, false->off); else null so the cascade default (auto) applies.
   GOAL_MODE=$("$HELPER" --default "auto" '.flow.goals.goalCreation // (if .flow.goals.requireGoalForStart == true then "always" elif .flow.goals.requireGoalForStart == false then "off" else null end)' 2>/dev/null)
   case "$GOAL_MODE" in auto|always|off) ;; *) GOAL_MODE="auto" ;; esac
   ENABLED=$("$HELPER" --default "true" '.flow.goals.enabled' 2>/dev/null)
+  # Empty means cascade-resolve itself failed — honor enabled-by-default intent
+  # rather than fail-open to a silently disabled gate.
+  [ -z "$ENABLED" ] && ENABLED="true"
   if [ "$ENABLED" != "true" ] || [ "$GOAL_MODE" = "off" ]; then
     echo "STATE=disabled"
     echo "REASON=flow.goals.enabled is false or goalCreation is off"
@@ -136,7 +139,7 @@ else
       echo "STATE=unavailable"
       echo "REASON=flow-active-goal.sh missing or non-executable"
     else
-      # --allow-terminal (#122): surface an already-`achieved` goal so the
+      # --allow-terminal: surface an already-`achieved` goal so the
       # GATE=pass branch below is reachable (the helper is active-only otherwise).
       GOAL_STATUS=$("$ACTIVE_GOAL_HELPER" --status --allow-terminal 2>/dev/null); GOAL_EXIT=$?
       case "$GOAL_EXIT" in
@@ -152,8 +155,8 @@ else
           fi
           ;;
         1)
-          # No active goal on this branch — gate not applicable (#111 D-GATE:
-          # gate on existence). PR creation proceeds; a goal-less PR is not blocked.
+          # No active goal on this branch — gate not applicable: the gate keys
+          # on goal existence. PR creation proceeds; a goal-less PR is not blocked.
           echo "STATE=none"
           echo "GATE=pass"
           echo "REASON=no active FlowGoal for this branch — gate not applicable"
@@ -318,7 +321,7 @@ After agents return, TaskUpdate each review task with findings.
 
    When `STATE=disabled` (`flow.goals.enabled` false or `goalCreation: off`): skip this step silently.
 
-   When `STATE=none` (no active FlowGoal for this branch): the gate is **not applicable** (#111 D-GATE gates on existence). Proceed with PR creation silently — a goal-less PR is not blocked and needs no prompt. The PR body omits the `## FlowGoal Status` section.
+   When `STATE=none` (no active FlowGoal for this branch): the gate is **not applicable** (it keys on goal existence). Proceed with PR creation silently — a goal-less PR is not blocked and needs no prompt. The PR body omits the `## FlowGoal Status` section.
 
 8. **Generate PR body** from template + findings + journal + comprehension report.
 

--- a/plugins/flow/commands/pr.md
+++ b/plugins/flow/commands/pr.md
@@ -136,10 +136,12 @@ else
       echo "STATE=unavailable"
       echo "REASON=flow-active-goal.sh missing or non-executable"
     else
-      GOAL_STATUS=$("$ACTIVE_GOAL_HELPER" --status 2>/dev/null); GOAL_EXIT=$?
+      # --allow-terminal (#122): surface an already-`achieved` goal so the
+      # GATE=pass branch below is reachable (the helper is active-only otherwise).
+      GOAL_STATUS=$("$ACTIVE_GOAL_HELPER" --status --allow-terminal 2>/dev/null); GOAL_EXIT=$?
       case "$GOAL_EXIT" in
         0)
-          GOAL_ID=$("$ACTIVE_GOAL_HELPER" --id 2>/dev/null)
+          GOAL_ID=$("$ACTIVE_GOAL_HELPER" --id --allow-terminal 2>/dev/null)
           echo "STATE=ok"
           echo "GOAL_ID=$GOAL_ID"
           echo "GOAL_LIFECYCLE=$GOAL_STATUS"

--- a/plugins/flow/commands/pr.md
+++ b/plugins/flow/commands/pr.md
@@ -114,17 +114,22 @@ else
     echo "STATE=empty"
   fi
 
-  # Section: FlowGoal State (v3, opt-in via flow.goals.requireGoalForStart)
-  # When v3 is enabled, surface the active goal's lifecycle so Phase 4 can
-  # gate PR creation on goal achievement. v2 projects (flag unset/false)
-  # see STATE=disabled and the gate is skipped silently.
+  # Section: FlowGoal State (v3) — gate on goal existence (#111 D-GATE).
+  # Surface the active goal's lifecycle so Phase 4 can gate PR creation on goal
+  # achievement WHEN a goal exists; a branch with no goal is not blocked. The
+  # gate is disabled when flow.goals.enabled is false or goalCreation is off,
+  # preserving the v2 (requireGoalForStart:false) UX.
   echo ""
   echo "### FlowGoal State"
   HELPER="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh"
-  REQUIRE_GOAL=$("$HELPER" --default "false" '.flow.goals.requireGoalForStart' 2>/dev/null)
-  if [ "$REQUIRE_GOAL" != "true" ]; then
+  # Migration-aware (#111 AC-1): goalCreation wins; else map legacy
+  # requireGoalForStart (true→always, false→off); else null → cascade default auto.
+  GOAL_MODE=$("$HELPER" --default "auto" '.flow.goals.goalCreation // (if .flow.goals.requireGoalForStart == true then "always" elif .flow.goals.requireGoalForStart == false then "off" else null end)' 2>/dev/null)
+  case "$GOAL_MODE" in auto|always|off) ;; *) GOAL_MODE="auto" ;; esac
+  ENABLED=$("$HELPER" --default "true" '.flow.goals.enabled' 2>/dev/null)
+  if [ "$ENABLED" != "true" ] || [ "$GOAL_MODE" = "off" ]; then
     echo "STATE=disabled"
-    echo "REASON=flow.goals.requireGoalForStart is not true"
+    echo "REASON=flow.goals.enabled is false or goalCreation is off"
   else
     ACTIVE_GOAL_HELPER="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/flow-active-goal.sh"
     if [ ! -x "$ACTIVE_GOAL_HELPER" ]; then
@@ -145,14 +150,16 @@ else
           fi
           ;;
         1)
-          echo "STATE=missing"
-          echo "GATE=block"
-          echo "REASON=v3 enabled but no active FlowGoal for this branch — run /flow:goal create issue first"
+          # No active goal on this branch — gate not applicable (#111 D-GATE:
+          # gate on existence). PR creation proceeds; a goal-less PR is not blocked.
+          echo "STATE=none"
+          echo "GATE=pass"
+          echo "REASON=no active FlowGoal for this branch — gate not applicable"
           ;;
         3)
           echo "STATE=degenerate"
           echo "GATE=block"
-          echo "REASON=multiple active goals detected (should be impossible) — run /flow:goal history and clear extras"
+          echo "REASON=multiple active goals on the current branch — run /flow:goal history and clear extras"
           ;;
         *)
           echo "STATE=unavailable"
@@ -307,9 +314,9 @@ After agents return, TaskUpdate each review task with findings.
      ```
    - **Option 3: Cancel** — exit `/flow:pr` and finish the implementation work first.
 
-   When `STATE=disabled` (v2 mode, `requireGoalForStart` not set): skip this step silently.
+   When `STATE=disabled` (`flow.goals.enabled` false or `goalCreation: off`): skip this step silently.
 
-   When `STATE=missing` (v3 enabled but no goal): present a different AskUserQuestion — "v3 is enabled but no FlowGoal exists for this branch. Create one now via `/flow:goal create issue` and re-run `/flow:pr`, or proceed without a goal (the merge gate will then have nothing to verify)?"
+   When `STATE=none` (no active FlowGoal for this branch): the gate is **not applicable** (#111 D-GATE gates on existence). Proceed with PR creation silently — a goal-less PR is not blocked and needs no prompt. The PR body omits the `## FlowGoal Status` section.
 
 8. **Generate PR body** from template + findings + journal + comprehension report.
 

--- a/plugins/flow/commands/resume.md
+++ b/plugins/flow/commands/resume.md
@@ -101,9 +101,10 @@ Flow records its own artifacts under `.flow/` and the decision journal under `.d
 # unlinked. Conservative by design (#111 AC-6 chose the simple definition over
 # diffing against the run's recorded paths): better to ask once too often than
 # to absorb a human's unrelated edits into a resumed workflow.
-UNLINKED=$(git status --porcelain 2>/dev/null | awk '
+UNLINKED=$(git -c core.quotePath=false status --porcelain 2>/dev/null | awk '
   { path = substr($0, 4) }
   { n = index(path, " -> "); if (n) path = substr(path, n + 4) }   # rename: take destination
+  { sub(/^"/, "", path); sub(/"$/, "", path) }                     # unquote special-char paths
   path !~ /^\.flow\// && path !~ /^\.decisions\// { print path }
 ')
 if [ -n "$UNLINKED" ]; then

--- a/plugins/flow/commands/resume.md
+++ b/plugins/flow/commands/resume.md
@@ -92,6 +92,41 @@ Read the last 5 lines of `events.jsonl` for additional context.
 
 Read the linked goal (if any): `.flow/goals/<metadata.goal>.goal.yaml`. Show AC pass/fail state.
 
+### Step 3.5: Detect unlinked working-tree changes (#111 AC-6)
+
+Flow records its own artifacts under `.flow/` and the decision journal under `.decisions/`. **Any other tracked change in the working tree is "unlinked"** — most likely unrelated human work that `/flow:resume` must not silently fold into a continuation.
+
+```!
+# Treat any porcelain entry whose path is NOT under .flow/ or .decisions/ as
+# unlinked. Conservative by design (#111 AC-6 chose the simple definition over
+# diffing against the run's recorded paths): better to ask once too often than
+# to absorb a human's unrelated edits into a resumed workflow.
+UNLINKED=$(git status --porcelain 2>/dev/null | awk '
+  { path = substr($0, 4) }
+  { n = index(path, " -> "); if (n) path = substr(path, n + 4) }   # rename: take destination
+  path !~ /^\.flow\// && path !~ /^\.decisions\// { print path }
+')
+if [ -n "$UNLINKED" ]; then
+  echo "FLOW_RESUME_UNLINKED=1"
+  printf '%s\n' "$UNLINKED" | sed 's/^/  /'
+else
+  echo "FLOW_RESUME_UNLINKED=0"
+fi
+true
+```
+
+When `FLOW_RESUME_UNLINKED=1`, you MUST surface the listed paths and **ask before suggesting continuation** — do not jump to the Step 5 next-action suggestion. Use `AskUserQuestion`:
+
+> Uncommitted changes exist that aren't linked to FlowRun `<RUN_ID>` (they're outside `.flow/` and `.decisions/`):
+> `<the listed paths>`
+>
+> Options:
+> 1. These belong to this run — continue (proceed to the resume suggestion)
+> 2. These are unrelated work — I'll handle them separately (stop here; do not suggest continuation)
+> 3. Cancel
+
+Remain informational-only: even on Option 1, `/flow:resume` never auto-executes the next phase — it only unlocks the Step 5 suggestion. When `FLOW_RESUME_UNLINKED=0`, proceed normally.
+
 ### Step 4: Format the resume report
 
 ```
@@ -144,6 +179,7 @@ If the user explicitly wants to act on the resume rather than just inspect, offe
 ## Anti-patterns
 
 - ❌ Auto-executing the next phase. /flow:resume is informational; the user decides whether to continue.
+- ❌ Suggesting continuation when unlinked working-tree changes exist (changes outside `.flow/` and `.decisions/`) without asking first (#111 AC-6). Flow must not absorb unrelated human work into a resumed run.
 - ❌ Resuming a `blocked` run without surfacing the blocker. If the blocker is "needs CI to pass," running the next phase before CI passes will fail again.
 - ❌ Resuming a run whose linked goal is `cancelled` or `failed`. Surface the goal's terminal state and recommend creating a new goal.
 - ❌ Reading `events.jsonl` lines without tolerating partial reads. Per the helper's design, the last line may be incomplete if a writer was killed mid-line.
@@ -160,6 +196,7 @@ If the user explicitly wants to act on the resume rather than just inspect, offe
 | Action | Tier | Behavior |
 |---|---|---|
 | Read `.flow/runs/*/run.yaml` to identify active/blocked runs | 1 | Autonomous, read-only |
+| Read `git status --porcelain` to detect unlinked working-tree changes | 1 | Autonomous, read-only |
 | Read linked `.flow/goals/<id>.goal.yaml` for goal context | 1 | Autonomous, read-only |
 | Read last N lines of `events.jsonl` for recent activity | 1 | Autonomous, read-only |
 | Format and print resume report | 1 | Autonomous, output-only |

--- a/plugins/flow/commands/resume.md
+++ b/plugins/flow/commands/resume.md
@@ -92,22 +92,35 @@ Read the last 5 lines of `events.jsonl` for additional context.
 
 Read the linked goal (if any): `.flow/goals/<metadata.goal>.goal.yaml`. Show AC pass/fail state.
 
-### Step 3.5: Detect unlinked working-tree changes (#111 AC-6)
+### Step 3.5: Detect unlinked working-tree changes
 
 Flow records its own artifacts under `.flow/` and the decision journal under `.decisions/`. **Any other tracked change in the working tree is "unlinked"** — most likely unrelated human work that `/flow:resume` must not silently fold into a continuation.
 
 ```!
 # Treat any porcelain entry whose path is NOT under .flow/ or .decisions/ as
-# unlinked. Conservative by design (#111 AC-6 chose the simple definition over
-# diffing against the run's recorded paths): better to ask once too often than
-# to absorb a human's unrelated edits into a resumed workflow.
-UNLINKED=$(git -c core.quotePath=false status --porcelain 2>/dev/null | awk '
-  { path = substr($0, 4) }
-  { n = index(path, " -> "); if (n) path = substr(path, n + 4) }   # rename: take destination
-  { sub(/^"/, "", path); sub(/"$/, "", path) }                     # unquote special-char paths
+# unlinked. Conservative by design (simple prefix test rather than diffing
+# against the run's recorded paths): better to ask once too often than to
+# absorb a human's unrelated edits into a resumed workflow.
+#
+# Capture git's exit code separately: a git failure (not a repo, git missing)
+# must NOT be read as "clean tree" — that would silently skip the guard. The
+# rename-arrow strip is gated to R/C status lines so a file literally named
+# `x -> .flow/y` can't masquerade as a flow-owned path and slip the filter.
+# Capture git output and exit code BEFORE piping, so a git failure isn't masked
+# by awk's exit status (the pipeline runs in a subshell where PIPESTATUS would
+# not survive the command-substitution assignment).
+PORCELAIN=$(git -c core.quotePath=false status --porcelain 2>/dev/null); GIT_EXIT=$?
+UNLINKED=$(printf '%s\n' "$PORCELAIN" | awk '
+  NF == 0 { next }
+  { st = substr($0, 1, 2); path = substr($0, 4) }
+  st ~ /^[RC]/ { n = index(path, " -> "); if (n) path = substr(path, n + 4) }  # rename/copy dest
+  { sub(/^"/, "", path); sub(/"$/, "", path) }                                 # unquote special-char paths
   path !~ /^\.flow\// && path !~ /^\.decisions\// { print path }
 ')
-if [ -n "$UNLINKED" ]; then
+if [ "$GIT_EXIT" -ne 0 ]; then
+  echo "FLOW_RESUME_UNLINKED=unknown"
+  echo "FLOW_RESUME_UNLINKED_REASON=git status failed (exit $GIT_EXIT) — cannot assess unlinked changes"
+elif [ -n "$UNLINKED" ]; then
   echo "FLOW_RESUME_UNLINKED=1"
   printf '%s\n' "$UNLINKED" | sed 's/^/  /'
 else
@@ -116,7 +129,7 @@ fi
 true
 ```
 
-When `FLOW_RESUME_UNLINKED=1`, you MUST surface the listed paths and **ask before suggesting continuation** — do not jump to the Step 5 next-action suggestion. Use `AskUserQuestion`:
+When `FLOW_RESUME_UNLINKED=unknown`, treat it like `1` for safety: surface that the working tree could not be assessed and ask before suggesting continuation. When `FLOW_RESUME_UNLINKED=1`, you MUST surface the listed paths and **ask before suggesting continuation** — do not jump to the Step 5 next-action suggestion. Use `AskUserQuestion`:
 
 > Uncommitted changes exist that aren't linked to FlowRun `<RUN_ID>` (they're outside `.flow/` and `.decisions/`):
 > `<the listed paths>`
@@ -180,7 +193,7 @@ If the user explicitly wants to act on the resume rather than just inspect, offe
 ## Anti-patterns
 
 - ❌ Auto-executing the next phase. /flow:resume is informational; the user decides whether to continue.
-- ❌ Suggesting continuation when unlinked working-tree changes exist (changes outside `.flow/` and `.decisions/`) without asking first (#111 AC-6). Flow must not absorb unrelated human work into a resumed run.
+- ❌ Suggesting continuation when unlinked working-tree changes exist (changes outside `.flow/` and `.decisions/`) without asking first. Flow must not absorb unrelated human work into a resumed run.
 - ❌ Resuming a `blocked` run without surfacing the blocker. If the blocker is "needs CI to pass," running the next phase before CI passes will fail again.
 - ❌ Resuming a run whose linked goal is `cancelled` or `failed`. Surface the goal's terminal state and recommend creating a new goal.
 - ❌ Reading `events.jsonl` lines without tolerating partial reads. Per the helper's design, the last line may be incomplete if a writer was killed mid-line.

--- a/plugins/flow/commands/setup.md
+++ b/plugins/flow/commands/setup.md
@@ -75,6 +75,42 @@ Write `.claude/settings.flow.json` with:
 
 **On re-run** (existing settings detected): Read current settings and merge — preserve user customizations, only add new keys that don't exist yet.
 
+The v3 runtime settings (`flow.goals`, `flow.runtime`, `flow.workflows`, `flow.triggers`) are intentionally **not** written into the team file — they are governed by the plugin defaults via the cascade, so the committed file stays lean. The one thing setup actively does for them is upgrade **deprecated** keys (next step).
+
+### Upgrade deprecated settings (re-run only)
+
+When existing settings are detected, check whether the committed `.claude/settings.flow.json` carries any deprecated keys and offer to upgrade it to the current schema. The runtime already honors deprecated keys read-only (via `cascade-resolve`), so this is a **hygiene upgrade — nothing breaks if declined**. Current migrations: `flow.goals.requireGoalForStart` → `flow.goals.goalCreation` (`true`→`always`, `false`→`off`).
+
+```!
+SETTINGS=".claude/settings.flow.json"
+MIGRATOR="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/flow-migrate-settings.sh"
+if [ -f "$SETTINGS" ] && [ -x "$MIGRATOR" ]; then
+  "$MIGRATOR" "$SETTINGS"   # dry-run — emits MIGRATE=... lines (MIGRATE=none when clean)
+else
+  echo "MIGRATE=skip (no committed settings or migrator unavailable)"
+fi
+true
+```
+
+If the output is `MIGRATE=none` or `MIGRATE=skip`, there is nothing to upgrade — proceed silently. Otherwise it reports the pending change(s) (`MIGRATE_FROM=...` / `MIGRATE_TO=...`). Surface them and use `AskUserQuestion`:
+
+> Your committed `.claude/settings.flow.json` uses deprecated settings keys that can be upgraded to the current schema:
+> {the `MIGRATE_FROM` → `MIGRATE_TO` lines}
+>
+> The runtime already honors the old keys read-only, so this is optional cleanup.
+>
+> Options:
+> 1. **Upgrade now (Recommended)** — rewrite the committed file in place (atomic; every other key preserved)
+> 2. **Leave as-is** — the read-only migration keeps it working; the deprecated key stays in version control
+
+On **Upgrade now**, apply the rewrite:
+
+```bash
+"$MIGRATOR" --apply ".claude/settings.flow.json"
+```
+
+It writes atomically and preserves all other keys. Note the change in the Phase 6 summary so the user reviews the one-line diff before committing.
+
 ## Phase 3: LSP Server Setup
 
 Configure Language Server Protocol servers for the detected tech stack. LSP provides code intelligence (go-to-definition, find-references, hover, diagnostics) that flow uses in EXPLORE, CODE, VERIFY, and REVIEW phases.
@@ -320,6 +356,7 @@ Any key set at a higher layer overrides lower layers. See [`references/gate-conf
 | Detect environment, tech stack, build commands | 1 | Autonomous, read-only |
 | Probe LSP capabilities | 1 | Autonomous, read-only |
 | Write `.claude/settings.flow.json` (project-shared settings) | 1 | Autonomous, project file |
+| Upgrade deprecated keys in an existing `.claude/settings.flow.json` (`flow-migrate-settings.sh --apply`) | 2 | AskUserQuestion before rewriting the committed file; atomic, preserves other keys |
 | Write `.claude/CLAUDE.md` flow integration block | 1 | Autonomous, project file |
 | Install LSP servers (when user opts in) | 2 | Journal-and-proceed (touches user environment outside repo) |
 | `mkdir -p .decisions/` | 1 | Autonomous |

--- a/plugins/flow/commands/setup.md
+++ b/plugins/flow/commands/setup.md
@@ -43,12 +43,16 @@ mkdir -p .claude
 
 **Ensure `.claude/settings.flow.local.json` is gitignored** (idempotent — adds the line only if missing). Without this, a downstream user creating a personal-pin file as documented in Phase 6 below would commit it accidentally, leaking their machine-local preferences and weakening the project-local override layer:
 
+Also ignore `.claude/*.lock` — `flow-migrate-settings.sh` (and other writers) create a transient `<file>.lock` beside the settings file; the trap removes it, but a hard kill (SIGKILL) could leave one behind, and it must never be committed.
+
 ```bash
-if [ -f .gitignore ] && ! grep -qxF '.claude/settings.flow.local.json' .gitignore; then
-  echo '.claude/settings.flow.local.json' >> .gitignore
-elif [ ! -f .gitignore ]; then
-  echo '.claude/settings.flow.local.json' > .gitignore
-fi
+for IGNORE in '.claude/settings.flow.local.json' '.claude/*.lock'; do
+  if [ -f .gitignore ]; then
+    grep -qxF "$IGNORE" .gitignore || echo "$IGNORE" >> .gitignore
+  else
+    echo "$IGNORE" > .gitignore
+  fi
+done
 ```
 
 Flow settings follow the standard Claude Code cascade — `local > project > user > plugin default`. Setup writes the project-shared file, which gives the whole team a baseline. Any user can then override locally via `.claude/settings.flow.local.json` (gitignored), set cross-project preferences in `$HOME/.claude/settings.flow.json`, or rely on the plugin's bundled defaults.
@@ -103,10 +107,10 @@ If the output is `MIGRATE=none` or `MIGRATE=skip`, there is nothing to upgrade �
 > 1. **Upgrade now (Recommended)** — rewrite the committed file in place (atomic; every other key preserved)
 > 2. **Leave as-is** — the read-only migration keeps it working; the deprecated key stays in version control
 
-On **Upgrade now**, apply the rewrite:
+On **Upgrade now**, apply the rewrite. This block re-resolves the helper path inline — shell variables from the detection `!`-block above do NOT persist into a separately-executed `bash` block:
 
 ```bash
-"$MIGRATOR" --apply ".claude/settings.flow.json"
+"$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/flow-migrate-settings.sh" --apply ".claude/settings.flow.json"
 ```
 
 It writes atomically and preserves all other keys. Note the change in the Phase 6 summary so the user reviews the one-line diff before committing.

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -460,7 +460,7 @@ Once the goal (if any) and the FlowRun exist, emit **one** compact runtime summa
 Compute the AC counts with the shared helper (it prints `<total>/<verifiable>`). It exits non-zero with no output when no goal owns the current branch — that is the **skip path** (goal creation was skipped), and the summary then omits the Goal line entirely:
 
 ```bash
-"$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/flow-active-goal.sh" --verifiable-count --allow-terminal 2>/dev/null || true
+"$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/flow-active-goal.sh" --verifiable-count 2>/dev/null || true
 ```
 
 **Truthfulness gate (load-bearing):** if the goal is degenerate — `<total>` is `0`, or `<verifiable>` is `0` — or the goal is unevaluated, the Goal line MUST be flagged, never shown as a clean `active`:

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -284,7 +284,7 @@ gh issue edit "$ISSUE_NUM" --add-assignee @me
 
 `goalCreation` is a 3-state setting — `auto` (default), `always`, or `off`:
 - `off` — never auto-create (manual `/flow:goal create` still works).
-- `always` — create a goal unconditionally (even a degenerate goal; flagged per AC-2).
+- `always` — create a goal unconditionally (even a degenerate goal; flagged in the compact summary).
 - `auto` — create **iff** the Spec Validation Gate passed with ≥1 acceptance criterion carrying a `verification_command`. An issue that yields zero verifiable ACs (e.g. a spec-free `documentation`/`chore` issue) is skipped **silently** — no prompt, no error.
 
 The master switch `flow.goals.enabled: false` forces `off` regardless of `goalCreation` (whole feature off — distinct from `goalCreation: off`, which leaves the feature on and only suppresses auto-creation).
@@ -297,7 +297,7 @@ if [ ! -x "$CASCADE" ]; then
   echo "FLOW_GOAL_ERROR=cascade-resolve.sh missing or non-executable at $CASCADE"
   true; exit 0
 fi
-# Read-only migration (#111 AC-1): goalCreation wins; else map the legacy
+# Read-only migration: goalCreation wins; else map the legacy
 # requireGoalForStart (true→always, false→off); else `null` so the cascade
 # default (auto) applies. `else null` — NOT "auto" — is load-bearing: it lets a
 # settings source carrying NEITHER key fall through to the next cascade source
@@ -363,7 +363,7 @@ true
 Dispatch based on `FLOW_GOAL_STATE`:
 
 - **`create`** — branch on `FLOW_GOAL_MODE`:
-  - **`always`** — create the goal unconditionally. A degenerate goal (0 ACs, or 0 ACs carrying a `verification_command`) is allowed here but is flagged in the compact summary per AC-2. Proceed to the skills below.
+  - **`always`** — create the goal unconditionally. A degenerate goal (0 ACs, or 0 ACs carrying a `verification_command`) is allowed here but is flagged in the compact summary. Proceed to the skills below.
   - **`auto`** — create the goal **iff** the Spec Validation Gate passed with ≥1 acceptance criterion carrying a `verification_command` (the "verifiable ACs win" rule — labels do not veto). If zero verifiable ACs (e.g. a spec-free `documentation`/`chore` issue that passed the gate with no commands), **skip silently**: do not invoke the skills, print no goal line, and treat exactly like `skip`. Otherwise proceed to the skills below.
 
   In both create paths the visibility echo is gated on the post-write verify.
@@ -395,7 +395,7 @@ For `FLOW_GOAL_STATE=create`:
      fi
    fi
    ```
-4. Only after verify passes, proceed to create the FlowRun (next section). **Do not** emit a per-artifact `FlowGoal created:` line here — the compact runtime summary that supersedes it is emitted once both the goal and run exist (see **Runtime summary** below, #111 AC-2).
+4. Only after verify passes, proceed to create the FlowRun (next section). **Do not** emit a per-artifact `FlowGoal created:` line here — the compact runtime summary that supersedes it is emitted once both the goal and run exist (see **Runtime summary** below).
 
 ### FlowRun (v3 runtime)
 
@@ -432,6 +432,8 @@ fi
 true
 ```
 
+Dispatch on `FLOW_RUN_STATE`: **`skip`** — proceed without a FlowRun (v2 behavior; the wiring is a no-op). **`blocked`** — `cascade-resolve.sh` was unavailable; surface the `FLOW_RUN_ERROR` line to the user and halt Phase 1 rather than silently proceeding without a run (same posture as `FLOW_GOAL_STATE=blocked`). **`create`** — proceed as below.
+
 When `FLOW_RUN_STATE=create`, invoke `Skill(run-state-management)` to create `.flow/runs/$RUN_ID/run.yaml` (workflow=`start-issue`, goal=`$GOAL_LINK` — the FlowGoal created above, or `null` when goal creation was skipped), initial phase `preflight`. Because `/flow:start` is issue-scoped, also emit the `workflow-run` artifact to `.decisions/issue-$ISSUE_NUM.md`:
 
 ```bash
@@ -445,7 +447,7 @@ if [ -n "$ISSUE_NUM" ]; then
 fi
 ```
 
-### Runtime summary (#111 AC-2)
+### Runtime summary
 
 Once the goal (if any) and the FlowRun exist, emit **one** compact runtime summary **in place of** any per-artifact `FlowGoal created:` line. Do not dump the goal/run YAML — "invisible" means low-ceremony, not hidden-state. The summary has exactly these lines:
 
@@ -455,10 +457,10 @@ Once the goal (if any) and the FlowRun exist, emit **one** compact runtime summa
 - **Branch**: `<current branch>` (`git branch --show-current`)
 - _I'll work until the goal is achieved, blocked, or needs your decision._
 
-Compute the AC counts with the shared helper (it prints `<total>/<verifiable>`):
+Compute the AC counts with the shared helper (it prints `<total>/<verifiable>`). It exits non-zero with no output when no goal owns the current branch — that is the **skip path** (goal creation was skipped), and the summary then omits the Goal line entirely:
 
 ```bash
-"$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/flow-active-goal.sh" --verifiable-count
+"$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/flow-active-goal.sh" --verifiable-count --allow-terminal 2>/dev/null || true
 ```
 
 **Truthfulness gate (load-bearing):** if the goal is degenerate — `<total>` is `0`, or `<verifiable>` is `0` — or the goal is unevaluated, the Goal line MUST be flagged, never shown as a clean `active`:

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -111,252 +111,6 @@ true
 
 If `PREFLIGHT_STATE=BLOCKED`, stop. Do not proceed to EXPLORE. The `PREFLIGHT_FAIL=` lines under the section enumerate the reasons.
 
-## Phase 0.5: FLOW V3 ONBOARDING
-
-Detects whether this is the first `/flow:start` in a project that has neither been configured nor produced any v3 runtime state. Fires the consent prompt once; subsequent invocations see the persisted answer and skip.
-
-```!
-# Onboarding detection. Three branches, evaluated in order:
-#
-# 1. `.flow/` directory exists — user already has v3 runtime state, skip
-#    regardless of settings file state.
-# 2. No settings file AND no `.flow/` — fresh install, prompt.
-# 3. Settings file exists but lacks `flow.goals` block — partial-file
-#    bypass (the user has never answered the v3 onboarding question; an
-#    unrelated v2 setting like `agentTeams` doesn't count as opting in
-#    either way). Prompt.
-#
-# Otherwise (settings file with `flow.goals` block present, regardless of
-# the block's contents) → skip; the user has answered.
-NEEDS_ONBOARDING=0
-
-if [ -d .flow ]; then
-  NEEDS_ONBOARDING=0
-elif [ ! -f .claude/settings.flow.json ]; then
-  NEEDS_ONBOARDING=1
-else
-  if command -v jq >/dev/null 2>&1; then
-    # `jq -e` exits non-zero on null/false/missing, which redirects
-    # HAS_GOALS to empty. Parse errors also produce empty output.
-    HAS_GOALS=$(jq -e '.flow.goals // empty' .claude/settings.flow.json 2>/dev/null)
-    [ -z "$HAS_GOALS" ] && NEEDS_ONBOARDING=1
-  fi
-  # If jq is unavailable we conservatively skip — a v2 user with a
-  # carefully configured settings file should not be re-prompted on every
-  # /flow:start just because we cannot parse the file. Onboarding is
-  # still reachable via /flow:goal create or manual settings edit.
-fi
-
-if [ "$NEEDS_ONBOARDING" = "1" ]; then
-  echo "FLOW_V3_ONBOARDING=needed"
-else
-  echo "FLOW_V3_ONBOARDING=skip"
-fi
-
-true
-```
-
-If `FLOW_V3_ONBOARDING=needed`, use `AskUserQuestion` exactly once with this prompt:
-
-> **Enable Flow v3 runtime layer for this project?**
->
-> Flow v3 adds durable completion contracts (FlowGoal), inspectable workflows, and resumable execution records under `.flow/`. Acceptance criteria with `verification_command` auto-validate via `/flow:goal evaluate`. See `references/flow-goals-quickstart.md` for a walkthrough.
->
-> Options:
-> 1. **Enable v3 (recommended for new projects)** — auto-create goals on `/flow:start`, run verification commands during evaluate
-> 2. **Skip — keep v2 behavior** — `/flow:start` proceeds without goals; v3 surfaces remain reachable via explicit `/flow:goal create`
-> 3. **Tell me more** — open the quickstart, decide on the next invocation
-
-Persist the answer to `.claude/settings.flow.json`. When the file already exists with a partial shape (e.g., the user committed `{"agentTeams": false}` from `/flow:setup` before v3 onboarding), the new keys are MERGED via `jq` so unrelated v2 settings are preserved. When the file is absent, a fresh JSON document is written. When `jq` is unavailable AND the file already exists, the helper refuses to write rather than clobber v2 keys with a heredoc fallback.
-
-The `set_flow_goals` helper below is shared by all three answer arms. After defining it, dispatch based on the user's `AskUserQuestion` response — the dispatch is prose-driven, not a shell `case` (the `AskUserQuestion` answer reaches Claude, not the shell, so Claude runs the appropriate arm directly).
-
-**Helper definition** (run once):
-
-```bash
-SETTINGS=.claude/settings.flow.json
-
-# Symlink defense: refuse to write through symlinks at .claude/ or settings file.
-# Matches the O_NOFOLLOW pattern documented in bin/journal-record.sh and the
-# CHANGELOG's "symlink defenses everywhere" rule. A hostile fork PR could plant
-# .claude as a symlink to ~/.ssh or settings.flow.json as a symlink to ~/.bashrc;
-# refuse rather than corrupt the target.
-if [ -e .claude ] && [ -L .claude ]; then
-  echo "FLOW_ONBOARDING_ERROR=.claude is a symlink — refusing to write through it" >&2
-  exit 1
-fi
-if [ -e "$SETTINGS" ] && [ -L "$SETTINGS" ]; then
-  echo "FLOW_ONBOARDING_ERROR=$SETTINGS is a symlink — refusing to write through it" >&2
-  exit 1
-fi
-mkdir -p .claude
-
-set_flow_goals() {
-  # Args: $1=requireGoalForStart (true|false) $2=executeVerificationCommands (true|false)
-  #       $3=workflowsEnabled (true|false|skip — "skip" omits the workflows key)
-  # Cycle-14 F2 (code-reviewer verifier): merges all three keys atomically
-  # via a single jq invocation so there's no partial-write state where
-  # flow.goals lands but flow.workflows.enabled is missing. The previous
-  # split into two helpers (set_flow_goals + set_flow_workflows_enabled)
-  # introduced the partial-success bug — eliminating the second helper
-  # eliminates the bug.
-  local req="$1" exe="$2" wfl="${3:-skip}"
-
-  # Re-check symlink between definition and call — defense against TOCTOU race.
-  if [ -e "$SETTINGS" ] && [ -L "$SETTINGS" ]; then
-    echo "FLOW_ONBOARDING_ERROR=$SETTINGS became a symlink — refusing to write" >&2
-    return 1
-  fi
-
-  # Compose the jq merge expression. Conditional workflows clause: "skip"
-  # leaves the existing value (or absence) untouched; "true"/"false" sets it.
-  local jq_expr='.flow.goals.requireGoalForStart = $req | .flow.goals.executeVerificationCommands = $exe'
-  if [ "$wfl" = "true" ] || [ "$wfl" = "false" ]; then
-    jq_expr="$jq_expr | .flow.workflows.enabled = \$wfl"
-  fi
-
-  if [ -f "$SETTINGS" ]; then
-    # File exists — must merge, never overwrite. Requires jq.
-    if ! command -v jq >/dev/null 2>&1; then
-      echo "FLOW_ONBOARDING_ERROR=$SETTINGS exists but jq is unavailable — refusing to overwrite v2 keys; install jq and re-run /flow:start" >&2
-      return 1
-    fi
-
-    # Cycle-14 SEC-6: use mktemp instead of PID-scoped tmpfile. PID
-    # predictability (~15 bits of entropy) allows symlink-planting attacks
-    # on multi-user systems; mktemp's random suffix defeats it.
-    local tmp
-    tmp=$(mktemp -t flow-settings.XXXXXX 2>/dev/null) || {
-      echo "FLOW_ONBOARDING_ERROR=mktemp failed for settings merge" >&2
-      return 1
-    }
-    local lockfile="${SETTINGS}.lock"
-    # Cycle-14 F5 (error-handler skeptic): trap to clean tmpfile on signal
-    # so .claude/ doesn't accumulate stale `settings.flow.json.tmp.NNNN`.
-    trap 'rm -f "$tmp"' EXIT INT TERM
-    (
-      # flock guards the read-modify-write window; (subshell) scopes the fd.
-      flock -x 9 || { echo "FLOW_ONBOARDING_ERROR=failed to acquire $lockfile" >&2; exit 1; }
-      if [ "$wfl" = "true" ] || [ "$wfl" = "false" ]; then
-        if ! jq --argjson req "$req" --argjson exe "$exe" --argjson wfl "$wfl" \
-             "$jq_expr" \
-             "$SETTINGS" > "$tmp"; then
-          rm -f "$tmp"
-          echo "FLOW_ONBOARDING_ERROR=jq merge failed on $SETTINGS" >&2
-          exit 1
-        fi
-      else
-        if ! jq --argjson req "$req" --argjson exe "$exe" \
-             "$jq_expr" \
-             "$SETTINGS" > "$tmp"; then
-          rm -f "$tmp"
-          echo "FLOW_ONBOARDING_ERROR=jq merge failed on $SETTINGS" >&2
-          exit 1
-        fi
-      fi
-      # Cycle-14 SEC-V5 (security verifier): validate the merged file is
-      # non-empty AND parseable BEFORE replacing the original — a jq that
-      # exits 0 with empty/truncated output would otherwise destroy settings.
-      if [ ! -s "$tmp" ] || ! jq empty "$tmp" >/dev/null 2>&1; then
-        rm -f "$tmp"
-        echo "FLOW_ONBOARDING_ERROR=jq produced empty or invalid JSON; $SETTINGS unchanged" >&2
-        exit 1
-      fi
-      if ! mv "$tmp" "$SETTINGS"; then
-        rm -f "$tmp"
-        echo "FLOW_ONBOARDING_ERROR=mv failed; $SETTINGS unchanged" >&2
-        exit 1
-      fi
-    ) 9>"$lockfile"
-    local rc=$?
-    trap - EXIT INT TERM
-    rm -f "$tmp"
-    [ "$rc" -ne 0 ] && return 1
-  else
-    # Fresh file — write atomically via tmpfile+mv (cycle-14 F4 error-handler
-    # verifier: the previous non-atomic `printf > $SETTINGS` left the file
-    # partial on signal mid-write).
-    local tmp
-    tmp=$(mktemp -t flow-settings.XXXXXX 2>/dev/null) || {
-      echo "FLOW_ONBOARDING_ERROR=mktemp failed for fresh-file write" >&2
-      return 1
-    }
-    trap 'rm -f "$tmp"' EXIT INT TERM
-    # Compose the JSON document with conditional workflows.enabled.
-    if [ "$wfl" = "true" ] || [ "$wfl" = "false" ]; then
-      printf '%s\n' "{" \
-        "  \"flow\": {" \
-        "    \"goals\": {" \
-        "      \"requireGoalForStart\": ${req}," \
-        "      \"executeVerificationCommands\": ${exe}" \
-        "    }," \
-        "    \"workflows\": {" \
-        "      \"enabled\": ${wfl}" \
-        "    }" \
-        "  }" \
-        "}" > "$tmp"
-    else
-      printf '%s\n' "{" \
-        "  \"flow\": {" \
-        "    \"goals\": {" \
-        "      \"requireGoalForStart\": ${req}," \
-        "      \"executeVerificationCommands\": ${exe}" \
-        "    }" \
-        "  }" \
-        "}" > "$tmp"
-    fi
-    if [ ! -s "$tmp" ] || ! jq empty "$tmp" >/dev/null 2>&1; then
-      rm -f "$tmp"
-      trap - EXIT INT TERM
-      echo "FLOW_ONBOARDING_ERROR=fresh file write produced empty or invalid JSON" >&2
-      return 1
-    fi
-    if ! mv "$tmp" "$SETTINGS"; then
-      rm -f "$tmp"
-      trap - EXIT INT TERM
-      echo "FLOW_ONBOARDING_ERROR=mv failed for fresh-file write" >&2
-      return 1
-    fi
-    trap - EXIT INT TERM
-  fi
-}
-
-# Cycle-14 F2 (code-reviewer verifier): set_flow_workflows_enabled REMOVED.
-# Previously cycle-13 added a second helper for the workflows.enabled key, but
-# the two-helper sequence created a partial-success failure mode: if the
-# second invocation failed, the settings file ended up with flow.goals but no
-# flow.workflows, and the Phase 0.5 detector silently skipped the re-prompt
-# (looks for .flow.goals only). The fix is structural: set_flow_goals now
-# takes a 3rd arg (workflows: "true"|"false"|"skip") and writes all keys in
-# a single jq merge. Enable arm passes "true"; Skip arm passes "skip" to
-# preserve any pre-existing flow.workflows.enabled setting.
-```
-
-**Dispatch based on the user's answer** (Claude runs ONE of the following based on the `AskUserQuestion` response — NOT a shell `case`):
-
-- **Answer = "Enable v3 (recommended for new projects)"**:
-  ```bash
-  set_flow_goals true true true \
-    && echo "Flow v3 enabled (goals + workflows). Settings written to $SETTINGS." \
-    && echo "Note: FlowTriggers (/flow:watch, /flow:trigger) remain separate opt-in." \
-    && echo "  Enable later via: jq '.flow.triggers.enabled = true' $SETTINGS > /tmp/s && mv /tmp/s $SETTINGS"
-  ```
-  Cycle-14 F2: `set_flow_goals` now writes all three keys atomically in one jq merge — no more partial-success state where goals lands but workflows is missing. If the helper returns non-zero, halt Phase 0.5 and surface the `FLOW_ONBOARDING_ERROR` line.
-
-- **Answer = "Skip — keep v2 behavior"**:
-  ```bash
-  set_flow_goals false false skip && echo "Flow v3 left disabled. Settings written to $SETTINGS (re-enable later by editing the file)."
-  ```
-  Third arg is `skip` so the helper leaves `flow.workflows` untouched (preserves any pre-existing user choice). Same error-halt semantics.
-
-- **Answer = "Tell me more"**:
-  ```bash
-  echo "Open plugins/flow/references/flow-goals-quickstart.md, then re-run /flow:start when ready."
-  ```
-  Do NOT write the settings file. Halt Phase 0.5 without proceeding. The next `/flow:start` will re-prompt — by design.
-
-Only the Enable and Skip arms write the settings file (with opposing flag values) so the prompt fires exactly once per project for users who actually answered. `Tell me more` is non-persistent so the user can re-enter the flow after reading the quickstart.
-
 ## Phase 1: EXPLORE
 
 Gather all context before planning.
@@ -526,7 +280,14 @@ Only after every criterion shows PASS or user-approved MANUAL can the workflow p
 gh issue edit "$ISSUE_NUM" --add-assignee @me
 ```
 
-**FlowGoal auto-creation (gated by `flow.goals.requireGoalForStart`):**
+**FlowGoal auto-creation (gated by `flow.goals.goalCreation`):**
+
+`goalCreation` is a 3-state setting — `auto` (default), `always`, or `off`:
+- `off` — never auto-create (manual `/flow:goal create` still works).
+- `always` — create a goal unconditionally (even a degenerate goal; flagged per AC-2).
+- `auto` — create **iff** the Spec Validation Gate passed with ≥1 acceptance criterion carrying a `verification_command`. An issue that yields zero verifiable ACs (e.g. a spec-free `documentation`/`chore` issue) is skipped **silently** — no prompt, no error.
+
+The master switch `flow.goals.enabled: false` forces `off` regardless of `goalCreation` (whole feature off — distinct from `goalCreation: off`, which leaves the feature on and only suppresses auto-creation).
 
 ```!
 CASCADE="$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/cascade-resolve.sh"
@@ -536,7 +297,19 @@ if [ ! -x "$CASCADE" ]; then
   echo "FLOW_GOAL_ERROR=cascade-resolve.sh missing or non-executable at $CASCADE"
   true; exit 0
 fi
-REQUIRE_GOAL=$("$CASCADE" --default "false" '.flow.goals.requireGoalForStart' 2>/dev/null)
+# Read-only migration (#111 AC-1): goalCreation wins; else map the legacy
+# requireGoalForStart (true→always, false→off); else `null` so the cascade
+# default (auto) applies. `else null` — NOT "auto" — is load-bearing: it lets a
+# settings source carrying NEITHER key fall through to the next cascade source
+# instead of short-circuiting and masking a lower-precedence requireGoalForStart.
+# Never rewrites the user's settings file, so configured projects are never
+# re-prompted or silently changed.
+GOAL_MODE=$("$CASCADE" --default "auto" '.flow.goals.goalCreation // (if .flow.goals.requireGoalForStart == true then "always" elif .flow.goals.requireGoalForStart == false then "off" else null end)' 2>/dev/null)
+case "$GOAL_MODE" in auto|always|off) ;; *) GOAL_MODE="auto" ;; esac
+# Master switch forces off when the whole feature is disabled.
+ENABLED=$("$CASCADE" --default "true" '.flow.goals.enabled' 2>/dev/null)
+[ "$ENABLED" != "true" ] && GOAL_MODE="off"
+echo "FLOW_GOAL_MODE=$GOAL_MODE"
 
 _RAW="$ARGUMENTS"  # Claude Code substitutes the bare arg token, not bash parameter-expansion
 ARG1="${_RAW%% *}"
@@ -545,7 +318,7 @@ case "$ARG1" in
   *) ISSUE_NUM="$ARG1" ;;
 esac
 
-if [ "$REQUIRE_GOAL" = "true" ] && [ -n "$ISSUE_NUM" ]; then
+if [ "$GOAL_MODE" != "off" ] && [ -n "$ISSUE_NUM" ]; then
   GOAL_ID="issue-$ISSUE_NUM"
   GOAL_PATH=".flow/goals/${GOAL_ID}.goal.yaml"
   if [ -f "$GOAL_PATH" ]; then
@@ -589,7 +362,11 @@ true
 
 Dispatch based on `FLOW_GOAL_STATE`:
 
-- **`create`** — proceed to invoke the skills (steps below). The visibility echo is gated on the post-write verify.
+- **`create`** — branch on `FLOW_GOAL_MODE`:
+  - **`always`** — create the goal unconditionally. A degenerate goal (0 ACs, or 0 ACs carrying a `verification_command`) is allowed here but is flagged in the compact summary per AC-2. Proceed to the skills below.
+  - **`auto`** — create the goal **iff** the Spec Validation Gate passed with ≥1 acceptance criterion carrying a `verification_command` (the "verifiable ACs win" rule — labels do not veto). If zero verifiable ACs (e.g. a spec-free `documentation`/`chore` issue that passed the gate with no commands), **skip silently**: do not invoke the skills, print no goal line, and treat exactly like `skip`. Otherwise proceed to the skills below.
+
+  In both create paths the visibility echo is gated on the post-write verify.
 - **`exists`** — non-terminal goal already on disk; print `FlowGoal already exists: <GOAL_PATH> (status: $GOAL_STATUS) — resuming. Use /flow:goal inspect <GOAL_ID> to review.`
 - **`terminal`** — goal is `achieved|failed|cancelled` and immutable. Refuse to resume; surface a six-field escalation per [`references/escalation-format.md`](../references/escalation-format.md): _Situation_: terminal goal at `<GOAL_PATH>`. _Tried_: detected `lifecycle.status=<GOAL_STATUS>`. _Options_: (1) Use `/flow:goal clear <GOAL_ID>` then re-run `/flow:start`, (2) Pick a new goal id, (3) Abort. _Recommendation_: Option 1 if the original goal is stale. _Blocking_: yes. _Risk_: mutating a terminal goal corrupts the audit trail.
 - **`blocked`** — cascade-resolve unavailable; surface `FLOW_GOAL_ERROR` and halt Phase 1.

--- a/plugins/flow/commands/start.md
+++ b/plugins/flow/commands/start.md
@@ -395,10 +395,7 @@ For `FLOW_GOAL_STATE=create`:
      fi
    fi
    ```
-4. Only after verify passes, emit:
-   ```
-   FlowGoal created: <GOAL_ID> at <GOAL_PATH> (status: active)
-   ```
+4. Only after verify passes, proceed to create the FlowRun (next section). **Do not** emit a per-artifact `FlowGoal created:` line here — the compact runtime summary that supersedes it is emitted once both the goal and run exist (see **Runtime summary** below, #111 AC-2).
 
 ### FlowRun (v3 runtime)
 
@@ -447,6 +444,28 @@ if [ -n "$ISSUE_NUM" ]; then
     --metadata workflow=start-issue --metadata run_id="$RUN_ID" --metadata status=active
 fi
 ```
+
+### Runtime summary (#111 AC-2)
+
+Once the goal (if any) and the FlowRun exist, emit **one** compact runtime summary **in place of** any per-artifact `FlowGoal created:` line. Do not dump the goal/run YAML — "invisible" means low-ceremony, not hidden-state. The summary has exactly these lines:
+
+- **Goal**: `<GOAL_ID>` (`<lifecycle status>`) — `<verifiable>` of `<total>` ACs carry a `verification_command`
+- **Workflow**: `start-issue`
+- **Run**: `<RUN_ID>` (the value emitted by the FlowRun block)
+- **Branch**: `<current branch>` (`git branch --show-current`)
+- _I'll work until the goal is achieved, blocked, or needs your decision._
+
+Compute the AC counts with the shared helper (it prints `<total>/<verifiable>`):
+
+```bash
+"$(__fr="${CLAUDE_PLUGIN_ROOT:-}";[ -x "$__fr/bin/cascade-resolve.sh" ]||__fr=$({ echo plugins/flow;ls -d "$HOME"/.claude/plugins/cache/synapti-marketplace/flow/*/ 2>/dev/null|sort -Vr;echo "$HOME/.claude/plugins/marketplaces/synapti-marketplace/plugins/flow"; }|while read -r __p;do [ -x "${__p%/}/bin/cascade-resolve.sh" ]&&{ echo "${__p%/}";break;};done);echo "$__fr")/bin/flow-active-goal.sh" --verifiable-count
+```
+
+**Truthfulness gate (load-bearing):** if the goal is degenerate — `<total>` is `0`, or `<verifiable>` is `0` — or the goal is unevaluated, the Goal line MUST be flagged, never shown as a clean `active`:
+
+- **Goal**: `<GOAL_ID>` ⚠ **degenerate / needs-attention** — `0` verifiable ACs; this goal cannot auto-evaluate.
+
+A degenerate goal can only arise under `goalCreation: always` or a manual `/flow:goal create` — `auto` never creates one (it requires ≥1 verifiable AC). When goal creation was **skipped** (`auto` with zero verifiable ACs, or `off`): omit the Goal line entirely and show only Workflow / Run / Branch — never present a skipped goal as if one exists.
 
 Phase order: `preflight → explore → plan → code → verify`. At each subsequent phase boundary (PLAN, CODE, VERIFY), invoke `Skill(run-state-management)` to write a FlowActivity record and advance `state.current_phase`. After the Phase 4 verdict settles, transition the FlowRun: `state.status: completed` when the verdict is PASS (and update the `workflow-run` artifact to `status=completed`); `state.status: blocked` (with `blocked_reason`) when the verdict is FAIL or the session ends mid-workflow, so `/flow:resume` can pick it up.
 

--- a/plugins/flow/commands/status.md
+++ b/plugins/flow/commands/status.md
@@ -13,7 +13,7 @@ _None — read-only status command. No skill invocations._
 
 ## Mode
 
-Parse an optional display mode from the command arguments (#111 AC-5). Use the bare-`$ARGUMENTS`-first pattern (#120) — copy the substituted token into a shell var BEFORE applying parameter-expansion, never `${ARGUMENTS%% *}` directly. An unknown argument falls back to the compact dashboard (never errors).
+Parse an optional display mode from the command arguments. Use the bare-`$ARGUMENTS`-first pattern — copy the substituted token into a shell var BEFORE applying parameter-expansion, never `${ARGUMENTS%% *}` directly. An unknown argument falls back to the compact dashboard (never errors).
 
 ```!
 _RAW="$ARGUMENTS"

--- a/plugins/flow/commands/status.md
+++ b/plugins/flow/commands/status.md
@@ -11,6 +11,23 @@ Read-only overview of the current development state. No skills needed — pure o
 
 _None — read-only status command. No skill invocations._
 
+## Mode
+
+Parse an optional display mode from the command arguments (#111 AC-5). Use the bare-`$ARGUMENTS`-first pattern (#120) — copy the substituted token into a shell var BEFORE applying parameter-expansion, never `${ARGUMENTS%% *}` directly. An unknown argument falls back to the compact dashboard (never errors).
+
+```!
+_RAW="$ARGUMENTS"
+ARG1="${_RAW%% *}"
+case "$ARG1" in
+  --full)        echo "STATUS_MODE=full" ;;
+  --json)        echo "STATUS_MODE=json" ;;
+  --evidence)    echo "STATUS_MODE=evidence" ;;
+  ""|--compact)  echo "STATUS_MODE=compact" ;;
+  *)             echo "STATUS_MODE=compact"; echo "STATUS_MODE_NOTE=unknown arg '$ARG1' — defaulting to compact dashboard" ;;
+esac
+true
+```
+
 ## Gather State
 
 ```!
@@ -394,6 +411,28 @@ State values: `unavailable` (gh API failed) | `no_open_prs` (user has no open PR
 
 ## Display
 
+Render according to `STATUS_MODE` (from the **Mode** block). All modes draw from the same gathered state; they differ only in shape. The v3 sections stay gated on `flow.goals.enabled` / `flow.triggers.enabled` — when disabled, render the existing `(… v3 not enabled …)` line in every mode (no change for v2 users). If `STATUS_MODE_NOTE` was emitted, print it as a one-line note above the output.
+
+### `compact` (default)
+
+A five-line operational dashboard — the fastest read of "where am I, and what's safe to do next":
+
+```markdown
+## Flow Status — {branch}
+
+- **Active work**: {issue/PR in flight, or "none"}
+- **Goal**: {GOAL_ID} {lifecycle} — {verifiable}/{total} ACs verified  (or "none (no active goal on this branch)", or the ⚠ degenerate / needs-attention marker when 0 verifiable ACs)
+- **Workflow**: {latest run workflow} @ {current_phase} ({latest activity}, or "no active run")
+- **Evidence**: {Findings Ledger one-liner — P1/P2/P3 per Render Rules}
+- **Next safe action**: {from Suggestions Logic}
+```
+
+When `flow.goals.enabled` is false, the Goal / Workflow / Evidence lines render `(v3 not enabled)` instead.
+
+### `--full`
+
+The complete verbose dashboard (every section):
+
 ```markdown
 ## Flow Status
 
@@ -456,6 +495,35 @@ State values: `unavailable` (gh API failed) | `no_open_prs` (user has no open PR
 ### Suggested Next Action
 {Based on state, suggest the most useful /flow command}
 ```
+
+### `--json`
+
+A single machine-readable JSON object for tooling/debugging — no prose, no tables:
+
+```json
+{
+  "branch": "{branch}",
+  "goal": {"id": "{GOAL_ID}", "lifecycle": "{status}", "acs": {"total": N, "verifiable": M}},
+  "run": {"id": "{RUN_ID}", "workflow": "{workflow}", "phase": "{current_phase}", "status": "{status}"},
+  "findings": {"p1": N, "p2": N, "p3": N},
+  "next_action": "{suggestion}"
+}
+```
+
+Emit `"goal": null` and/or `"run": null` when none is active. When `flow.goals.enabled` is false, emit `"v3_enabled": false` and set `goal`/`run` to `null`.
+
+### `--evidence`
+
+Per-AC evidence listing for the active goal (debugging the verdict path). One row per AC from `flow-active-goal.sh --ac-summary`, with the evidence sidecar path under `.flow/runs/<id>/evidence/`:
+
+```markdown
+## Goal Evidence — {GOAL_ID}
+| AC | Status | Evidence ref | Last result |
+|----|--------|--------------|-------------|
+| {id} | {status} | {evidence_ref} | {last_result} |
+```
+
+When no active goal exists: render `No active goal on this branch.` (or `(v3 not enabled)` when `flow.goals.enabled` is false).
 
 ## Render Rules — Findings Ledger
 

--- a/plugins/flow/commands/status.md
+++ b/plugins/flow/commands/status.md
@@ -181,7 +181,7 @@ echo "### Recent Runs"
 if [ ! -d ".flow/runs" ]; then
   echo "STATE=empty"
 else
-  # Most-recent-first sort by mtime. Cycle-14 F2 (code-reviewer skeptic):
+  # Most-recent-first sort by mtime:
   # the previous `... | tac 2>/dev/null || ... | tail -3` fallback silently
   # produced oldest-first when tac was missing (macOS without coreutils).
   # Use awk-based reverse instead — portable POSIX and matches the

--- a/plugins/flow/hooks/scripts/flow-goal-evaluator.sh
+++ b/plugins/flow/hooks/scripts/flow-goal-evaluator.sh
@@ -142,7 +142,13 @@ if [ "$STOP_ACTIVE" = "true" ] && [ -f "$THROTTLE_FILE" ]; then
     ACTIVE_GOAL_HELPER="${PLUGIN_ROOT}/bin/flow-active-goal.sh"
     if [ -x "$ACTIVE_GOAL_HELPER" ]; then
       THROTTLE_GOAL_PATH=$("$ACTIVE_GOAL_HELPER" --path --branch-strict 2>/dev/null)
-      if [ -n "$THROTTLE_GOAL_PATH" ] && [ -f "$THROTTLE_GOAL_PATH" ]; then
+      if [ -z "$THROTTLE_GOAL_PATH" ]; then
+        # No active goal owns the current branch — nothing to attribute the
+        # throttle-block event to. The throttle decision below still fires; only
+        # the per-run event log is skipped. Surface it so the gap is diagnosable
+        # rather than a silent hole in /flow:learn's event history.
+        echo "flow-goal-evaluator: throttle event skipped — no active goal on the current branch" >&2
+      elif [ -f "$THROTTLE_GOAL_PATH" ]; then
         # argv-passing instead of -c with bash interpolation —
         # closes the Python code injection vector where a file with a `'` in
         # the path would inject into the single-quoted Python literal.

--- a/plugins/flow/hooks/scripts/flow-goal-evaluator.sh
+++ b/plugins/flow/hooks/scripts/flow-goal-evaluator.sh
@@ -141,7 +141,7 @@ if [ "$STOP_ACTIVE" = "true" ] && [ -f "$THROTTLE_FILE" ]; then
     # throttle decision is the primary outcome.
     ACTIVE_GOAL_HELPER="${PLUGIN_ROOT}/bin/flow-active-goal.sh"
     if [ -x "$ACTIVE_GOAL_HELPER" ]; then
-      THROTTLE_GOAL_PATH=$("$ACTIVE_GOAL_HELPER" --path 2>/dev/null)
+      THROTTLE_GOAL_PATH=$("$ACTIVE_GOAL_HELPER" --path --branch-strict 2>/dev/null)
       if [ -n "$THROTTLE_GOAL_PATH" ] && [ -f "$THROTTLE_GOAL_PATH" ]; then
         # argv-passing instead of -c with bash interpolation —
         # closes the Python code injection vector where a file with a `'` in
@@ -192,23 +192,17 @@ PYEOF
   fi
 fi
 
-# Find active goal (same logic as flow-goal-stop.sh).
-ACTIVE_GOAL=$(python3 - <<'PYEOF' 2>/dev/null
-import os, glob, sys, yaml
-sys.path[:] = [p for p in sys.path if p not in ("", ".")]
-if not os.path.isdir(".flow/goals"):
-    sys.exit(0)
-for path in sorted(glob.glob(".flow/goals/*.goal.yaml")):
-    try:
-        with open(path, "r", encoding="utf-8") as f:
-            data = yaml.safe_load(f) or {}
-        if data.get("lifecycle", {}).get("status") == "active":
-            print(path)
-            sys.exit(0)
-    except Exception:
-        continue
-PYEOF
-)
+# Find the active goal that owns the current branch. Delegate to the
+# centralized branch-aware resolver (--branch-strict) so that, when goals are
+# active across multiple branches, the evaluator acts on THIS branch's goal and
+# never a stale goal on another branch. Empty result (approve) when the helper
+# is unavailable — the Stop hook must not block the user on infra failure.
+GOAL_HELPER="${PLUGIN_ROOT}/bin/flow-active-goal.sh"
+if [ -x "$GOAL_HELPER" ]; then
+  ACTIVE_GOAL=$("$GOAL_HELPER" --path --branch-strict 2>/dev/null)
+else
+  ACTIVE_GOAL=""
+fi
 [ -z "$ACTIVE_GOAL" ] && { echo '{"decision":"approve","reason":"no active flow goal"}'; exit 0; }
 
 # Budget check. Read turns_evaluated and max_iterations; transition to

--- a/plugins/flow/hooks/scripts/flow-goal-evaluator.sh
+++ b/plugins/flow/hooks/scripts/flow-goal-evaluator.sh
@@ -131,7 +131,7 @@ if [ "$STOP_ACTIVE" = "true" ] && [ -f "$THROTTLE_FILE" ]; then
   [ "$SINCE" -gt 300 ] && CONTINUE_COUNT=0
   if [ "$CONTINUE_COUNT" -ge 3 ] && [ "$SINCE" -lt 300 ]; then
     rm -f "$THROTTLE_FILE"
-    # F8: Log the throttle-block event to the active run's events.jsonl so
+    # Log the throttle-block event to the active run's events.jsonl so
     # /flow:learn pattern analysis can detect projects where the evaluator
     # loop hits the throttle frequently (signal: the goal contract or the
     # executor's iteration cadence needs adjustment).
@@ -143,7 +143,7 @@ if [ "$STOP_ACTIVE" = "true" ] && [ -f "$THROTTLE_FILE" ]; then
     if [ -x "$ACTIVE_GOAL_HELPER" ]; then
       THROTTLE_GOAL_PATH=$("$ACTIVE_GOAL_HELPER" --path 2>/dev/null)
       if [ -n "$THROTTLE_GOAL_PATH" ] && [ -f "$THROTTLE_GOAL_PATH" ]; then
-        # Cycle-14 SEC-3: argv-passing instead of -c with bash interpolation —
+        # argv-passing instead of -c with bash interpolation —
         # closes the Python code injection vector where a file with a `'` in
         # the path would inject into the single-quoted Python literal.
         THROTTLE_RUN_ID=$(python3 - "$THROTTLE_GOAL_PATH" <<'PYEOF' 2>/dev/null
@@ -157,16 +157,16 @@ except Exception as e:
     print(f"flow-goal-evaluator: throttle run_id lookup failed: {e}", file=sys.stderr)
 PYEOF
 )
-        # Cycle-14 SEC-1: defensive reject path-traversal in run_id even
+        # defensive reject path-traversal in run_id even
         # though the schema now constrains it — defense-in-depth in case a
-        # hostile YAML bypassed schema (e.g., jsonschema unavailable per F11).
+        # hostile YAML bypassed schema (e.g., jsonschema unavailable).
         case "$THROTTLE_RUN_ID" in
           ''|.|..|*..*|*/*|*$'\n'*)
             THROTTLE_RUN_ID=""
             ;;
         esac
         if [ -n "$THROTTLE_RUN_ID" ] && [ -d ".flow/runs/$THROTTLE_RUN_ID" ]; then
-          # Cycle-14 SEC-2: symlink defense on events.jsonl — the bash `>>`
+          # symlink defense on events.jsonl — the bash `>>`
           # follows symlinks; a planted symlink at .flow/runs/<id>/events.jsonl
           # would redirect the throttle-block payload to any user-writable
           # target. Refuse the write if the file is a symlink. Matches the
@@ -245,9 +245,9 @@ except Exception as e:
 PYEOF
 )
 
-# Cycle-14 SEC-1: defense-in-depth path-traversal reject on RUN_ID. The
+# defense-in-depth path-traversal reject on RUN_ID. The
 # schema constrains scope.run_id to ^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$ but
-# when jsonschema is unavailable (F11 silent-skip path), a hostile YAML
+# when jsonschema is unavailable, a hostile YAML
 # could land on disk and reach this point with `..` or `/` in run_id.
 # Reject any value that contains a path separator, traversal, control char,
 # or empty bare-dot.
@@ -299,7 +299,7 @@ _record_verdict() {
     || echo "flow-goal-evaluator: last-verdict.json write failed (delta computation on next turn will fall back to 'unchanged')" >&2
 }
 
-# F9: Stuck-detection helper. Increments a per-run counter when the verdict's
+# Stuck-detection helper. Increments a per-run counter when the verdict's
 # delta is 'unchanged'; resets the counter on any other delta. When the counter
 # reaches flow.goals.failAfterStuckTurns (cascade-resolved; default 3), the
 # helper transitions the active goal to lifecycle.status=failed via
@@ -319,7 +319,7 @@ _check_stuck() {
 
   local counter_file="$run_dir/stuck-counter"
 
-  # Cycle-14 SEC-3: symlink defense on stuck-counter. The read+write below
+  # symlink defense on stuck-counter. The read+write below
   # use shell redirection which follows symlinks; a hostile project could
   # plant a symlink at .flow/runs/<id>/stuck-counter pointing at e.g.
   # ~/.bashrc and the integer write would overwrite it. Refuse to operate
@@ -345,7 +345,7 @@ _check_stuck() {
     # the stuck condition.
     counter=0
   fi
-  # Cycle-14 F2 (error-handler skeptic): surface counter-write failures
+  # surface counter-write failures
   # instead of silently swallowing with `|| true`. A silent write failure
   # means in-memory counter advances but on-disk state stays — next turn
   # re-reads stale state and the threshold is never reached, trapping the
@@ -368,7 +368,7 @@ _check_stuck() {
   local goal_id
   goal_id=$(basename "$ACTIVE_GOAL" .goal.yaml)
 
-  # Cycle-14 F1 (code-reviewer verifier): preserve turns_evaluated history.
+  # preserve turns_evaluated history.
   # flow-goal-record.sh's lifecycle-update path replaces (does not deep-merge)
   # the lifecycle block, so writing `turns_evaluated: 0` here would drop the
   # real iteration count from disk — making /flow:learn's stuck-pattern
@@ -401,7 +401,7 @@ last_evaluation:
   reason: "stuck_no_progress: delta unchanged for ${counter} consecutive turns (threshold=${threshold})"
   at: "${now_iso}"
 EOF
-  # Cycle-14 F7 (error-handler skeptic): surface write failures honestly.
+  # surface write failures honestly.
   # Previously the `|| echo "stuck-transition write failed"` was followed by
   # the caller emitting "lifecycle transitioned to failed" — a lie when the
   # write didn't actually happen. Now we return 0 on failure so the caller
@@ -415,7 +415,7 @@ EOF
     return 0  # keep the block loop active; do NOT lie that we transitioned.
   fi
 
-  # Cycle-14 SEC-2: symlink defense on events.jsonl for stuck event log.
+  # symlink defense on events.jsonl for stuck event log.
   local events_file="$run_dir/events.jsonl"
   if [ ! -L "$events_file" ]; then
     jq -nc \
@@ -483,11 +483,11 @@ PYEOF
   # Persist verdict so next-turn delta computation has memory. Confidence
   # 1.0 because the deterministic must_pass failure is unambiguous
   # evidence of `not_achieved`. Record BEFORE deciding block-or-approve so
-  # _check_stuck (F9) can read the persisted delta history.
+  # _check_stuck can read the persisted delta history.
   _record_verdict "not_achieved" "1.0" "unchanged" \
     "must_pass criterion failed deterministically" "" "evaluator-loop-must-pass-fail"
 
-  # F9: Stuck-detection. If the goal has been stuck on "unchanged" for
+  # Stuck-detection. If the goal has been stuck on "unchanged" for
   # failAfterStuckTurns consecutive turns, transition to failed and emit
   # approve so the user isn't trapped in an infinite block loop.
   if _check_stuck "unchanged"; then
@@ -609,7 +609,7 @@ case "$VERDICT" in
     jq -nc --arg r "Goal $VERDICT: $REASON_TXT" '{decision:"approve", reason:$r}'
     ;;
   not_achieved|*)
-    # F9: Check stuck-detection on the judge's delta. Stuck threshold may
+    # Check stuck-detection on the judge's delta. Stuck threshold may
     # transition the goal to failed and override the block with approve.
     if _check_stuck "$DELTA"; then
       echo "$((CONTINUE_COUNT + 1)):$NOW" > "$THROTTLE_FILE"

--- a/plugins/flow/references/flow-goals-quickstart.md
+++ b/plugins/flow/references/flow-goals-quickstart.md
@@ -8,26 +8,24 @@ A 5-minute walkthrough of the v3 runtime layer on a synthetic issue. By the end 
 - A git repository (any one — a scratch repo works)
 - `python3` with `PyYAML` available (`python3 -c 'import yaml'` exits 0)
 
-If you've never run `/flow:start` in this project, the first invocation will prompt you to enable v3 — answer **Enable v3** and the prompt will not fire again.
+As of v3.1, FlowGoals are on by default (`goalCreation: auto`) — there is no onboarding prompt. Running `/flow:start <issue>` on an issue with ≥1 verifiable AC just creates the goal.
 
-## Step 1 — Enable v3 explicitly (skip if you've already onboarded)
+## Step 1 — (Optional) tune goal creation
 
-In an existing project where you skipped the onboarding prompt or you want to opt in without re-running `/flow:start`, write `.claude/settings.flow.json`:
+Goal creation defaults to `auto`, so most projects need no settings at all. To change the policy or enable Stop-hook command execution, write `.claude/settings.flow.json`:
 
 ```json
 {
   "flow": {
     "goals": {
-      "requireGoalForStart": true,
-      "executeVerificationCommands": true
+      "goalCreation": "auto",
+      "executeVerificationCommands": false
     }
   }
 }
 ```
 
-These two flags do the load-bearing work:
-
-- `requireGoalForStart: true` — `/flow:start <issue>` will auto-create a FlowGoal after the Spec Validation Gate passes.
+- `goalCreation` — `auto` (default; create iff ≥1 AC carries a `verification_command`), `always` (create unconditionally; degenerate goals are flagged), or `off` (never auto-create; manual `/flow:goal create` still works). The deprecated `requireGoalForStart` is migrated read-only: `true`→`always`, `false`→`off`.
 - `executeVerificationCommands: true` — when the Stop hook (`flow-goal-stop.sh` / `flow-goal-evaluator.sh`) runs deterministic checks against an active goal, it will execute each AC's `verification_command` rather than reporting `not_executed`. The flag is honored by `bin/flow-run-deterministic-checks.sh` (the hook path); `/flow:goal evaluate` and `Skill(goal-evaluator)` always execute verification commands when present — the flag does not gate that path. Keep `false` (default) for repos where you don't want the Stop hook running arbitrary shell from goal YAMLs; set `true` once you trust the source of `.flow/goals/*.goal.yaml`.
 
 ## Step 2 — Create a synthetic issue
@@ -92,7 +90,7 @@ You'll see a per-AC table and the verdict.
 /flow:goal status
 ```
 
-If lifecycle is `achieved`, the goal is complete. `/flow:pr` and `/flow:merge` from this point require the goal to be `achieved` (with `requireGoalForStart: true`).
+If lifecycle is `achieved`, the goal is complete. When an active goal exists for the branch, `/flow:pr` and `/flow:merge` require it to be `achieved` (#111 D-GATE: the gate is on goal *existence* — a branch with no goal is not blocked).
 
 ## Common adjustments
 

--- a/plugins/flow/references/flow-goals-quickstart.md
+++ b/plugins/flow/references/flow-goals-quickstart.md
@@ -90,7 +90,7 @@ You'll see a per-AC table and the verdict.
 /flow:goal status
 ```
 
-If lifecycle is `achieved`, the goal is complete. When an active goal exists for the branch, `/flow:pr` and `/flow:merge` require it to be `achieved` (#111 D-GATE: the gate is on goal *existence* — a branch with no goal is not blocked).
+If lifecycle is `achieved`, the goal is complete. When an active goal exists for the branch, `/flow:pr` and `/flow:merge` require it to be `achieved` — the gate is on goal *existence*, so a branch with no goal is not blocked.
 
 ## Common adjustments
 

--- a/plugins/flow/references/flow-goals.md
+++ b/plugins/flow/references/flow-goals.md
@@ -16,25 +16,30 @@ A FlowGoal is a durable, schema-validated YAML file at `.flow/goals/<id>.goal.ya
 
 The full schema lives at `plugins/flow/schemas/v1/goal.schema.json`.
 
-## Enabling v3 in your project
+## FlowGoals are on by default (v3.1)
 
-Flow v3 ships dormant by default — the feature flags default to `false` so v2 projects upgrade with zero behavioral change. To turn on FlowGoals for `/flow:start` and `/flow:pr` / `/flow:merge`, add to `.claude/settings.flow.json`:
+As of v3.1, `/flow:start` records FlowGoals automatically — `flow.goals.goalCreation` defaults to `auto`. There is no opt-in prompt; goals, runs, and evidence are written to `.flow/` behind the scenes and surfaced through `/flow:status`. You interact with outcomes, not the runtime.
+
+`goalCreation` is a 3-state setting in `.claude/settings.flow.json`:
 
 ```json
 {
   "flow": {
     "goals": {
-      "requireGoalForStart": true,
-      "executeVerificationCommands": true
+      "goalCreation": "auto",
+      "executeVerificationCommands": false
     }
   }
 }
 ```
 
-- `requireGoalForStart: true` — `/flow:start <issue>` auto-creates `.flow/goals/issue-<N>.goal.yaml` after the Spec Validation Gate.
+- `goalCreation: auto` (default) — `/flow:start <issue>` creates `.flow/goals/issue-<N>.goal.yaml` **iff** the Spec Validation Gate passed with ≥1 acceptance criterion carrying a `verification_command` (labels do not veto). An issue that yields zero verifiable ACs (e.g. a spec-free `documentation`/`chore` issue) creates **no** goal, silently.
+- `goalCreation: always` — create a goal unconditionally; a degenerate goal (no verifiable ACs) is allowed but flagged in the compact summary.
+- `goalCreation: off` — never auto-create; manual `/flow:goal create` still works.
+- `flow.goals.enabled: false` — disables the whole feature (Stop hook fast-paths, `/flow:goal` disabled). Distinct from `goalCreation: off`, which keeps the feature on and only suppresses auto-creation.
 - `executeVerificationCommands: true` — lets the Stop hook's deterministic-checks runner execute each AC's `verification_command` rather than reporting `not_executed`. Governs only the Stop hook path (`bin/flow-run-deterministic-checks.sh`); `/flow:goal evaluate` and `Skill(goal-evaluator)` execute verification commands when present regardless. Set `true` only when you trust the source of `.flow/goals/*.goal.yaml` (Stop hook fires on every turn — running unvetted commands every turn is a hostile-fork attack surface).
 
-`/flow:start` will also prompt you the first time you run it in a project that has neither `.claude/settings.flow.json` nor `.flow/` — answer **Enable v3** and the same flags are written automatically.
+> **Upgrading from the v3.0 `requireGoalForStart` flag?** It is mapped read-only — `true` → `always`, `false` → `off`, absent → `auto` — and your settings file is never rewritten. See `migration-v2-to-v3.md`.
 
 See [`flow-goals-quickstart.md`](flow-goals-quickstart.md) for a 5-minute walkthrough on a synthetic issue, and [`migration-v2-to-v3.md`](migration-v2-to-v3.md) for the step-by-step v2 → v3 opt-in across all four feature areas (goals, Stop hook, workflows, triggers).
 
@@ -121,7 +126,7 @@ All settings live under `flow.goals.*` and resolve via `bin/cascade-resolve.sh` 
 |---|---|---|
 | `flow.runtime.enabled` | `true` | Master switch for `.flow/` runtime layer |
 | `flow.goals.enabled` | `true` | Master switch for FlowGoal feature |
-| `flow.goals.requireGoalForStart` | `false` | If `true`, `/flow:start` auto-creates a goal after Spec Validation Gate |
+| `flow.goals.goalCreation` | `auto` | `auto` (create iff ≥1 verifiable AC) \| `always` \| `off`. Replaces the deprecated `requireGoalForStart` (migrated read-only: `true`→`always`, `false`→`off`) |
 | `flow.goals.stopHookEnforcement` | `warn` | `warn \| block \| evaluator-loop` |
 | `flow.goals.failAfterStuckTurns` | `3` | evaluator-loop fails goal after N turns of unchanged pass-set |
 | `flow.goals.judge.model` | `haiku` | Judge subprocess model |
@@ -155,7 +160,7 @@ If your needs require any of the above, FlowGoal is the wrong primitive — esca
 
 ## Compose with other flow features
 
-- **`/flow:start <issue>`** — when `requireGoalForStart: true`, creates `.flow/goals/issue-<N>.goal.yaml` after Spec Validation Gate. Lifecycle stays `active` through Phase 4 (CODE, VERIFY); `verdict-judge` PASS transitions to `achieved`.
+- **`/flow:start <issue>`** — under `goalCreation: auto` (default), creates `.flow/goals/issue-<N>.goal.yaml` after the Spec Validation Gate **iff** ≥1 AC carries a `verification_command`. Lifecycle stays `active` through Phase 4 (CODE, VERIFY); `verdict-judge` PASS transitions to `achieved`.
 - **`/flow:review <PR>`** — creates a `pr-<N>-review.goal.yaml` with review-checklist ACs.
 - **`/flow:address <PR>`** — creates a `pr-<N>-address.goal.yaml` with one AC per unresolved finding.
 - **`/flow:debug`** — Goal with `outcome: "The reported failure is reproduced, root-caused, and a fix is verified."` and ACs derived from the bug hypothesis.

--- a/plugins/flow/references/migration-v2-to-v3.md
+++ b/plugins/flow/references/migration-v2-to-v3.md
@@ -2,42 +2,47 @@
 
 flow v3.0 is **purely additive**. Existing v2.x projects upgrade with zero behavioral change unless you opt in. This guide walks through enabling v3 features one at a time.
 
-## What "no change" means
+## What changes when you upgrade (v3.1)
 
-After upgrading to v3.0 without editing settings:
+v3.1 makes FlowGoals **invisible-by-default**: `flow.goals.goalCreation` defaults to `auto`, so goal/run/evidence artifacts are recorded for you rather than gated behind an opt-in. After upgrading without editing settings:
 
-- `/flow:start <issue>` runs exactly as in v2.x — no goal is created, no `.flow/` directory appears, no settings are written.
-- The Stop hook fires but exits silently (default mode is `warn`, and `warn` is itself silent when no active FlowGoal exists).
-- `/flow:status`, `/flow:learn`, `/flow:pr`, `/flow:merge`, `/flow:review`, `/flow:address` behave identically to v2.4.
+- `/flow:start <issue>` creates `.flow/goals/issue-<N>.goal.yaml` whenever the Spec Validation Gate passes with **≥1 acceptance criterion carrying a `verification_command`**. An issue that yields zero verifiable ACs (e.g. a spec-free `documentation`/`chore` issue) creates **no** goal, silently. All artifacts are local under `.flow/` — nothing is pushed, posted, or sent.
+- `/flow:status` surfaces the active goal/run; `/flow:pr` and `/flow:merge` gate on goal **existence** — a branch whose goal isn't `achieved` is held back, but a branch with **no** goal is not blocked.
+- The Stop hook fires but stays silent in the default `warn` mode unless an active goal lacks evidence.
+- `/flow:learn`, `/flow:review`, `/flow:address` behave as before (review/address record a FlowRun but no user-facing goal).
 
-The new v3 commands (`/flow:goal`, `/flow:resume`, `/flow:workflow`, `/flow:trigger`, `/flow:watch`, `/flow:run`) are available but only have effect when their feature flags are enabled.
+There is **no consent prompt** — the v3.0 first-run onboarding `AskUserQuestion` was retired in v3.1. Writing local `.flow/` artifacts needs no confirmation.
 
-### One v2-visible behavior change: the first-run onboarding prompt
+### Migrating the old `requireGoalForStart` flag
 
-There is one path where v3.0 changes behavior for a v2 project without an explicit opt-in: the **first `/flow:start` after upgrade** may emit a one-time `AskUserQuestion` consent prompt asking whether to enable v3. The prompt fires only when **both** signals say "the v3 question has never been answered":
+If your `.claude/settings.flow.json` set the v3.0 `flow.goals.requireGoalForStart` flag, it is honored via a **read-only** migration — your file is never rewritten:
 
-1. No `.flow/` directory exists at the repo root, AND
-2. `.claude/settings.flow.json` is either absent OR present without a `flow.goals` block.
+| v3.0 setting | v3.1 behavior |
+|---|---|
+| `requireGoalForStart: true` | `goalCreation: always` |
+| `requireGoalForStart: false` | `goalCreation: off` |
+| absent | `goalCreation: auto` (default) |
 
-v2 projects that already committed a `.claude/settings.flow.json` with a `flow.goals` block (any contents — even `{}`) skip the prompt. Projects that have `.flow/` artifacts also skip (clearly already using v3).
+To adopt the new key explicitly, replace `requireGoalForStart` with `goalCreation` in your settings.
 
-If you don't want to see the prompt at all, pre-write `.claude/settings.flow.json` with `{"flow": {"goals": {"requireGoalForStart": false, "executeVerificationCommands": false}}}` and the gate stays quiet on the first invocation. Answering "Skip — keep v2 behavior" persists the same JSON automatically.
+### Opting out
 
-## Enable v3 in four optional steps
+- `goalCreation: off` — `/flow:start` won't auto-create goals (manual `/flow:goal create` still works); the pr/merge goal gate is disabled.
+- `flow.goals.enabled: false` — disables the whole FlowGoal feature (Stop hook fast-paths, `/flow:goal` disabled).
+
+## Tune goal behavior in optional steps
 
 Each step is independent. Adopt them in the order below or skip ones that don't fit your workflow.
 
-### Step 1 — Enable goals (recommended starting point)
+### Step 1 — Goals (on by default)
 
-Adds durable completion contracts to `/flow:start`. After the Spec Validation Gate passes, a `.flow/goals/issue-<N>.goal.yaml` is created with `lifecycle.status: active`. `/flow:pr` and `/flow:merge` will require the goal to be `achieved` before proceeding (override path: six-field escalation).
-
-Add to `.claude/settings.flow.json` (create the file if it doesn't exist):
+Goals are created automatically under `goalCreation: auto`. To require a goal on **every** `/flow:start` regardless of verifiable ACs, set `goalCreation: always`:
 
 ```json
 {
   "flow": {
     "goals": {
-      "requireGoalForStart": true,
+      "goalCreation": "always",
       "executeVerificationCommands": true
     }
   }
@@ -46,7 +51,7 @@ Add to `.claude/settings.flow.json` (create the file if it doesn't exist):
 
 `executeVerificationCommands: true` lets `/flow:goal evaluate` auto-run each AC's `verification_command`. Without it, evaluator returns `not_executed` and you must capture evidence manually.
 
-Run `/flow:goal status` to confirm v3 is on. Walk through `flow-goals-quickstart.md` for a worked example.
+Run `/flow:goal status` to confirm goal state. Walk through `flow-goals-quickstart.md` for a worked example.
 
 ### Step 2 — Enable active Stop-hook enforcement (optional)
 

--- a/plugins/flow/references/plugin-root-resolution.md
+++ b/plugins/flow/references/plugin-root-resolution.md
@@ -22,9 +22,9 @@ This is unsafe for **marketplace installs**:
   repo the plugin lives under `~/.claude/plugins/...`, so the fallback points at
   a path that does not exist and every bundled helper becomes unreachable.
 
-Observed failure: `/flow:start` in a consumer repo with
-`flow.goals.requireGoalForStart: true` could not find `cascade-resolve.sh`, so
-the FlowGoal was never created and the `/flow:merge` goal gate had nothing to
+Observed failure: `/flow:start` in a consumer repo with goal creation active
+(`flow.goals.goalCreation: auto` or `always`) could not find `cascade-resolve.sh`,
+so the FlowGoal was never created and the `/flow:merge` goal gate had nothing to
 check.
 
 Hooks are unaffected (they get `CLAUDE_PLUGIN_ROOT` per the docs), so

--- a/plugins/flow/schema.json
+++ b/plugins/flow/schema.json
@@ -292,10 +292,15 @@
               "default": true,
               "description": "Master switch for the FlowGoal feature. When false, /flow:goal is disabled and the Stop hook fast-paths to approve."
             },
+            "goalCreation": {
+              "enum": ["auto", "always", "off"],
+              "default": "auto",
+              "description": "Controls /flow:start FlowGoal auto-creation (#111 AC-1). 'auto' (default): create a goal iff the Spec Validation Gate passed with >=1 acceptance criterion carrying a verification_command (labels do not veto); spec-free issues yielding zero verifiable ACs are skipped silently. 'always': create unconditionally (a degenerate goal is allowed but flagged in the compact summary). 'off': never auto-create; manual /flow:goal create still works. Distinct from goals.enabled:false, which disables the whole feature. The Phase 0.5 consent prompt is retired — invisible-auto is the default."
+            },
             "requireGoalForStart": {
               "type": "boolean",
-              "default": false,
-              "description": "When true, /flow:start automatically creates a FlowGoal after the Spec Validation Gate. v3.0 ships default false so /flow:start UX is byte-identical to v2.4.0; teams flip to true after one release cycle of opt-in usage."
+              "deprecated": true,
+              "description": "DEPRECATED — superseded by goalCreation (#111 AC-1). Still accepted for backward compatibility via a read-only migration: true maps to goalCreation 'always', false maps to 'off'. Absence maps to 'auto'. Set goalCreation directly in new configs."
             },
             "stopHookEnforcement": {
               "enum": ["warn", "block", "evaluator-loop"],

--- a/plugins/flow/schema.json
+++ b/plugins/flow/schema.json
@@ -295,12 +295,12 @@
             "goalCreation": {
               "enum": ["auto", "always", "off"],
               "default": "auto",
-              "description": "Controls /flow:start FlowGoal auto-creation (#111 AC-1). 'auto' (default): create a goal iff the Spec Validation Gate passed with >=1 acceptance criterion carrying a verification_command (labels do not veto); spec-free issues yielding zero verifiable ACs are skipped silently. 'always': create unconditionally (a degenerate goal is allowed but flagged in the compact summary). 'off': never auto-create; manual /flow:goal create still works. Distinct from goals.enabled:false, which disables the whole feature. The Phase 0.5 consent prompt is retired — invisible-auto is the default."
+              "description": "Controls /flow:start FlowGoal auto-creation. 'auto' (default): create a goal iff the Spec Validation Gate passed with >=1 acceptance criterion carrying a verification_command (labels do not veto); spec-free issues yielding zero verifiable ACs are skipped silently. 'always': create unconditionally (a degenerate goal is allowed but flagged in the compact summary). 'off': never auto-create; manual /flow:goal create still works. Distinct from goals.enabled:false, which disables the whole feature. There is no consent prompt — invisible-auto is the default."
             },
             "requireGoalForStart": {
               "type": "boolean",
-              "deprecated": true,
-              "description": "DEPRECATED — superseded by goalCreation (#111 AC-1). Still accepted for backward compatibility via a read-only migration: true maps to goalCreation 'always', false maps to 'off'. Absence maps to 'auto'. Set goalCreation directly in new configs."
+              "x-deprecated": true,
+              "description": "DEPRECATED — superseded by goalCreation. Still accepted for backward compatibility via a read-only migration: true maps to goalCreation 'always', false maps to 'off'. Absence maps to 'auto'. Set goalCreation directly in new configs."
             },
             "stopHookEnforcement": {
               "enum": ["warn", "block", "evaluator-loop"],

--- a/plugins/flow/settings.json
+++ b/plugins/flow/settings.json
@@ -94,7 +94,7 @@
     },
     "goals": {
       "enabled": true,
-      "requireGoalForStart": false,
+      "goalCreation": "auto",
       "stopHookEnforcement": "warn",
       "failAfterStuckTurns": 3,
       "executeVerificationCommands": false,

--- a/plugins/flow/skills/workflow-validation/SKILL.md
+++ b/plugins/flow/skills/workflow-validation/SKILL.md
@@ -20,7 +20,7 @@ The invoking command MUST pass:
 
 ## Outputs
 
-Structured JSON report on stdout. Each violation entry includes `source_file` (the YAML path that failed) and `example` (a snippet showing the corrected form) so the caller can render actionable error messages without consulting the schema separately (F15):
+Structured JSON report on stdout. Each violation entry includes `source_file` (the YAML path that failed) and `example` (a snippet showing the corrected form) so the caller can render actionable error messages without consulting the schema separately:
 
 ```json
 {
@@ -51,7 +51,7 @@ Exit code: 0 if `overall: pass`; 1 if any cross-reference, recursion, native-sla
 
 ### Step 1: Schema validation (with v3.0.x deprecation migration)
 
-**Cycle-14 F4 (error-handler verifier)**: the previous documentation showed both an in-memory migration shim AND a `python3 -m jsonschema -i <file> <schema>` invocation. The CLI re-reads the file from disk, bypassing the in-memory shim entirely. Any project-local workflow with the legacy `completion_gate.requires` field would fail schema validation despite the documented "accept legacy through v3.0.x" contract. The shim and the validator must run in the same Python process. The canonical invocation is:
+the previous documentation showed both an in-memory migration shim AND a `python3 -m jsonschema -i <file> <schema>` invocation. The CLI re-reads the file from disk, bypassing the in-memory shim entirely. Any project-local workflow with the legacy `completion_gate.requires` field would fail schema validation despite the documented "accept legacy through v3.0.x" contract. The shim and the validator must run in the same Python process. The canonical invocation is:
 
 ```bash
 python3 - "$WORKFLOW_PATH" "$SCHEMA_PATH" <<'PYEOF'
@@ -75,7 +75,7 @@ if "requires" in gate and "documented_requirements" not in gate:
         file=sys.stderr,
     )
 elif "requires" in gate and "documented_requirements" in gate:
-    # Cycle-14 F3 (code-reviewer verifier): both fields present — drop legacy,
+    # both fields present — drop legacy,
     # emit WARN. Previously the shim silently skipped this case and the schema
     # rejected the YAML with an opaque `additionalProperties` error.
     del gate["requires"]

--- a/plugins/flow/tests/cascade-resolve.test.sh
+++ b/plugins/flow/tests/cascade-resolve.test.sh
@@ -210,7 +210,7 @@ ERR=$(cat "$STDERR_TMP")
 assert_exit 2 "$EXIT" "exit 2 without --default"
 assert_contains "jq not installed" "$ERR" "stderr WARN about missing jq"
 
-# --- Compound migration expression (#111 AC-1) ───────────────────────────────
+# --- Compound migration expression ────────────────────────────────────────
 # cascade-resolve passes any jq through, but the 3-state goalCreation migration
 # relies on a compound if/elif/else-null expression that was previously untested.
 # The `else null` (not "auto") is load-bearing: a source carrying NEITHER key

--- a/plugins/flow/tests/cascade-resolve.test.sh
+++ b/plugins/flow/tests/cascade-resolve.test.sh
@@ -209,3 +209,54 @@ EXIT=$?
 ERR=$(cat "$STDERR_TMP")
 assert_exit 2 "$EXIT" "exit 2 without --default"
 assert_contains "jq not installed" "$ERR" "stderr WARN about missing jq"
+
+# --- Compound migration expression (#111 AC-1) ───────────────────────────────
+# cascade-resolve passes any jq through, but the 3-state goalCreation migration
+# relies on a compound if/elif/else-null expression that was previously untested.
+# The `else null` (not "auto") is load-bearing: a source carrying NEITHER key
+# must yield null so the cascade falls through instead of short-circuiting.
+MIG='.flow.goals.goalCreation // (if .flow.goals.requireGoalForStart == true then "always" elif .flow.goals.requireGoalForStart == false then "off" else null end)'
+
+_flow_test_begin "migration expr: requireGoalForStart:true -> always"
+DIR=$(_make_scratch mig-true)
+echo '{}' > "$DIR/plugins/flow/settings.json"
+echo '{"flow":{"goals":{"requireGoalForStart":true}}}' > "$DIR/.claude/settings.flow.json"
+OUT=$(cd "$DIR" && HOME="$DIR/home" CLAUDE_PLUGIN_ROOT="plugins/flow" "$HELPER" --default auto "$MIG" 2>/dev/null)
+assert_equal "always" "$OUT" "legacy true maps to always"
+
+_flow_test_begin "migration expr: requireGoalForStart:false -> off"
+DIR=$(_make_scratch mig-false)
+echo '{}' > "$DIR/plugins/flow/settings.json"
+echo '{"flow":{"goals":{"requireGoalForStart":false}}}' > "$DIR/.claude/settings.flow.json"
+OUT=$(cd "$DIR" && HOME="$DIR/home" CLAUDE_PLUGIN_ROOT="plugins/flow" "$HELPER" --default auto "$MIG" 2>/dev/null)
+assert_equal "off" "$OUT" "legacy false maps to off"
+
+_flow_test_begin "migration expr: no key anywhere -> auto (cascade default)"
+DIR=$(_make_scratch mig-none)
+echo '{}' > "$DIR/plugins/flow/settings.json"
+OUT=$(cd "$DIR" && HOME="$DIR/home" CLAUDE_PLUGIN_ROOT="plugins/flow" "$HELPER" --default auto "$MIG" 2>/dev/null)
+assert_equal "auto" "$OUT" "absent everywhere -> auto"
+
+_flow_test_begin "migration expr: explicit goalCreation wins"
+DIR=$(_make_scratch mig-explicit)
+echo '{}' > "$DIR/plugins/flow/settings.json"
+echo '{"flow":{"goals":{"goalCreation":"always","requireGoalForStart":false}}}' > "$DIR/.claude/settings.flow.json"
+OUT=$(cd "$DIR" && HOME="$DIR/home" CLAUDE_PLUGIN_ROOT="plugins/flow" "$HELPER" --default auto "$MIG" 2>/dev/null)
+assert_equal "always" "$OUT" "goalCreation overrides legacy key in same source"
+
+_flow_test_begin "migration expr: PRECEDENCE-LEAK GUARD — unrelated local file does not mask project requireGoalForStart"
+DIR=$(_make_scratch mig-leak)
+echo '{}' > "$DIR/plugins/flow/settings.json"
+echo '{"flow":{"goals":{"requireGoalForStart":true}}}' > "$DIR/.claude/settings.flow.json"
+# Highest-precedence local file with NO goals key (e.g. an unrelated agentTeams override).
+echo '{"agentTeams":false}' > "$DIR/.claude/settings.flow.local.json"
+OUT=$(cd "$DIR" && HOME="$DIR/home" CLAUDE_PLUGIN_ROOT="plugins/flow" "$HELPER" --default auto "$MIG" 2>/dev/null)
+assert_equal "always" "$OUT" "else-null lets the neither-key local file fall through to project (a buggy else-\"auto\" would mask it as auto)"
+
+_flow_test_begin "migration expr: explicit local goalCreation:off correctly wins over project legacy true"
+DIR=$(_make_scratch mig-localwins)
+echo '{}' > "$DIR/plugins/flow/settings.json"
+echo '{"flow":{"goals":{"requireGoalForStart":true}}}' > "$DIR/.claude/settings.flow.json"
+echo '{"flow":{"goals":{"goalCreation":"off"}}}' > "$DIR/.claude/settings.flow.local.json"
+OUT=$(cd "$DIR" && HOME="$DIR/home" CLAUDE_PLUGIN_ROOT="plugins/flow" "$HELPER" --default auto "$MIG" 2>/dev/null)
+assert_equal "off" "$OUT" "a real local goalCreation still wins (precedence preserved)"

--- a/plugins/flow/tests/command-frontmatter.test.sh
+++ b/plugins/flow/tests/command-frontmatter.test.sh
@@ -20,10 +20,10 @@
 
 COMMANDS_DIR="$REPO_ROOT/plugins/flow/commands"
 SKILLS_DIR="$REPO_ROOT/plugins/flow/skills"
-# Floor matches the current count of command files (17 as of this writing).
-# A drop below this is either a real deletion (update the floor in the same
-# PR) or a path resolution bug (find and fix). Either way: fail loudly.
-FILE_COUNT_FLOOR=15
+# Floor sits just under the current count of command files (23 as of this
+# writing). A drop below this is either a real deletion (update the floor in the
+# same PR) or a path resolution bug (find and fix). Either way: fail loudly.
+FILE_COUNT_FLOOR=20
 
 # Strip bash-style quoted spans from a body of text. Used by the $ARGUMENTS
 # lint to ignore safely-quoted occurrences. Removes "..." and '...' on a

--- a/plugins/flow/tests/command-frontmatter.test.sh
+++ b/plugins/flow/tests/command-frontmatter.test.sh
@@ -1,9 +1,9 @@
 # Static lint over plugins/flow/commands/*.md.
 #
-# What this catches (regression-of-record from PR #103 / PR #104 review cycles):
-#   - F3:  `!` block missing trailing `true` (start.md Phase 1 was the original miss)
+# What this catches:
+#   - `!` block missing trailing `true`
 #   - C4-*: `!` block silently exits non-zero from a trailing pipeline
-#   - F2/F6: $ARGUMENTS interpolated into an `!` block without quoting/validation
+#   - $ARGUMENTS interpolated into an `!` block without quoting/validation
 #   - C1:  `allowed-tools` Bash() pattern that no body invocation actually matches
 #   - Required Skills entry that doesn't resolve to a plugins/flow/skills/<name>/ dir
 #   - destructive shell commands inside an `!` block (! blocks are read-only context)
@@ -36,7 +36,7 @@ _strip_quoted() {
 }
 
 # --- Test 1: every `!` block ends with `true`, and no triple-backtick fences
-# appear inside an `!` block. The trailing-`true` check is the F3 regression
+# appear inside an `!` block. The trailing-`true` check is the regression
 # guard; the no-nested-fence assertion guarantees the awk extractor's
 # correctness (a `!` block containing a literal ``` line would silently
 # close the block early, hiding everything after it).
@@ -221,7 +221,7 @@ fi
 # --- Test 5: allowed-tools Bash(...) prefix-validation logic works
 # Currently NO flow command file uses prefix-restricted `Bash(prefix:*)`
 # patterns — they all declare full `Bash` access. The previous form of this
-# test iterated over zero patterns and trivially passed (F6/TV6). Instead,
+# test iterated over zero patterns and trivially passed. Instead,
 # exercise the logic against synthetic fixtures: one frontmatter where the
 # prefix has a matching body invocation (must PASS), one where it doesn't
 # (must FAIL the inner check).

--- a/plugins/flow/tests/flow-active-goal.test.sh
+++ b/plugins/flow/tests/flow-active-goal.test.sh
@@ -1,4 +1,4 @@
-# Tests for plugins/flow/bin/flow-active-goal.sh (cycle 13, F1/F2/F3 foundation).
+# Tests for plugins/flow/bin/flow-active-goal.sh.
 #
 # Contract:
 #   - Output modes: --path, --id, --status, --json, --ac-summary, --verifiable-count

--- a/plugins/flow/tests/flow-active-goal.test.sh
+++ b/plugins/flow/tests/flow-active-goal.test.sh
@@ -179,7 +179,7 @@ assert_contains "degenerate state" "$ERR" "stderr names the degenerate state"
 assert_contains "feature/shared" "$ERR" "stderr names the colliding branch"
 
 # --- Test 9b: 2 active goals on DIFFERENT branches → each resolves its own (exit 0)
-# This is the core AC-4 fix: concurrent goals across branches/worktrees must
+# Concurrent goals across branches/worktrees must
 # stop tripping the degenerate-state error.
 _flow_test_begin "2 active goals on different branches each resolve (exit 0)"
 DIR=$(_fag_mkdir)

--- a/plugins/flow/tests/flow-active-goal.test.sh
+++ b/plugins/flow/tests/flow-active-goal.test.sh
@@ -437,12 +437,28 @@ OUT=$(cd "$DIR" && bash "$HELPER" --id --branch feature/mine --branch-strict 2>/
 assert_equal "0" "$EXIT" "resolves the current-branch goal (exit 0)"
 assert_equal "issue-mine" "$OUT" "--branch-strict returns the current branch's own active goal"
 
-_flow_test_begin "--branch-strict + --allow-terminal: achieved-on-branch resolves; achieved-elsewhere does not"
+_flow_test_begin "--branch-strict + --allow-terminal: achieved-on-branch resolves; cross-branch (active OR achieved) does not"
 DIR=$(_fag_mkdir)
 mkdir -p "$DIR/.flow/goals"
 _fag_write_goal "$DIR/.flow/goals/issue-done-here.goal.yaml" "achieved" "issue-done-here" "feature/mine"
+# An active goal on a different branch must ALSO be suppressed under strict — so
+# querying from feature/elsewhere has both an achieved (mine) and an active
+# (other) goal available, and strict must surface NEITHER.
+_fag_write_goal "$DIR/.flow/goals/issue-active-other.goal.yaml" "active" "issue-active-other" "feature/other"
 OUT=$(cd "$DIR" && bash "$HELPER" --id --allow-terminal --branch-strict --branch feature/mine 2>/dev/null); EXIT=$?
 assert_equal "0" "$EXIT" "achieved goal on current branch resolves under strict+allow-terminal"
 assert_equal "issue-done-here" "$OUT" "returns the current-branch achieved goal"
 EXIT=$(cd "$DIR" && bash "$HELPER" --status --allow-terminal --branch-strict --branch feature/elsewhere >/dev/null 2>&1; echo $?)
-assert_equal "1" "$EXIT" "achieved goal on another branch is not applicable under strict (exit 1)"
+assert_equal "1" "$EXIT" "from a third branch, neither the cross-branch achieved nor active goal is applicable (exit 1)"
+
+_flow_test_begin "--branch-strict with UNKNOWN branch still falls back (CI / detached-HEAD safety valve)"
+# The fixture tmpdir is not a git repo, so `git branch --show-current` fails and
+# the branch is unknown (""). With nothing to discriminate on, --branch-strict
+# must STILL resolve the single active goal (this is the safety valve that keeps
+# the Stop-hook evaluator working in CI / detached HEAD).
+DIR=$(_fag_mkdir)
+mkdir -p "$DIR/.flow/goals"
+_fag_write_goal "$DIR/.flow/goals/issue-only.goal.yaml" "active" "issue-only" "feature/other"
+OUT=$(cd "$DIR" && bash "$HELPER" --id --branch-strict 2>/dev/null); EXIT=$?
+assert_equal "0" "$EXIT" "unknown branch + strict still resolves (exit 0)"
+assert_equal "issue-only" "$OUT" "falls back to the most-recent active goal when the branch is unknown"

--- a/plugins/flow/tests/flow-active-goal.test.sh
+++ b/plugins/flow/tests/flow-active-goal.test.sh
@@ -2,7 +2,7 @@
 #
 # Contract:
 #   - Output modes: --path, --id, --status, --json, --ac-summary, --verifiable-count
-#   - Branch-first selection (#111 AC-4): prefer scope.branch == current branch,
+#   - Branch-first selection: prefer scope.branch == current branch,
 #     fall back to most-recently-modified active; --branch <name> overrides detection
 #   - Exit 0: active goal found
 #   - Exit 1: no active goal
@@ -73,7 +73,7 @@ EOF
 }
 
 # Goal fixture with a controllable number of verification_command-carrying ACs,
-# for --verifiable-count and degenerate-marker tests (#111 AC-2).
+# for --verifiable-count and degenerate-marker tests.
 _fag_write_goal_vc() {
   local path="$1" status="$2" goal_id="$3" verifiable="$4" branch="${5:-feature/test}"
   {
@@ -164,7 +164,7 @@ EXIT=$(cd "$DIR" && bash "$HELPER" --status >/dev/null 2>&1; echo $?)
 assert_equal "1" "$EXIT" "exit 1 — only achieved goals exist"
 
 # --- Test 9: degenerate state — 2 active goals on the SAME (current) branch → exit 3
-# Branch-first selection (#111 AC-4): degeneracy is now scoped to the current
+# Branch-first selection: degeneracy is now scoped to the current
 # branch, so both fixtures share one branch and we pin the current branch via
 # --branch to exercise the same-branch collision deterministically.
 _flow_test_begin "2 active goals on same branch → exit 3 (degenerate)"
@@ -292,31 +292,48 @@ _fag_write_goal_vc "$DIR/.flow/goals/issue-1.goal.yaml" "active" "issue-1" 0
 OUT=$(cd "$DIR" && bash "$HELPER" --verifiable-count 2>/dev/null)
 assert_equal "2/0" "$OUT" "no AC carries a verification_command — degenerate"
 
-# --- #122: --allow-terminal surfaces achieved goals for the merge/pr gate ------
-_flow_test_begin "#122: achieved goal is hidden by default (active-only) → exit 1"
+# --- --allow-terminal: branch-scoped surfacing of achieved goals for the gate --
+_flow_test_begin "achieved goal is hidden by default (active-only) -> exit 1"
 DIR=$(_fag_mkdir)
 mkdir -p "$DIR/.flow/goals"
-_fag_write_goal "$DIR/.flow/goals/issue-72.goal.yaml" "achieved" "issue-72"
-EXIT=$(cd "$DIR" && bash "$HELPER" --status >/dev/null 2>&1; echo $?)
+_fag_write_goal "$DIR/.flow/goals/issue-72.goal.yaml" "achieved" "issue-72" "feature/done"
+EXIT=$(cd "$DIR" && bash "$HELPER" --status --branch feature/done >/dev/null 2>&1; echo $?)
 assert_equal "1" "$EXIT" "achieved goal not surfaced without --allow-terminal (Stop hook / status semantics preserved)"
 
-_flow_test_begin "#122: --allow-terminal surfaces the achieved goal (exit 0, status achieved)"
-OUT=$(cd "$DIR" && bash "$HELPER" --status --allow-terminal 2>/dev/null); EXIT=$?
-assert_equal "0" "$EXIT" "achieved goal surfaced with --allow-terminal"
-assert_equal "achieved" "$OUT" "status reads 'achieved' — makes the gate's achieved-branch reachable"
-OUT=$(cd "$DIR" && bash "$HELPER" --id --allow-terminal 2>/dev/null)
+_flow_test_begin "--allow-terminal surfaces an achieved goal that owns the current branch"
+OUT=$(cd "$DIR" && bash "$HELPER" --status --allow-terminal --branch feature/done 2>/dev/null); EXIT=$?
+assert_equal "0" "$EXIT" "achieved goal surfaced with --allow-terminal on its own branch"
+assert_equal "achieved" "$OUT" "status reads 'achieved' — the gate's achieved branch is reachable"
+OUT=$(cd "$DIR" && bash "$HELPER" --id --allow-terminal --branch feature/done 2>/dev/null)
 assert_equal "issue-72" "$OUT" "--id resolves the achieved goal"
 
-_flow_test_begin "#122: active goals take precedence over achieved under --allow-terminal"
+_flow_test_begin "achieved goal is NOT surfaced cross-branch (no terminal mtime fallback)"
+# A planted or stale achieved goal on another branch must never answer the gate
+# for the current branch.
+OUT=$(cd "$DIR" && bash "$HELPER" --status --allow-terminal --branch feature/other 2>/dev/null); EXIT=$?
+assert_equal "1" "$EXIT" "achieved goal on a different branch is not applicable (exit 1)"
+
+_flow_test_begin "active goal on the current branch beats an achieved goal on the same branch"
 DIR=$(_fag_mkdir)
 mkdir -p "$DIR/.flow/goals"
 _fag_write_goal "$DIR/.flow/goals/issue-done.goal.yaml" "achieved" "issue-done" "feature/x"
 _fag_write_goal "$DIR/.flow/goals/issue-live.goal.yaml" "active" "issue-live" "feature/x"
 OUT=$(cd "$DIR" && bash "$HELPER" --id --allow-terminal --branch feature/x 2>/dev/null); EXIT=$?
 assert_equal "0" "$EXIT" "resolves (exit 0)"
-assert_equal "issue-live" "$OUT" "active goal wins over achieved fallback"
+assert_equal "issue-live" "$OUT" "active goal wins over achieved on the same branch"
 
-_flow_test_begin "#122: achieved fallback is branch-first too"
+_flow_test_begin "branch ownership beats lifecycle status: achieved-on-current > active-cross-branch"
+# Branch ownership takes priority over status — an achieved goal owning the
+# current branch must beat an active goal on a different branch.
+DIR=$(_fag_mkdir)
+mkdir -p "$DIR/.flow/goals"
+_fag_write_goal "$DIR/.flow/goals/issue-other.goal.yaml" "active" "issue-other" "feature/aaa"
+_fag_write_goal "$DIR/.flow/goals/issue-mine.goal.yaml" "achieved" "issue-mine" "feature/bbb"
+OUT=$(cd "$DIR" && bash "$HELPER" --id --allow-terminal --branch feature/bbb 2>/dev/null); EXIT=$?
+assert_equal "0" "$EXIT" "resolves (exit 0)"
+assert_equal "issue-mine" "$OUT" "achieved goal on current branch beats active goal on another branch"
+
+_flow_test_begin "achieved fallback prefers the current branch among multiple achieved"
 DIR=$(_fag_mkdir)
 mkdir -p "$DIR/.flow/goals"
 _fag_write_goal "$DIR/.flow/goals/issue-a.goal.yaml" "achieved" "issue-a" "feature/aaa"
@@ -324,7 +341,7 @@ _fag_write_goal "$DIR/.flow/goals/issue-b.goal.yaml" "achieved" "issue-b" "featu
 OUT=$(cd "$DIR" && bash "$HELPER" --id --allow-terminal --branch feature/bbb 2>/dev/null)
 assert_equal "issue-b" "$OUT" "achieved goal on the current branch is preferred"
 
-_flow_test_begin "#122: multiple achieved goals on one branch do NOT trip exit 3 (history is normal)"
+_flow_test_begin "multiple achieved goals on one branch do NOT trip exit 3 (history is normal)"
 DIR=$(_fag_mkdir)
 mkdir -p "$DIR/.flow/goals"
 _fag_write_goal "$DIR/.flow/goals/issue-1.goal.yaml" "achieved" "issue-1" "feature/x"
@@ -334,9 +351,66 @@ OUT=$(cd "$DIR" && bash "$HELPER" --id --allow-terminal --branch feature/x 2>/de
 assert_equal "0" "$EXIT" "no degenerate error for multiple achieved on a branch"
 assert_equal "issue-2" "$OUT" "most-recently-modified achieved goal wins"
 
-_flow_test_begin "#122: failed/cancelled goals are NOT surfaced even with --allow-terminal"
+_flow_test_begin "failed/cancelled goals are NOT surfaced even with --allow-terminal"
 DIR=$(_fag_mkdir)
 mkdir -p "$DIR/.flow/goals"
-_fag_write_goal "$DIR/.flow/goals/issue-x.goal.yaml" "cancelled" "issue-x"
-EXIT=$(cd "$DIR" && bash "$HELPER" --status --allow-terminal >/dev/null 2>&1; echo $?)
+_fag_write_goal "$DIR/.flow/goals/issue-x.goal.yaml" "cancelled" "issue-x" "feature/x"
+EXIT=$(cd "$DIR" && bash "$HELPER" --status --allow-terminal --branch feature/x >/dev/null 2>&1; echo $?)
 assert_equal "1" "$EXIT" "only 'achieved' is a gate-relevant terminal state; cancelled stays out of window"
+
+# --- robustness: degenerate AC shapes + legacy goals ---------------------------
+_flow_test_begin "--verifiable-count on a goal with zero ACs -> 0/0"
+DIR=$(_fag_mkdir)
+mkdir -p "$DIR/.flow/goals"
+cat > "$DIR/.flow/goals/issue-empty.goal.yaml" <<'EOF'
+apiVersion: flow.synapti.ai/v1
+kind: FlowGoal
+metadata: { id: issue-empty, created_at: "2026-05-21T00:00:00Z" }
+scope: { repo: owner/example, branch: feature/test }
+objective:
+  outcome: Test outcome
+  acceptance_criteria: []
+evaluator: { type: hybrid }
+lifecycle: { status: active }
+EOF
+OUT=$(cd "$DIR" && bash "$HELPER" --verifiable-count --branch feature/test 2>/dev/null); EXIT=$?
+assert_equal "0" "$EXIT" "resolves (exit 0)"
+assert_equal "0/0" "$OUT" "empty acceptance_criteria reports 0/0 (degenerate)"
+
+_flow_test_begin "--verifiable-count / --ac-summary tolerate a non-list acceptance_criteria (no crash)"
+DIR=$(_fag_mkdir)
+mkdir -p "$DIR/.flow/goals"
+cat > "$DIR/.flow/goals/issue-bad.goal.yaml" <<'EOF'
+apiVersion: flow.synapti.ai/v1
+kind: FlowGoal
+metadata: { id: issue-bad, created_at: "2026-05-21T00:00:00Z" }
+scope: { repo: owner/example, branch: feature/test }
+objective:
+  outcome: Test outcome
+  acceptance_criteria: 42
+evaluator: { type: hybrid }
+lifecycle: { status: active }
+EOF
+OUT=$(cd "$DIR" && bash "$HELPER" --verifiable-count --branch feature/test 2>/dev/null); EXIT=$?
+assert_equal "0" "$EXIT" "non-list acceptance_criteria does not crash --verifiable-count"
+assert_equal "0/0" "$OUT" "scalar acceptance_criteria treated as zero ACs"
+OUT=$(cd "$DIR" && bash "$HELPER" --ac-summary --branch feature/test 2>/dev/null); EXIT=$?
+assert_equal "0" "$EXIT" "non-list acceptance_criteria does not crash --ac-summary"
+
+_flow_test_begin "legacy goal with no scope.branch resolves via the most-recent-active fallback"
+DIR=$(_fag_mkdir)
+mkdir -p "$DIR/.flow/goals"
+cat > "$DIR/.flow/goals/issue-legacy.goal.yaml" <<'EOF'
+apiVersion: flow.synapti.ai/v1
+kind: FlowGoal
+metadata: { id: issue-legacy, created_at: "2026-05-21T00:00:00Z" }
+objective:
+  outcome: Test outcome
+  acceptance_criteria:
+    - { id: AC1, text: First, status: pending }
+evaluator: { type: hybrid }
+lifecycle: { status: active }
+EOF
+OUT=$(cd "$DIR" && bash "$HELPER" --id --branch feature/anything 2>/dev/null); EXIT=$?
+assert_equal "0" "$EXIT" "legacy goal (no scope.branch) still resolves via mtime fallback"
+assert_equal "issue-legacy" "$OUT" "the active legacy goal is returned"

--- a/plugins/flow/tests/flow-active-goal.test.sh
+++ b/plugins/flow/tests/flow-active-goal.test.sh
@@ -291,3 +291,52 @@ mkdir -p "$DIR/.flow/goals"
 _fag_write_goal_vc "$DIR/.flow/goals/issue-1.goal.yaml" "active" "issue-1" 0
 OUT=$(cd "$DIR" && bash "$HELPER" --verifiable-count 2>/dev/null)
 assert_equal "2/0" "$OUT" "no AC carries a verification_command — degenerate"
+
+# --- #122: --allow-terminal surfaces achieved goals for the merge/pr gate ------
+_flow_test_begin "#122: achieved goal is hidden by default (active-only) → exit 1"
+DIR=$(_fag_mkdir)
+mkdir -p "$DIR/.flow/goals"
+_fag_write_goal "$DIR/.flow/goals/issue-72.goal.yaml" "achieved" "issue-72"
+EXIT=$(cd "$DIR" && bash "$HELPER" --status >/dev/null 2>&1; echo $?)
+assert_equal "1" "$EXIT" "achieved goal not surfaced without --allow-terminal (Stop hook / status semantics preserved)"
+
+_flow_test_begin "#122: --allow-terminal surfaces the achieved goal (exit 0, status achieved)"
+OUT=$(cd "$DIR" && bash "$HELPER" --status --allow-terminal 2>/dev/null); EXIT=$?
+assert_equal "0" "$EXIT" "achieved goal surfaced with --allow-terminal"
+assert_equal "achieved" "$OUT" "status reads 'achieved' — makes the gate's achieved-branch reachable"
+OUT=$(cd "$DIR" && bash "$HELPER" --id --allow-terminal 2>/dev/null)
+assert_equal "issue-72" "$OUT" "--id resolves the achieved goal"
+
+_flow_test_begin "#122: active goals take precedence over achieved under --allow-terminal"
+DIR=$(_fag_mkdir)
+mkdir -p "$DIR/.flow/goals"
+_fag_write_goal "$DIR/.flow/goals/issue-done.goal.yaml" "achieved" "issue-done" "feature/x"
+_fag_write_goal "$DIR/.flow/goals/issue-live.goal.yaml" "active" "issue-live" "feature/x"
+OUT=$(cd "$DIR" && bash "$HELPER" --id --allow-terminal --branch feature/x 2>/dev/null); EXIT=$?
+assert_equal "0" "$EXIT" "resolves (exit 0)"
+assert_equal "issue-live" "$OUT" "active goal wins over achieved fallback"
+
+_flow_test_begin "#122: achieved fallback is branch-first too"
+DIR=$(_fag_mkdir)
+mkdir -p "$DIR/.flow/goals"
+_fag_write_goal "$DIR/.flow/goals/issue-a.goal.yaml" "achieved" "issue-a" "feature/aaa"
+_fag_write_goal "$DIR/.flow/goals/issue-b.goal.yaml" "achieved" "issue-b" "feature/bbb"
+OUT=$(cd "$DIR" && bash "$HELPER" --id --allow-terminal --branch feature/bbb 2>/dev/null)
+assert_equal "issue-b" "$OUT" "achieved goal on the current branch is preferred"
+
+_flow_test_begin "#122: multiple achieved goals on one branch do NOT trip exit 3 (history is normal)"
+DIR=$(_fag_mkdir)
+mkdir -p "$DIR/.flow/goals"
+_fag_write_goal "$DIR/.flow/goals/issue-1.goal.yaml" "achieved" "issue-1" "feature/x"
+sleep 1
+_fag_write_goal "$DIR/.flow/goals/issue-2.goal.yaml" "achieved" "issue-2" "feature/x"
+OUT=$(cd "$DIR" && bash "$HELPER" --id --allow-terminal --branch feature/x 2>/dev/null); EXIT=$?
+assert_equal "0" "$EXIT" "no degenerate error for multiple achieved on a branch"
+assert_equal "issue-2" "$OUT" "most-recently-modified achieved goal wins"
+
+_flow_test_begin "#122: failed/cancelled goals are NOT surfaced even with --allow-terminal"
+DIR=$(_fag_mkdir)
+mkdir -p "$DIR/.flow/goals"
+_fag_write_goal "$DIR/.flow/goals/issue-x.goal.yaml" "cancelled" "issue-x"
+EXIT=$(cd "$DIR" && bash "$HELPER" --status --allow-terminal >/dev/null 2>&1; echo $?)
+assert_equal "1" "$EXIT" "only 'achieved' is a gate-relevant terminal state; cancelled stays out of window"

--- a/plugins/flow/tests/flow-active-goal.test.sh
+++ b/plugins/flow/tests/flow-active-goal.test.sh
@@ -1,11 +1,13 @@
 # Tests for plugins/flow/bin/flow-active-goal.sh (cycle 13, F1/F2/F3 foundation).
 #
 # Contract:
-#   - Output modes: --path, --id, --status, --json, --ac-summary
+#   - Output modes: --path, --id, --status, --json, --ac-summary, --verifiable-count
+#   - Branch-first selection (#111 AC-4): prefer scope.branch == current branch,
+#     fall back to most-recently-modified active; --branch <name> overrides detection
 #   - Exit 0: active goal found
 #   - Exit 1: no active goal
 #   - Exit 2: infrastructure error (missing python3/PyYAML or symlink rejected)
-#   - Exit 3: degenerate state (multiple active goals)
+#   - Exit 3: degenerate state (>1 active goal on the current branch)
 #   - Symlink defense on .flow/goals/ AND individual goal YAMLs
 
 HELPER="$REPO_ROOT/plugins/flow/bin/flow-active-goal.sh"
@@ -42,7 +44,7 @@ fi
 # (we don't run jsonschema here — only the helper's lifecycle.status check
 # needs to be exercised).
 _fag_write_goal() {
-  local path="$1" status="$2" goal_id="$3"
+  local path="$1" status="$2" goal_id="$3" branch="${4:-feature/test}"
   cat > "$path" <<EOF
 apiVersion: flow.synapti.ai/v1
 kind: FlowGoal
@@ -51,7 +53,7 @@ metadata:
   created_at: "2026-05-21T00:00:00Z"
 scope:
   repo: owner/example
-  branch: feature/test
+  branch: ${branch}
 objective:
   outcome: Test outcome
   acceptance_criteria:
@@ -68,6 +70,42 @@ evaluator:
 lifecycle:
   status: ${status}
 EOF
+}
+
+# Goal fixture with a controllable number of verification_command-carrying ACs,
+# for --verifiable-count and degenerate-marker tests (#111 AC-2).
+_fag_write_goal_vc() {
+  local path="$1" status="$2" goal_id="$3" verifiable="$4" branch="${5:-feature/test}"
+  {
+    cat <<EOF
+apiVersion: flow.synapti.ai/v1
+kind: FlowGoal
+metadata:
+  id: ${goal_id}
+  created_at: "2026-05-21T00:00:00Z"
+scope:
+  repo: owner/example
+  branch: ${branch}
+objective:
+  outcome: Test outcome
+  acceptance_criteria:
+EOF
+    # AC1 always present; carries a verification_command iff verifiable >= 1.
+    echo "    - id: AC1"
+    echo "      text: First criterion"
+    echo "      status: pending"
+    [ "$verifiable" -ge 1 ] && echo "      verification_command: \"bash tests/run.sh\""
+    echo "    - id: AC2"
+    echo "      text: Second criterion"
+    echo "      status: pending"
+    [ "$verifiable" -ge 2 ] && echo "      verification_command: \"npm test\""
+    cat <<EOF
+evaluator:
+  type: hybrid
+lifecycle:
+  status: ${status}
+EOF
+  } > "$path"
 }
 
 # --- Test 1: no .flow/ → exit 1
@@ -125,16 +163,56 @@ _fag_write_goal "$DIR/.flow/goals/issue-1.goal.yaml" "achieved" "issue-1"
 EXIT=$(cd "$DIR" && bash "$HELPER" --status >/dev/null 2>&1; echo $?)
 assert_equal "1" "$EXIT" "exit 1 — only achieved goals exist"
 
-# --- Test 9: degenerate state — 2 active goals → exit 3
-_flow_test_begin "2 active goals → exit 3 (degenerate)"
+# --- Test 9: degenerate state — 2 active goals on the SAME (current) branch → exit 3
+# Branch-first selection (#111 AC-4): degeneracy is now scoped to the current
+# branch, so both fixtures share one branch and we pin the current branch via
+# --branch to exercise the same-branch collision deterministically.
+_flow_test_begin "2 active goals on same branch → exit 3 (degenerate)"
 DIR=$(_fag_mkdir)
 mkdir -p "$DIR/.flow/goals"
-_fag_write_goal "$DIR/.flow/goals/issue-a.goal.yaml" "active" "issue-a"
-_fag_write_goal "$DIR/.flow/goals/issue-b.goal.yaml" "active" "issue-b"
-ERR=$(cd "$DIR" && bash "$HELPER" --status 2>&1 >/dev/null)
-EXIT=$(cd "$DIR" && bash "$HELPER" --status >/dev/null 2>&1; echo $?)
-assert_equal "3" "$EXIT" "exit 3 — degenerate"
+_fag_write_goal "$DIR/.flow/goals/issue-a.goal.yaml" "active" "issue-a" "feature/shared"
+_fag_write_goal "$DIR/.flow/goals/issue-b.goal.yaml" "active" "issue-b" "feature/shared"
+ERR=$(cd "$DIR" && bash "$HELPER" --status --branch feature/shared 2>&1 >/dev/null)
+EXIT=$(cd "$DIR" && bash "$HELPER" --status --branch feature/shared >/dev/null 2>&1; echo $?)
+assert_equal "3" "$EXIT" "exit 3 — degenerate on the current branch"
 assert_contains "degenerate state" "$ERR" "stderr names the degenerate state"
+assert_contains "feature/shared" "$ERR" "stderr names the colliding branch"
+
+# --- Test 9b: 2 active goals on DIFFERENT branches → each resolves its own (exit 0)
+# This is the core AC-4 fix: concurrent goals across branches/worktrees must
+# stop tripping the degenerate-state error.
+_flow_test_begin "2 active goals on different branches each resolve (exit 0)"
+DIR=$(_fag_mkdir)
+mkdir -p "$DIR/.flow/goals"
+_fag_write_goal "$DIR/.flow/goals/issue-a.goal.yaml" "active" "issue-a" "feature/aaa"
+_fag_write_goal "$DIR/.flow/goals/issue-b.goal.yaml" "active" "issue-b" "feature/bbb"
+OUT_A=$(cd "$DIR" && bash "$HELPER" --id --branch feature/aaa 2>/dev/null); EXIT_A=$?
+OUT_B=$(cd "$DIR" && bash "$HELPER" --id --branch feature/bbb 2>/dev/null); EXIT_B=$?
+assert_equal "0" "$EXIT_A" "branch aaa resolves (exit 0)"
+assert_equal "issue-a" "$OUT_A" "branch aaa returns its own goal"
+assert_equal "0" "$EXIT_B" "branch bbb resolves (exit 0)"
+assert_equal "issue-b" "$OUT_B" "branch bbb returns its own goal"
+
+# --- Test 9c: no goal owns the current branch → fall back to most-recently-modified
+_flow_test_begin "no branch match → fall back to most-recently-modified active"
+DIR=$(_fag_mkdir)
+mkdir -p "$DIR/.flow/goals"
+_fag_write_goal "$DIR/.flow/goals/issue-old.goal.yaml" "active" "issue-old" "feature/aaa"
+sleep 1
+_fag_write_goal "$DIR/.flow/goals/issue-new.goal.yaml" "active" "issue-new" "feature/bbb"
+OUT=$(cd "$DIR" && bash "$HELPER" --id --branch feature/unrelated 2>/dev/null); EXIT=$?
+assert_equal "0" "$EXIT" "fallback resolves (exit 0)"
+assert_equal "issue-new" "$OUT" "fallback returns the most-recently-modified active goal"
+
+# --- Test 9d: --branch requires a value
+_flow_test_begin "--branch without value → exit 2"
+DIR=$(_fag_mkdir)
+mkdir -p "$DIR/.flow/goals"
+_fag_write_goal "$DIR/.flow/goals/issue-1.goal.yaml" "active" "issue-1"
+ERR=$(cd "$DIR" && bash "$HELPER" --branch 2>&1 >/dev/null)
+EXIT=$(cd "$DIR" && bash "$HELPER" --branch >/dev/null 2>&1; echo $?)
+assert_equal "2" "$EXIT" "exit 2 when --branch has no value"
+assert_contains "--branch requires a value" "$ERR" "stderr names the missing value"
 
 # --- Test 10: symlink at .flow/goals/ is refused
 _flow_test_begin "symlinked .flow/goals/ → exit 2"
@@ -188,3 +266,28 @@ ERR=$(cd "$DIR" && bash "$HELPER" --status --id 2>&1 >/dev/null)
 EXIT=$(cd "$DIR" && bash "$HELPER" --status --id >/dev/null 2>&1; echo $?)
 assert_equal "2" "$EXIT" "exit 2 — only one mode allowed"
 assert_contains "only one mode flag" "$ERR" "stderr names the conflict"
+
+# --- Test 15: --verifiable-count reports total/verifiable (both ACs verifiable)
+_flow_test_begin "--verifiable-count: 2 ACs, 2 verifiable → 2/2"
+DIR=$(_fag_mkdir)
+mkdir -p "$DIR/.flow/goals"
+_fag_write_goal_vc "$DIR/.flow/goals/issue-1.goal.yaml" "active" "issue-1" 2
+OUT=$(cd "$DIR" && bash "$HELPER" --verifiable-count 2>/dev/null); EXIT=$?
+assert_equal "0" "$EXIT" "exit 0 with active goal"
+assert_equal "2/2" "$OUT" "2 total ACs, 2 carry verification_command"
+
+# --- Test 16: --verifiable-count with one verifiable AC → 2/1
+_flow_test_begin "--verifiable-count: 2 ACs, 1 verifiable → 2/1"
+DIR=$(_fag_mkdir)
+mkdir -p "$DIR/.flow/goals"
+_fag_write_goal_vc "$DIR/.flow/goals/issue-1.goal.yaml" "active" "issue-1" 1
+OUT=$(cd "$DIR" && bash "$HELPER" --verifiable-count 2>/dev/null)
+assert_equal "2/1" "$OUT" "1 of 2 ACs carries a verification_command"
+
+# --- Test 17: --verifiable-count degenerate (0 verifiable) → 2/0
+_flow_test_begin "--verifiable-count: 2 ACs, 0 verifiable → 2/0 (degenerate)"
+DIR=$(_fag_mkdir)
+mkdir -p "$DIR/.flow/goals"
+_fag_write_goal_vc "$DIR/.flow/goals/issue-1.goal.yaml" "active" "issue-1" 0
+OUT=$(cd "$DIR" && bash "$HELPER" --verifiable-count 2>/dev/null)
+assert_equal "2/0" "$OUT" "no AC carries a verification_command — degenerate"

--- a/plugins/flow/tests/flow-active-goal.test.sh
+++ b/plugins/flow/tests/flow-active-goal.test.sh
@@ -414,3 +414,35 @@ EOF
 OUT=$(cd "$DIR" && bash "$HELPER" --id --branch feature/anything 2>/dev/null); EXIT=$?
 assert_equal "0" "$EXIT" "legacy goal (no scope.branch) still resolves via mtime fallback"
 assert_equal "issue-legacy" "$OUT" "the active legacy goal is returned"
+
+# --- --branch-strict: gate/evaluator callers never resolve a cross-branch goal -
+_flow_test_begin "--branch-strict: no goal on current branch + active goal elsewhere -> exit 1"
+DIR=$(_fag_mkdir)
+mkdir -p "$DIR/.flow/goals"
+_fag_write_goal "$DIR/.flow/goals/issue-elsewhere.goal.yaml" "active" "issue-elsewhere" "feature/other"
+# Lenient (default) resolves the cross-branch goal via the mtime fallback...
+OUT=$(cd "$DIR" && bash "$HELPER" --id --branch feature/mine 2>/dev/null); EXIT=$?
+assert_equal "0" "$EXIT" "lenient mode falls back cross-branch (exit 0)"
+assert_equal "issue-elsewhere" "$OUT" "lenient mode returns the cross-branch active goal"
+# ...but --branch-strict refuses it: this branch owns no goal -> not applicable.
+EXIT=$(cd "$DIR" && bash "$HELPER" --status --branch feature/mine --branch-strict >/dev/null 2>&1; echo $?)
+assert_equal "1" "$EXIT" "--branch-strict suppresses the cross-branch fallback (exit 1)"
+
+_flow_test_begin "--branch-strict: active goal owning the current branch still resolves"
+DIR=$(_fag_mkdir)
+mkdir -p "$DIR/.flow/goals"
+_fag_write_goal "$DIR/.flow/goals/issue-mine.goal.yaml" "active" "issue-mine" "feature/mine"
+_fag_write_goal "$DIR/.flow/goals/issue-other.goal.yaml" "active" "issue-other" "feature/other"
+OUT=$(cd "$DIR" && bash "$HELPER" --id --branch feature/mine --branch-strict 2>/dev/null); EXIT=$?
+assert_equal "0" "$EXIT" "resolves the current-branch goal (exit 0)"
+assert_equal "issue-mine" "$OUT" "--branch-strict returns the current branch's own active goal"
+
+_flow_test_begin "--branch-strict + --allow-terminal: achieved-on-branch resolves; achieved-elsewhere does not"
+DIR=$(_fag_mkdir)
+mkdir -p "$DIR/.flow/goals"
+_fag_write_goal "$DIR/.flow/goals/issue-done-here.goal.yaml" "achieved" "issue-done-here" "feature/mine"
+OUT=$(cd "$DIR" && bash "$HELPER" --id --allow-terminal --branch-strict --branch feature/mine 2>/dev/null); EXIT=$?
+assert_equal "0" "$EXIT" "achieved goal on current branch resolves under strict+allow-terminal"
+assert_equal "issue-done-here" "$OUT" "returns the current-branch achieved goal"
+EXIT=$(cd "$DIR" && bash "$HELPER" --status --allow-terminal --branch-strict --branch feature/elsewhere >/dev/null 2>&1; echo $?)
+assert_equal "1" "$EXIT" "achieved goal on another branch is not applicable under strict (exit 1)"

--- a/plugins/flow/tests/flow-cycle14-behavioral.test.sh
+++ b/plugins/flow/tests/flow-cycle14-behavioral.test.sh
@@ -3,10 +3,8 @@
 #
 # Covered:
 #   - workflow-validation migration shim accepts legacy `requires` field
-#   - _check_stuck increments counter on unchanged delta, resets on
-#     progress/regress, transitions goal to failed at threshold, writes
-#     the stuck-detection-fired event, and fails honestly when the transition
-#     write fails
+#   - _check_stuck counter increments on unchanged delta and resets on
+#     progress/regress; symlink guard rejects a counter-file swap
 #   - goal-evaluator SKILL.md documents the proposed_transition contract
 #     (skill does NOT write terminal status; caller persists)
 
@@ -21,7 +19,7 @@ trap _c14_cleanup EXIT
 
 _c14_mktmp() {
   local out
-  out=$(mktemp -d -t flow-.tests.XXXXXX 2>/dev/null)
+  out=$(mktemp -d -t flow-behavioral.tests.XXXXXX 2>/dev/null)
   [ -z "$out" ] && { echo "mktemp failed" >&2; exit 2; }
   C14_CLEANUP_PATHS+=("$out")
   printf '%s' "$out"
@@ -278,7 +276,7 @@ DIR=$(_c14_mktmp)
 mkdir -p "$DIR/.claude"
 echo '{"flow":{"workflows":{"enabled":false}}}' > "$DIR/.claude/settings.flow.json"
 RESULT=$(cd "$DIR" && "$REPO_ROOT/plugins/flow/bin/cascade-resolve.sh" --default "default-fallback" '.flow.workflows.enabled')
-assert_equal "false" "$RESULT" "bare expression returns 'false' (was always 'true' before )"
+assert_equal "false" "$RESULT" "bare expression returns 'false' (was always 'true' before this fix)"
 
 # Compare against // empty which still swallows false (legacy callers)
 _flow_test_begin "cascade-resolve.sh + // empty still falls through on false (backward-compat for non-boolean callers)"

--- a/plugins/flow/tests/flow-cycle14-behavioral.test.sh
+++ b/plugins/flow/tests/flow-cycle14-behavioral.test.sh
@@ -1,15 +1,14 @@
-# Behavioral tests for cycle-13 fixes that previously had source-presence-only
-# coverage. Upgraded in cycle 14 (paired-reviewer test-skeptic S1-S6 +
-# test-verifier F6-V1/F9-V1/F10-V1 surfaced the gaps).
+# Behavioral tests for command/hook behaviors that previously had only
+# source-presence coverage.
 #
 # Covered:
-#   F4 — workflow-validation migration shim accepts legacy `requires` field
-#   F9 — _check_stuck increments counter on unchanged delta, resets on
-#        progress/regress, transitions goal to failed at threshold, writes
-#        stuck-detection-fired event, fails honestly when transition write
-#        fails
-#   F10 — goal-evaluator SKILL.md documents the proposed_transition contract
-#         (skill does NOT write terminal status; caller persists)
+#   - workflow-validation migration shim accepts legacy `requires` field
+#   - _check_stuck increments counter on unchanged delta, resets on
+#     progress/regress, transitions goal to failed at threshold, writes
+#     the stuck-detection-fired event, and fails honestly when the transition
+#     write fails
+#   - goal-evaluator SKILL.md documents the proposed_transition contract
+#     (skill does NOT write terminal status; caller persists)
 
 C14_CLEANUP_PATHS=()
 _c14_cleanup() {
@@ -22,7 +21,7 @@ trap _c14_cleanup EXIT
 
 _c14_mktmp() {
   local out
-  out=$(mktemp -d -t flow-cycle14.tests.XXXXXX 2>/dev/null)
+  out=$(mktemp -d -t flow-.tests.XXXXXX 2>/dev/null)
   [ -z "$out" ] && { echo "mktemp failed" >&2; exit 2; }
   C14_CLEANUP_PATHS+=("$out")
   printf '%s' "$out"
@@ -44,8 +43,8 @@ if ! python3 -c "import jsonschema" >/dev/null 2>&1; then
   return 0
 fi
 
-# --- F4 — migration shim accepts legacy `requires` field with WARN
-_flow_test_begin "F4 — workflow-validation migration shim accepts legacy 'requires'"
+# --- migration shim accepts legacy `requires` field with WARN
+_flow_test_begin "workflow-validation migration shim accepts legacy 'requires'"
 
 SCHEMA="$REPO_ROOT/plugins/flow/schemas/v1/workflow.schema.json"
 DIR=$(_c14_mktmp)
@@ -100,7 +99,7 @@ assert_contains "deprecated" "$RESULT" "WARN names deprecation"
 assert_contains "schema_valid: true" "$RESULT" "post-migration validation passes"
 
 # Both-fields-present case: drop legacy + WARN
-_flow_test_begin "F4 — migration shim drops legacy when both fields present"
+_flow_test_begin "migration shim drops legacy when both fields present"
 cat > "$DIR/both.yaml" <<'EOF'
 apiVersion: flow.synapti.ai/v1
 kind: FlowWorkflow
@@ -149,8 +148,8 @@ assert_contains "schema_valid: true" "$RESULT" "both-fields validates after drop
 assert_contains "dropping legacy" "$RESULT" "WARN names the drop"
 
 
-# --- F9 — _check_stuck behavioral: 3 unchanged turns → goal failed
-_flow_test_begin "F9 — stuck-counter file increments on unchanged delta"
+# --- _check_stuck behavioral: 3 unchanged turns → goal failed
+_flow_test_begin "stuck-counter file increments on unchanged delta"
 
 DIR=$(_c14_mktmp)
 cd "$DIR"
@@ -174,7 +173,7 @@ assert_equal "0" "$RESET" "counter resets to 0 on non-unchanged delta"
 
 cd - >/dev/null
 
-_flow_test_begin "F9 — symlink defense on stuck-counter rejects swap"
+_flow_test_begin "symlink defense on stuck-counter rejects swap"
 DIR=$(_c14_mktmp)
 cd "$DIR"
 mkdir -p .flow/runs/test-run
@@ -191,8 +190,8 @@ rm -f /tmp/hostile-target.$$
 cd - >/dev/null
 
 
-# --- F10 — goal-evaluator SKILL.md documents proposed_transition contract
-_flow_test_begin "F10 — goal-evaluator SKILL.md describes proposed_transition + caller-side write"
+# --- goal-evaluator SKILL.md documents proposed_transition contract
+_flow_test_begin "goal-evaluator SKILL.md describes proposed_transition + caller-side write"
 
 SKILL_PATH="$REPO_ROOT/plugins/flow/skills/goal-evaluator/SKILL.md"
 if [ ! -f "$SKILL_PATH" ]; then
@@ -206,13 +205,13 @@ else
   assert_contains "Non-terminal transitions" "$CONTENT" "Non-terminal branch documented separately"
 fi
 
-_flow_test_begin "F10 — /flow:goal evaluate command documents the three confirm options"
+_flow_test_begin "/flow:goal evaluate command documents the three confirm options"
 GOAL_CMD="$REPO_ROOT/plugins/flow/commands/goal.md"
 if [ ! -f "$GOAL_CMD" ]; then
   _flow_assert_fail "goal.md missing"
 else
   CONTENT=$(cat "$GOAL_CMD")
-  assert_contains "Terminal-transition Tier 2 confirmation" "$CONTENT" "F10 confirmation section heading"
+  assert_contains "Terminal-transition Tier 2 confirmation" "$CONTENT" "confirmation section heading"
   assert_contains "Confirm" "$CONTENT" "Confirm option"
   assert_contains "Re-evaluate" "$CONTENT" "Re-evaluate option"
   assert_contains "Cancel" "$CONTENT" "Cancel option"
@@ -231,8 +230,8 @@ assert_contains "STATE=unavailable" "$CONTENT" "unavailable state documented"
 assert_contains "STATE=disabled" "$CONTENT" "disabled state (enabled:false / goalCreation:off) documented"
 
 
-# --- F8 — throttle and stuck events both have their own emit sites
-_flow_test_begin "F8 — flow-goal-evaluator emits TWO distinct event types"
+# --- throttle and stuck events both have their own emit sites
+_flow_test_begin "flow-goal-evaluator emits TWO distinct event types"
 HOOK="$REPO_ROOT/plugins/flow/hooks/scripts/flow-goal-evaluator.sh"
 CONTENT=$(cat "$HOOK")
 # Use grep -c with a literal string to count occurrences
@@ -245,7 +244,7 @@ else
 fi
 
 # Symlink defense on BOTH events.jsonl write sites
-_flow_test_begin "F8 — events.jsonl writes guarded by symlink check"
+_flow_test_begin "events.jsonl writes guarded by symlink check"
 SYMLINK_GUARD_COUNT=$(grep -c 'is a symlink' "$HOOK" 2>/dev/null)
 # Expected at least 3: throttle events.jsonl + stuck events.jsonl + stuck-counter symlink check
 if [ "$SYMLINK_GUARD_COUNT" -ge "3" ]; then
@@ -256,38 +255,38 @@ fi
 
 
 # --- Schema patterns: run_id, target.workflow constrained
-_flow_test_begin "SEC-1 — goal.schema.json constrains scope.run_id to safe pattern"
+_flow_test_begin "goal.schema.json constrains scope.run_id to safe pattern"
 RUN_ID_PATTERN=$(jq -r '.properties.scope.properties.run_id.pattern // "absent"' "$REPO_ROOT/plugins/flow/schemas/v1/goal.schema.json")
 assert_contains "[A-Za-z0-9]" "$RUN_ID_PATTERN" "run_id pattern present and starts with safe char class"
 
-_flow_test_begin "SEC-6 — trigger.schema.json constrains target.workflow + target.goal patterns"
+_flow_test_begin "trigger.schema.json constrains target.workflow + target.goal patterns"
 WF_PATTERN=$(jq -r '.properties.target.properties.workflow.pattern // "absent"' "$REPO_ROOT/plugins/flow/schemas/v1/trigger.schema.json")
 GOAL_PATTERN=$(jq -r '.properties.target.properties.goal.pattern // "absent"' "$REPO_ROOT/plugins/flow/schemas/v1/trigger.schema.json")
 assert_contains "[a-z0-9]" "$WF_PATTERN" "target.workflow pattern present"
 assert_contains "[a-z0-9]" "$GOAL_PATTERN" "target.goal pattern present"
 
 
-# --- Cascade `null` recognition of explicit false (cycle-14 SEC-V4)
+# --- Cascade `null` recognition of explicit false
 #
 # Both `// empty` and `// null` in jq trigger on null AND false (both are
 # "falsy" per jq's // operator semantics) — so neither preserves an explicit
 # false. The fix is BOTH: (a) cascade-resolve treats "null" output as
 # not-found, AND (b) callers use BARE expressions (no //) so jq outputs
 # "false" / "true" / "null" verbatim.
-_flow_test_begin "SEC-V4 — cascade-resolve.sh with bare expression returns 'false' for explicit false"
+_flow_test_begin "cascade-resolve.sh with bare expression returns 'false' for explicit false"
 DIR=$(_c14_mktmp)
 mkdir -p "$DIR/.claude"
 echo '{"flow":{"workflows":{"enabled":false}}}' > "$DIR/.claude/settings.flow.json"
 RESULT=$(cd "$DIR" && "$REPO_ROOT/plugins/flow/bin/cascade-resolve.sh" --default "default-fallback" '.flow.workflows.enabled')
-assert_equal "false" "$RESULT" "bare expression returns 'false' (was always 'true' before cycle-14)"
+assert_equal "false" "$RESULT" "bare expression returns 'false' (was always 'true' before )"
 
 # Compare against // empty which still swallows false (legacy callers)
-_flow_test_begin "SEC-V4 — cascade-resolve.sh + // empty still falls through on false (backward-compat for non-boolean callers)"
+_flow_test_begin "cascade-resolve.sh + // empty still falls through on false (backward-compat for non-boolean callers)"
 RESULT_EMPTY=$(cd "$DIR" && "$REPO_ROOT/plugins/flow/bin/cascade-resolve.sh" --default "default-fallback" '.flow.workflows.enabled // empty')
 assert_equal "default-fallback" "$RESULT_EMPTY" "// empty falls through to default (legacy behavior preserved)"
 
 # Absent key returns default for both expression styles
-_flow_test_begin "SEC-V4 — absent key with bare expression falls through to default"
+_flow_test_begin "absent key with bare expression falls through to default"
 DIR2=$(_c14_mktmp)
 mkdir -p "$DIR2/.claude"
 echo '{"other": "value"}' > "$DIR2/.claude/settings.flow.json"

--- a/plugins/flow/tests/flow-cycle14-behavioral.test.sh
+++ b/plugins/flow/tests/flow-cycle14-behavioral.test.sh
@@ -222,7 +222,7 @@ fi
 
 # --- pr.md FlowGoal gate state coverage: gate-on-existence means no-goal is
 # STATE=none/GATE=pass rather than a blocking STATE=missing
-_flow_test_begin "F1 — pr.md gate distinguishes states (none vs degenerate vs unavailable)"
+_flow_test_begin "pr.md gate distinguishes states (none vs degenerate vs unavailable)"
 PR_CMD="$REPO_ROOT/plugins/flow/commands/pr.md"
 CONTENT=$(cat "$PR_CMD")
 assert_contains "STATE=none" "$CONTENT" "no-goal state (gate not applicable) documented"

--- a/plugins/flow/tests/flow-cycle14-behavioral.test.sh
+++ b/plugins/flow/tests/flow-cycle14-behavioral.test.sh
@@ -220,8 +220,8 @@ else
 fi
 
 
-# --- F1 — pr.md FlowGoal gate handles all states (#111 D-GATE: gate on existence,
-# so no-goal is STATE=none/GATE=pass rather than a blocking STATE=missing)
+# --- pr.md FlowGoal gate state coverage: gate-on-existence means no-goal is
+# STATE=none/GATE=pass rather than a blocking STATE=missing
 _flow_test_begin "F1 — pr.md gate distinguishes states (none vs degenerate vs unavailable)"
 PR_CMD="$REPO_ROOT/plugins/flow/commands/pr.md"
 CONTENT=$(cat "$PR_CMD")

--- a/plugins/flow/tests/flow-cycle14-behavioral.test.sh
+++ b/plugins/flow/tests/flow-cycle14-behavioral.test.sh
@@ -220,14 +220,15 @@ else
 fi
 
 
-# --- F1 — pr.md FlowGoal gate handles all 5 states (ok, missing, degenerate, unavailable, disabled)
-_flow_test_begin "F1 — pr.md gate distinguishes block subkinds (missing vs degenerate vs unavailable)"
+# --- F1 — pr.md FlowGoal gate handles all states (#111 D-GATE: gate on existence,
+# so no-goal is STATE=none/GATE=pass rather than a blocking STATE=missing)
+_flow_test_begin "F1 — pr.md gate distinguishes states (none vs degenerate vs unavailable)"
 PR_CMD="$REPO_ROOT/plugins/flow/commands/pr.md"
 CONTENT=$(cat "$PR_CMD")
-assert_contains "STATE=missing" "$CONTENT" "missing state documented"
+assert_contains "STATE=none" "$CONTENT" "no-goal state (gate not applicable) documented"
 assert_contains "STATE=degenerate" "$CONTENT" "degenerate state documented"
 assert_contains "STATE=unavailable" "$CONTENT" "unavailable state documented"
-assert_contains "STATE=disabled" "$CONTENT" "disabled state (v2 mode) documented"
+assert_contains "STATE=disabled" "$CONTENT" "disabled state (enabled:false / goalCreation:off) documented"
 
 
 # --- F8 — throttle and stuck events both have their own emit sites

--- a/plugins/flow/tests/flow-goal-record-jsonschema.test.sh
+++ b/plugins/flow/tests/flow-goal-record-jsonschema.test.sh
@@ -1,4 +1,4 @@
-# Tests for cycle-13 F11 — bin/flow-goal-record.sh now emits a stderr WARN
+# Tests that bin/flow-goal-record.sh emits a stderr WARN
 # when jsonschema is unavailable instead of silently skipping validation.
 #
 # Strategy: Run the helper under a PYTHONPATH-isolated subshell that fails
@@ -86,7 +86,7 @@ _fjs_write_goal "$GOAL"
 
 CUSTOM_DIR=$(_fjs_mkdir)
 cat > "$CUSTOM_DIR/sitecustomize.py" <<'PYEOF'
-# Test stub — blocks `import jsonschema` so we can exercise the F11 WARN path.
+# Test stub — blocks `import jsonschema` so we can exercise the WARN path.
 import sys, importlib.abc, importlib.machinery
 class _BlockJsonschema(importlib.abc.MetaPathFinder, importlib.abc.Loader):
     def find_spec(self, fullname, path, target=None):
@@ -100,7 +100,7 @@ class _BlockJsonschema(importlib.abc.MetaPathFinder, importlib.abc.Loader):
 sys.meta_path.insert(0, _BlockJsonschema())
 PYEOF
 
-# Cycle-14: WARN dedup uses per-day file sentinel at $TMPDIR/. Isolate TMPDIR
+# WARN dedup uses per-day file sentinel at $TMPDIR/. Isolate TMPDIR
 # so the test sentinel doesn't survive across runs (which would silently pass
 # even if the WARN logic regressed). Use TMPDIR (not HOME) because HOME
 # isolation also breaks Python's user-site-packages lookup and hides PyYAML.
@@ -113,7 +113,7 @@ assert_contains "WARN" "$ERR" "WARN tag visible in the message"
 
 # --- Test 1b: Second invocation in the same isolated HOME — WARN should NOT
 # re-fire (per-day sentinel dedup works).
-_flow_test_begin "WARN deduped across same-day invocations (cycle-14 F11-SENTINEL)"
+_flow_test_begin "WARN deduped across same-day invocations"
 GOAL2="$DIR/.flow/goals/issue-jsonschema-test-second.goal.yaml"
 cat > "$GOAL2" <<'EOF'
 apiVersion: flow.synapti.ai/v1

--- a/plugins/flow/tests/flow-migrate-settings.test.sh
+++ b/plugins/flow/tests/flow-migrate-settings.test.sh
@@ -99,3 +99,38 @@ D=$(_ms_dir)
 OUT=$(bash "$HELPER" --apply "$D/.claude/nope.json" 2>&1); EXIT=$?
 assert_equal "2" "$EXIT" "exit 2 when file absent"
 assert_contains "not found" "$OUT" "stderr names the missing file"
+
+_flow_test_begin "no flow block ({}) -> MIGRATE=none (else-branch, exit 0)"
+D=$(_ms_dir); F="$D/.claude/settings.flow.json"
+echo '{}' > "$F"
+OUT=$(bash "$HELPER" --apply "$F" 2>&1); EXIT=$?
+assert_equal "0" "$EXIT" "empty object is a clean no-op"
+assert_contains "MIGRATE=none" "$OUT" "nothing to migrate for {}"
+
+_flow_test_begin "flow.goals is a non-object -> MIGRATE=none (guarded else-branch)"
+D=$(_ms_dir); F="$D/.claude/settings.flow.json"
+echo '{"flow":{"goals":true}}' > "$F"
+OUT=$(bash "$HELPER" --apply "$F" 2>&1); EXIT=$?
+assert_equal "0" "$EXIT" "non-object flow.goals does not crash"
+assert_contains "MIGRATE=none" "$OUT" "type guard prevents touching a non-object goals"
+
+_flow_test_begin "top-level non-object JSON ([]) -> exit 2"
+D=$(_ms_dir); F="$D/.claude/settings.flow.json"
+printf '[]' > "$F"
+OUT=$(bash "$HELPER" --apply "$F" 2>&1); EXIT=$?
+assert_equal "2" "$EXIT" "exit 2 on a top-level array"
+assert_contains "not a JSON object" "$OUT" "stderr names the non-object input"
+
+_flow_test_begin "v3-clean file (goalCreation only) -> MIGRATE=none, untouched"
+D=$(_ms_dir); F="$D/.claude/settings.flow.json"
+echo '{"flow":{"goals":{"goalCreation":"always"}}}' > "$F"; BEFORE=$(cat "$F")
+OUT=$(bash "$HELPER" --apply "$F" 2>&1)
+assert_contains "MIGRATE=none" "$OUT" "already-current file is a no-op"
+assert_equal "$BEFORE" "$(cat "$F")" "v3-clean file left byte-identical"
+
+_flow_test_begin "no lock-file residue after a successful --apply"
+D=$(_ms_dir); F="$D/.claude/settings.flow.json"
+echo '{"flow":{"goals":{"requireGoalForStart":true}}}' > "$F"
+bash "$HELPER" --apply "$F" >/dev/null 2>&1
+RESIDUE=$(ls "$D/.claude"/*.lock 2>/dev/null)
+assert_equal "" "$RESIDUE" "the .lock file is cleaned up after apply"

--- a/plugins/flow/tests/flow-migrate-settings.test.sh
+++ b/plugins/flow/tests/flow-migrate-settings.test.sh
@@ -1,0 +1,101 @@
+# Tests for plugins/flow/bin/flow-migrate-settings.sh — settings schema upgrade.
+#
+# Migrates deprecated keys (currently flow.goals.requireGoalForStart ->
+# flow.goals.goalCreation) in a committed settings file, atomically and
+# idempotently, preserving all other keys.
+
+HELPER="$REPO_ROOT/plugins/flow/bin/flow-migrate-settings.sh"
+
+MS_CLEANUP=()
+_ms_cleanup() { local p; for p in "${MS_CLEANUP[@]:-}"; do [ -n "$p" ] && rm -rf "$p" 2>/dev/null; done; }
+trap _ms_cleanup EXIT
+
+if ! command -v jq >/dev/null 2>&1; then
+  _flow_test_begin "jq prerequisite"
+  _flow_assert_pass "SKIP: jq not installed"
+  return 0
+fi
+
+_ms_dir() {
+  local d; d=$(mktemp -d -t flow-migrate.XXXXXX 2>/dev/null)
+  [ -z "$d" ] && { echo "mktemp failed" >&2; exit 2; }
+  MS_CLEANUP+=("$d"); mkdir -p "$d/.claude"; printf '%s' "$d"
+}
+
+_flow_test_begin "requireGoalForStart:true -> goalCreation:always (apply), other keys preserved"
+D=$(_ms_dir); F="$D/.claude/settings.flow.json"
+echo '{"agentTeams":false,"flow":{"goals":{"requireGoalForStart":true},"runtime":{"enabled":true}}}' > "$F"
+OUT=$(bash "$HELPER" --apply "$F" 2>&1); EXIT=$?
+assert_equal "0" "$EXIT" "exit 0 on apply"
+assert_contains "MIGRATE_APPLIED=1" "$OUT" "reports applied"
+assert_equal "always" "$(jq -r '.flow.goals.goalCreation' "$F")" "goalCreation=always"
+assert_equal "absent" "$(jq -r '.flow.goals.requireGoalForStart // "absent"' "$F")" "deprecated key removed"
+assert_equal "false" "$(jq -r '.agentTeams' "$F")" "unrelated key agentTeams preserved"
+assert_equal "true" "$(jq -r '.flow.runtime.enabled' "$F")" "unrelated key flow.runtime preserved"
+
+_flow_test_begin "requireGoalForStart:false -> goalCreation:off"
+D=$(_ms_dir); F="$D/.claude/settings.flow.json"
+echo '{"flow":{"goals":{"requireGoalForStart":false}}}' > "$F"
+bash "$HELPER" --apply "$F" >/dev/null 2>&1
+assert_equal "off" "$(jq -r '.flow.goals.goalCreation' "$F")" "false maps to off"
+
+_flow_test_begin "non-boolean requireGoalForStart -> goalCreation:auto"
+D=$(_ms_dir); F="$D/.claude/settings.flow.json"
+echo '{"flow":{"goals":{"requireGoalForStart":"yes"}}}' > "$F"
+bash "$HELPER" --apply "$F" >/dev/null 2>&1
+assert_equal "auto" "$(jq -r '.flow.goals.goalCreation' "$F")" "non-bool maps to auto"
+
+_flow_test_begin "both keys present: goalCreation wins, deprecated key dropped"
+D=$(_ms_dir); F="$D/.claude/settings.flow.json"
+echo '{"flow":{"goals":{"goalCreation":"auto","requireGoalForStart":true}}}' > "$F"
+bash "$HELPER" --apply "$F" >/dev/null 2>&1
+assert_equal "auto" "$(jq -r '.flow.goals.goalCreation' "$F")" "explicit goalCreation preserved (not overwritten to always)"
+assert_equal "absent" "$(jq -r '.flow.goals.requireGoalForStart // "absent"' "$F")" "deprecated key dropped"
+
+_flow_test_begin "no deprecated key: MIGRATE=none, file byte-unchanged"
+D=$(_ms_dir); F="$D/.claude/settings.flow.json"
+echo '{"flow":{"goals":{"goalCreation":"auto"}},"agentTeams":true}' > "$F"
+BEFORE=$(cat "$F")
+OUT=$(bash "$HELPER" --apply "$F" 2>&1); EXIT=$?
+assert_equal "0" "$EXIT" "exit 0"
+assert_contains "MIGRATE=none" "$OUT" "reports nothing to migrate"
+assert_equal "$BEFORE" "$(cat "$F")" "file unchanged when nothing to migrate"
+
+_flow_test_begin "dry-run does NOT modify the file"
+D=$(_ms_dir); F="$D/.claude/settings.flow.json"
+echo '{"flow":{"goals":{"requireGoalForStart":true}}}' > "$F"
+BEFORE=$(cat "$F")
+OUT=$(bash "$HELPER" "$F" 2>&1)
+assert_contains "MIGRATE=requireGoalForStart->goalCreation" "$OUT" "dry-run reports the pending change"
+assert_contains "dry-run" "$OUT" "dry-run mode noted"
+assert_equal "$BEFORE" "$(cat "$F")" "dry-run left the file untouched"
+
+_flow_test_begin "idempotent: a second --apply reports nothing to migrate"
+D=$(_ms_dir); F="$D/.claude/settings.flow.json"
+echo '{"flow":{"goals":{"requireGoalForStart":true}}}' > "$F"
+bash "$HELPER" --apply "$F" >/dev/null 2>&1
+OUT=$(bash "$HELPER" --apply "$F" 2>&1)
+assert_contains "MIGRATE=none" "$OUT" "second run is a no-op"
+
+_flow_test_begin "malformed JSON -> exit 2, file untouched"
+D=$(_ms_dir); F="$D/.claude/settings.flow.json"
+printf '{ this is not json' > "$F"; BEFORE=$(cat "$F")
+OUT=$(bash "$HELPER" --apply "$F" 2>&1); EXIT=$?
+assert_equal "2" "$EXIT" "exit 2 on malformed JSON"
+assert_contains "not valid JSON" "$OUT" "stderr names the parse failure"
+assert_equal "$BEFORE" "$(cat "$F")" "malformed file left untouched"
+
+_flow_test_begin "symlinked settings file -> exit 2 (refuse)"
+D=$(_ms_dir); REAL="$D/real.json"; LINK="$D/.claude/settings.flow.json"
+echo '{"flow":{"goals":{"requireGoalForStart":true}}}' > "$REAL"
+rm -f "$LINK"; ln -s "$REAL" "$LINK"
+OUT=$(bash "$HELPER" --apply "$LINK" 2>&1); EXIT=$?
+assert_equal "2" "$EXIT" "exit 2 on symlinked settings"
+assert_contains "symlink" "$OUT" "stderr names the symlink refusal"
+assert_equal "true" "$(jq -r '.flow.goals.requireGoalForStart' "$REAL")" "symlink target untouched"
+
+_flow_test_begin "missing file -> exit 2"
+D=$(_ms_dir)
+OUT=$(bash "$HELPER" --apply "$D/.claude/nope.json" 2>&1); EXIT=$?
+assert_equal "2" "$EXIT" "exit 2 when file absent"
+assert_contains "not found" "$OUT" "stderr names the missing file"

--- a/plugins/flow/tests/flow-pr-merge-goal-gate.test.sh
+++ b/plugins/flow/tests/flow-pr-merge-goal-gate.test.sh
@@ -15,10 +15,11 @@ if [ ! -f "$PR_CMD" ]; then
 else
   CONTENT=$(cat "$PR_CMD")
   assert_contains "### FlowGoal State" "$CONTENT" "Phase 1 section heading present"
-  assert_contains 'flow.goals.requireGoalForStart' "$CONTENT" "settings key gated"
+  assert_contains 'flow.goals.goalCreation' "$CONTENT" "migration-aware goalCreation resolution (#111 AC-1)"
   assert_contains "flow-active-goal.sh" "$CONTENT" "uses the centralized helper"
   assert_contains "GATE=pass" "$CONTENT" "pass sentinel emitted"
   assert_contains "GATE=block" "$CONTENT" "block sentinel emitted"
+  assert_contains "STATE=none" "$CONTENT" "no-goal state is gate-not-applicable (#111 D-GATE: gate on existence)"
 fi
 
 _flow_test_begin "F1 — /flow:pr Phase 4 step 7a uses AskUserQuestion on gate block"
@@ -36,7 +37,8 @@ else
   assert_contains "### FlowGoal Gate" "$CONTENT" "merge.md Phase 1 gate section present"
   assert_contains "FLOW_GOAL_GATE_STATE" "$CONTENT" "gate state sentinel emitted"
   assert_contains "flow-active-goal.sh" "$CONTENT" "uses centralized helper"
-  assert_contains "fail closed" "$CONTENT" "behavior documented as fail-closed"
+  assert_contains 'flow.goals.goalCreation' "$CONTENT" "migration-aware goalCreation resolution (#111 AC-1)"
+  assert_contains "gate not applicable" "$CONTENT" "no-goal merge is NOT blocked (#111 D-GATE: gate on existence)"
 fi
 
 _flow_test_begin "F1 — /flow:merge BLOCKED display includes FlowGoal row"

--- a/plugins/flow/tests/flow-pr-merge-goal-gate.test.sh
+++ b/plugins/flow/tests/flow-pr-merge-goal-gate.test.sh
@@ -15,11 +15,11 @@ if [ ! -f "$PR_CMD" ]; then
 else
   CONTENT=$(cat "$PR_CMD")
   assert_contains "### FlowGoal State" "$CONTENT" "Phase 1 section heading present"
-  assert_contains 'flow.goals.goalCreation' "$CONTENT" "migration-aware goalCreation resolution (#111 AC-1)"
+  assert_contains 'flow.goals.goalCreation' "$CONTENT" "migration-aware goalCreation resolution"
   assert_contains "flow-active-goal.sh" "$CONTENT" "uses the centralized helper"
   assert_contains "GATE=pass" "$CONTENT" "pass sentinel emitted"
   assert_contains "GATE=block" "$CONTENT" "block sentinel emitted"
-  assert_contains "STATE=none" "$CONTENT" "no-goal state is gate-not-applicable (#111 D-GATE: gate on existence)"
+  assert_contains "STATE=none" "$CONTENT" "no-goal state is gate-not-applicable (gate on existence)"
 fi
 
 _flow_test_begin "F1 — /flow:pr Phase 4 step 7a uses AskUserQuestion on gate block"
@@ -37,8 +37,8 @@ else
   assert_contains "### FlowGoal Gate" "$CONTENT" "merge.md Phase 1 gate section present"
   assert_contains "FLOW_GOAL_GATE_STATE" "$CONTENT" "gate state sentinel emitted"
   assert_contains "flow-active-goal.sh" "$CONTENT" "uses centralized helper"
-  assert_contains 'flow.goals.goalCreation' "$CONTENT" "migration-aware goalCreation resolution (#111 AC-1)"
-  assert_contains "gate not applicable" "$CONTENT" "no-goal merge is NOT blocked (#111 D-GATE: gate on existence)"
+  assert_contains 'flow.goals.goalCreation' "$CONTENT" "migration-aware goalCreation resolution"
+  assert_contains "gate not applicable" "$CONTENT" "no-goal merge is NOT blocked (gate on existence)"
 fi
 
 _flow_test_begin "F1 — /flow:merge BLOCKED display includes FlowGoal row"
@@ -47,13 +47,13 @@ assert_contains "Merge Prerequisites Not Met" "$CONTENT" "Updated BLOCKED templa
 assert_contains "| FlowGoal" "$CONTENT" "BLOCKED table has FlowGoal row"
 assert_contains "/flow:goal evaluate" "$CONTENT" "remediation references goal evaluate"
 
-# --- #122: gates pass --allow-terminal so an achieved goal is observable -------
-_flow_test_begin "#122: merge.md FlowGoal gate queries the helper with --allow-terminal"
+# --- gates pass --allow-terminal so an achieved goal is observable -----------
+_flow_test_begin "merge.md FlowGoal gate queries the helper with --allow-terminal"
 CONTENT=$(cat "$MERGE_CMD")
 assert_contains -- "--status --allow-terminal" "$CONTENT" "merge gate --status uses --allow-terminal"
 assert_contains -- "--id --allow-terminal" "$CONTENT" "merge gate --id uses --allow-terminal"
 
-_flow_test_begin "#122: pr.md FlowGoal state queries the helper with --allow-terminal"
+_flow_test_begin "pr.md FlowGoal state queries the helper with --allow-terminal"
 CONTENT=$(cat "$PR_CMD")
 assert_contains -- "--status --allow-terminal" "$CONTENT" "pr gate --status uses --allow-terminal"
 assert_contains -- "--id --allow-terminal" "$CONTENT" "pr gate --id uses --allow-terminal"

--- a/plugins/flow/tests/flow-pr-merge-goal-gate.test.sh
+++ b/plugins/flow/tests/flow-pr-merge-goal-gate.test.sh
@@ -50,10 +50,15 @@ assert_contains "/flow:goal evaluate" "$CONTENT" "remediation references goal ev
 # --- gates pass --allow-terminal so an achieved goal is observable -----------
 _flow_test_begin "merge.md FlowGoal gate queries the helper with --allow-terminal"
 CONTENT=$(cat "$MERGE_CMD")
-assert_contains -- "--status --allow-terminal" "$CONTENT" "merge gate --status uses --allow-terminal"
-assert_contains -- "--id --allow-terminal" "$CONTENT" "merge gate --id uses --allow-terminal"
+assert_contains "--status --allow-terminal" "$CONTENT" "merge gate --status uses --allow-terminal"
+assert_contains "--id --allow-terminal" "$CONTENT" "merge gate --id uses --allow-terminal"
 
 _flow_test_begin "pr.md FlowGoal state queries the helper with --allow-terminal"
 CONTENT=$(cat "$PR_CMD")
-assert_contains -- "--status --allow-terminal" "$CONTENT" "pr gate --status uses --allow-terminal"
-assert_contains -- "--id --allow-terminal" "$CONTENT" "pr gate --id uses --allow-terminal"
+assert_contains "--status --allow-terminal" "$CONTENT" "pr gate --status uses --allow-terminal"
+assert_contains "--id --allow-terminal" "$CONTENT" "pr gate --id uses --allow-terminal"
+
+# --- gate callers resolve branch-strict (no cross-branch false-block) ----------
+_flow_test_begin "pr.md + merge.md gate resolve with --branch-strict"
+assert_contains "--branch-strict" "$(cat "$PR_CMD")" "pr gate passes --branch-strict to the resolver"
+assert_contains "--branch-strict" "$(cat "$MERGE_CMD")" "merge gate passes --branch-strict to the resolver"

--- a/plugins/flow/tests/flow-pr-merge-goal-gate.test.sh
+++ b/plugins/flow/tests/flow-pr-merge-goal-gate.test.sh
@@ -46,3 +46,14 @@ CONTENT=$(cat "$MERGE_CMD")
 assert_contains "Merge Prerequisites Not Met" "$CONTENT" "Updated BLOCKED template heading"
 assert_contains "| FlowGoal" "$CONTENT" "BLOCKED table has FlowGoal row"
 assert_contains "/flow:goal evaluate" "$CONTENT" "remediation references goal evaluate"
+
+# --- #122: gates pass --allow-terminal so an achieved goal is observable -------
+_flow_test_begin "#122: merge.md FlowGoal gate queries the helper with --allow-terminal"
+CONTENT=$(cat "$MERGE_CMD")
+assert_contains -- "--status --allow-terminal" "$CONTENT" "merge gate --status uses --allow-terminal"
+assert_contains -- "--id --allow-terminal" "$CONTENT" "merge gate --id uses --allow-terminal"
+
+_flow_test_begin "#122: pr.md FlowGoal state queries the helper with --allow-terminal"
+CONTENT=$(cat "$PR_CMD")
+assert_contains -- "--status --allow-terminal" "$CONTENT" "pr gate --status uses --allow-terminal"
+assert_contains -- "--id --allow-terminal" "$CONTENT" "pr gate --id uses --allow-terminal"

--- a/plugins/flow/tests/flow-pr-merge-goal-gate.test.sh
+++ b/plugins/flow/tests/flow-pr-merge-goal-gate.test.sh
@@ -1,5 +1,5 @@
-# Tests for plugins/flow/commands/pr.md + merge.md FlowGoal gate (cycle-13 F1).
-# Source-presence lints; behavioral coverage is in flow-cycle14-behavioral.test.sh.
+# Tests for plugins/flow/commands/pr.md + merge.md FlowGoal gate.
+# Source-presence lints; behavioral coverage is in flow--behavioral.test.sh.
 #
 # These check that the gate bash blocks are present in the command markdown
 # and use the new bin/flow-active-goal.sh helper. Behavioral tests of the
@@ -9,7 +9,7 @@
 PR_CMD="$REPO_ROOT/plugins/flow/commands/pr.md"
 MERGE_CMD="$REPO_ROOT/plugins/flow/commands/merge.md"
 
-_flow_test_begin "F1 — /flow:pr Phase 1 includes FlowGoal State section"
+_flow_test_begin "/flow:pr Phase 1 includes FlowGoal State section"
 if [ ! -f "$PR_CMD" ]; then
   _flow_assert_fail "pr.md missing"
 else
@@ -22,14 +22,14 @@ else
   assert_contains "STATE=none" "$CONTENT" "no-goal state is gate-not-applicable (gate on existence)"
 fi
 
-_flow_test_begin "F1 — /flow:pr Phase 4 step 7a uses AskUserQuestion on gate block"
+_flow_test_begin "/flow:pr Phase 4 step 7a uses AskUserQuestion on gate block"
 CONTENT=$(cat "$PR_CMD")
 assert_contains "FlowGoal gate (v3, opt-in)" "$CONTENT" "Phase 4 step 7a heading present"
 assert_contains "/flow:goal evaluate" "$CONTENT" "Recommends running evaluate first"
 assert_contains "Create PR with goal not-yet-achieved" "$CONTENT" "Override option offered"
 assert_contains "FlowGoal Status" "$CONTENT" "PR body section name documented"
 
-_flow_test_begin "F1 — /flow:merge Phase 1 includes FlowGoal Gate block"
+_flow_test_begin "/flow:merge Phase 1 includes FlowGoal Gate block"
 if [ ! -f "$MERGE_CMD" ]; then
   _flow_assert_fail "merge.md missing"
 else
@@ -41,7 +41,7 @@ else
   assert_contains "gate not applicable" "$CONTENT" "no-goal merge is NOT blocked (gate on existence)"
 fi
 
-_flow_test_begin "F1 — /flow:merge BLOCKED display includes FlowGoal row"
+_flow_test_begin "/flow:merge BLOCKED display includes FlowGoal row"
 CONTENT=$(cat "$MERGE_CMD")
 assert_contains "Merge Prerequisites Not Met" "$CONTENT" "Updated BLOCKED template heading"
 assert_contains "| FlowGoal" "$CONTENT" "BLOCKED table has FlowGoal row"

--- a/plugins/flow/tests/flow-readme-commands.test.sh
+++ b/plugins/flow/tests/flow-readme-commands.test.sh
@@ -1,0 +1,27 @@
+# Tests for plugins/flow/README.md command surface (#111 AC-7).
+#
+# Guards the count-drift fix dynamically: the README "COMMANDS (N)" header must
+# equal the actual number of commands/*.md files, so the next added/removed
+# command can't silently desync the docs again.
+
+README="$REPO_ROOT/plugins/flow/README.md"
+CMD_DIR="$REPO_ROOT/plugins/flow/commands"
+
+_flow_test_begin "AC-7: README COMMANDS (N) matches the actual command-file count"
+ACTUAL=$(ls -1 "$CMD_DIR"/*.md 2>/dev/null | wc -l | tr -d ' ')
+DOC_N=$(grep -oE 'COMMANDS \(([0-9]+)\)' "$README" | grep -oE '[0-9]+' | head -1)
+assert_equal "$ACTUAL" "$DOC_N" "README COMMANDS ($DOC_N) equals $ACTUAL command files"
+
+_flow_test_begin "AC-7: README leads with Work-first framing"
+CONTENT=$(cat "$README")
+assert_contains "you don't manage it by hand" "$CONTENT" "Work-first lead present"
+assert_contains "### Work (intent) commands" "$CONTENT" "intent commands section heading"
+
+_flow_test_begin "AC-7: runtime primitives demoted to Advanced / runtime internals"
+assert_contains "### Advanced / runtime internals" "$CONTENT" "Advanced subsection present"
+for c in goal workflow trigger run resume watch; do
+  assert_contains "\`/flow:$c\`" "$CONTENT" "runtime command /flow:$c documented in Advanced"
+done
+
+_flow_test_begin "AC-7: /flow:goal create reframed as the --manual path"
+assert_contains '`/flow:goal create` is the `--manual` path' "$CONTENT" "goal create reframed as manual-only"

--- a/plugins/flow/tests/flow-readme-commands.test.sh
+++ b/plugins/flow/tests/flow-readme-commands.test.sh
@@ -1,4 +1,4 @@
-# Tests for plugins/flow/README.md command surface (#111 AC-7).
+# Tests for plugins/flow/README.md command surface.
 #
 # Guards the count-drift fix dynamically: the README "COMMANDS (N)" header must
 # equal the actual number of commands/*.md files, so the next added/removed

--- a/plugins/flow/tests/flow-readme-commands.test.sh
+++ b/plugins/flow/tests/flow-readme-commands.test.sh
@@ -7,21 +7,21 @@
 README="$REPO_ROOT/plugins/flow/README.md"
 CMD_DIR="$REPO_ROOT/plugins/flow/commands"
 
-_flow_test_begin "AC-7: README COMMANDS (N) matches the actual command-file count"
+_flow_test_begin "README COMMANDS (N) matches the actual command-file count"
 ACTUAL=$(ls -1 "$CMD_DIR"/*.md 2>/dev/null | wc -l | tr -d ' ')
 DOC_N=$(grep -oE 'COMMANDS \(([0-9]+)\)' "$README" | grep -oE '[0-9]+' | head -1)
 assert_equal "$ACTUAL" "$DOC_N" "README COMMANDS ($DOC_N) equals $ACTUAL command files"
 
-_flow_test_begin "AC-7: README leads with Work-first framing"
+_flow_test_begin "README leads with Work-first framing"
 CONTENT=$(cat "$README")
 assert_contains "you don't manage it by hand" "$CONTENT" "Work-first lead present"
 assert_contains "### Work (intent) commands" "$CONTENT" "intent commands section heading"
 
-_flow_test_begin "AC-7: runtime primitives demoted to Advanced / runtime internals"
+_flow_test_begin "runtime primitives demoted to Advanced / runtime internals"
 assert_contains "### Advanced / runtime internals" "$CONTENT" "Advanced subsection present"
 for c in goal workflow trigger run resume watch; do
   assert_contains "\`/flow:$c\`" "$CONTENT" "runtime command /flow:$c documented in Advanced"
 done
 
-_flow_test_begin "AC-7: /flow:goal create reframed as the --manual path"
+_flow_test_begin "/flow:goal create reframed as the --manual path"
 assert_contains '`/flow:goal create` is the `--manual` path' "$CONTENT" "goal create reframed as manual-only"

--- a/plugins/flow/tests/flow-resume-unlinked.test.sh
+++ b/plugins/flow/tests/flow-resume-unlinked.test.sh
@@ -1,5 +1,4 @@
-# Tests for plugins/flow/commands/resume.md — #111 AC-6 conservatism on
-# unlinked working-tree changes.
+# Tests for /flow:resume conservatism on unlinked working-tree changes.
 #
 # Source-presence lints for the Step 3.5 contract, plus behavioral coverage:
 # extract the unlinked-detection bash block and run it in throwaway git repos.
@@ -7,7 +6,7 @@
 RESUME_CMD="$REPO_ROOT/plugins/flow/commands/resume.md"
 
 # --- Source-presence -----------------------------------------------------------
-_flow_test_begin "AC-6: resume.md documents unlinked-change detection + ask-first"
+_flow_test_begin "resume.md documents unlinked-change detection + ask-first"
 if [ ! -f "$RESUME_CMD" ]; then
   _flow_assert_fail "resume.md missing"
 else
@@ -48,13 +47,13 @@ _new_repo() {
   printf '%s' "$d"
 }
 
-_flow_test_begin "AC-6: only .flow/.decisions changes -> UNLINKED=0"
+_flow_test_begin "only .flow/.decisions changes -> UNLINKED=0"
 D=$(_new_repo)
 ( cd "$D" && echo "run: x" > .flow/runs/r.yaml && echo "j" > .decisions/issue-1.md )
 OUT=$(cd "$D" && bash -c "$UNLINKED_BLOCK")
 assert_contains "FLOW_RESUME_UNLINKED=0" "$OUT" "flow-owned changes are not unlinked"
 
-_flow_test_begin "AC-6: an unrelated tracked change -> UNLINKED=1 and lists the path"
+_flow_test_begin "an unrelated tracked change -> UNLINKED=1 and lists the path"
 D=$(_new_repo)
 ( cd "$D" && echo "edit" >> src/keep.txt && echo "new" > src/other.txt && echo "run" > .flow/runs/r.yaml )
 OUT=$(cd "$D" && bash -c "$UNLINKED_BLOCK")
@@ -63,12 +62,12 @@ assert_contains "src/keep.txt" "$OUT" "modified unrelated file listed"
 assert_contains "src/other.txt" "$OUT" "untracked unrelated file listed"
 assert_not_contains ".flow/runs/r.yaml" "$OUT" "flow-owned change excluded from the unlinked list"
 
-_flow_test_begin "AC-6: clean tree -> UNLINKED=0"
+_flow_test_begin "clean tree -> UNLINKED=0"
 D=$(_new_repo)
 OUT=$(cd "$D" && bash -c "$UNLINKED_BLOCK")
 assert_contains "FLOW_RESUME_UNLINKED=0" "$OUT" "clean tree is not unlinked"
 
-_flow_test_begin "AC-6 (F1): special-char/non-ASCII .flow path is still excluded (quotePath robustness)"
+_flow_test_begin "special-char/non-ASCII .flow path is still excluded (quotePath robustness)"
 D=$(_new_repo)
 # git quotes non-ASCII paths under default core.quotePath; the detector must
 # still recognize the .flow/ prefix (core.quotePath=false + unquote) and a
@@ -78,3 +77,21 @@ OUT=$(cd "$D" && bash -c "$UNLINKED_BLOCK")
 assert_contains "FLOW_RESUME_UNLINKED=1" "$OUT" "the unrelated non-ASCII file is flagged"
 assert_contains "src/café.txt" "$OUT" "unrelated non-ASCII path listed"
 assert_not_contains ".flow/runs/café.yaml" "$OUT" "non-ASCII .flow path excluded despite git quoting"
+
+_flow_test_begin "rename is evaluated by its destination path (R/C-gated arrow strip)"
+D=$(_new_repo)
+# A staged rename shows as 'R  old -> new' in porcelain; the arrow strip (gated
+# to R/C status lines) must extract the DESTINATION. Renaming an unrelated file
+# keeps it flagged as unlinked under its new path, not the raw 'old -> new'.
+( cd "$D" && git mv src/keep.txt src/moved.txt )
+OUT=$(cd "$D" && bash -c "$UNLINKED_BLOCK")
+assert_contains "FLOW_RESUME_UNLINKED=1" "$OUT" "renamed unrelated file is flagged"
+assert_contains "src/moved.txt" "$OUT" "rename destination is listed"
+assert_not_contains "src/keep.txt -> " "$OUT" "the raw arrow form is not emitted as a path"
+
+_flow_test_begin "git failure surfaces UNLINKED=unknown (never a false 'clean')"
+NOREPO=$(mktemp -d -t flow-resume-norepo.XXXXXX)
+RESUME_CLEANUP+=("$NOREPO")
+OUT=$(cd "$NOREPO" && bash -c "$UNLINKED_BLOCK")
+assert_contains "FLOW_RESUME_UNLINKED=unknown" "$OUT" "git status failure -> unknown, not 0"
+assert_contains "FLOW_RESUME_UNLINKED_REASON" "$OUT" "reason surfaced for the unknown state"

--- a/plugins/flow/tests/flow-resume-unlinked.test.sh
+++ b/plugins/flow/tests/flow-resume-unlinked.test.sh
@@ -1,0 +1,69 @@
+# Tests for plugins/flow/commands/resume.md — #111 AC-6 conservatism on
+# unlinked working-tree changes.
+#
+# Source-presence lints for the Step 3.5 contract, plus behavioral coverage:
+# extract the unlinked-detection bash block and run it in throwaway git repos.
+
+RESUME_CMD="$REPO_ROOT/plugins/flow/commands/resume.md"
+
+# --- Source-presence -----------------------------------------------------------
+_flow_test_begin "AC-6: resume.md documents unlinked-change detection + ask-first"
+if [ ! -f "$RESUME_CMD" ]; then
+  _flow_assert_fail "resume.md missing"
+else
+  CONTENT=$(cat "$RESUME_CMD")
+  assert_contains "FLOW_RESUME_UNLINKED" "$CONTENT" "unlinked sentinel documented"
+  assert_contains "git status --porcelain" "$CONTENT" "uses porcelain to detect changes"
+  assert_contains "ask before suggesting continuation" "$CONTENT" "ask-first contract stated"
+  assert_contains "unrelated work" "$CONTENT" "AskUserQuestion offers the unrelated-work path"
+fi
+
+# --- Behavioral: extract and run the Step 3.5 detection block ------------------
+RESUME_CLEANUP=()
+_resume_cleanup() { local p; for p in "${RESUME_CLEANUP[@]:-}"; do [ -n "$p" ] && rm -rf "$p" 2>/dev/null; done; }
+trap _resume_cleanup EXIT
+
+if ! command -v git >/dev/null 2>&1; then
+  _flow_test_begin "AC-6 behavioral"
+  _flow_assert_pass "SKIP: git not installed"
+  return 0
+fi
+
+UNLINKED_BLOCK=$(python3 - "$RESUME_CMD" <<'PY'
+import sys, re
+src = open(sys.argv[1]).read()
+after = src.split("### Step 3.5", 1)[1]
+m = re.search(r"```!\n(.*?)\n```", after, re.S)
+sys.stdout.write(m.group(1) if m else "")
+PY
+)
+
+_new_repo() {
+  local d
+  d=$(mktemp -d -t flow-resume.XXXXXX)
+  RESUME_CLEANUP+=("$d")
+  ( cd "$d" && git init -q && git config user.email t@t.t && git config user.name t \
+      && mkdir -p .flow/runs .decisions src \
+      && echo base > src/keep.txt && git add src/keep.txt && git commit -qm base )
+  printf '%s' "$d"
+}
+
+_flow_test_begin "AC-6: only .flow/.decisions changes -> UNLINKED=0"
+D=$(_new_repo)
+( cd "$D" && echo "run: x" > .flow/runs/r.yaml && echo "j" > .decisions/issue-1.md )
+OUT=$(cd "$D" && bash -c "$UNLINKED_BLOCK")
+assert_contains "FLOW_RESUME_UNLINKED=0" "$OUT" "flow-owned changes are not unlinked"
+
+_flow_test_begin "AC-6: an unrelated tracked change -> UNLINKED=1 and lists the path"
+D=$(_new_repo)
+( cd "$D" && echo "edit" >> src/keep.txt && echo "new" > src/other.txt && echo "run" > .flow/runs/r.yaml )
+OUT=$(cd "$D" && bash -c "$UNLINKED_BLOCK")
+assert_contains "FLOW_RESUME_UNLINKED=1" "$OUT" "unrelated change flagged"
+assert_contains "src/keep.txt" "$OUT" "modified unrelated file listed"
+assert_contains "src/other.txt" "$OUT" "untracked unrelated file listed"
+assert_not_contains ".flow/runs/r.yaml" "$OUT" "flow-owned change excluded from the unlinked list"
+
+_flow_test_begin "AC-6: clean tree -> UNLINKED=0"
+D=$(_new_repo)
+OUT=$(cd "$D" && bash -c "$UNLINKED_BLOCK")
+assert_contains "FLOW_RESUME_UNLINKED=0" "$OUT" "clean tree is not unlinked"

--- a/plugins/flow/tests/flow-resume-unlinked.test.sh
+++ b/plugins/flow/tests/flow-resume-unlinked.test.sh
@@ -23,7 +23,7 @@ _resume_cleanup() { local p; for p in "${RESUME_CLEANUP[@]:-}"; do [ -n "$p" ] &
 trap _resume_cleanup EXIT
 
 if ! command -v git >/dev/null 2>&1; then
-  _flow_test_begin "AC-6 behavioral"
+  _flow_test_begin "unlinked-detection behavioral prerequisites"
   _flow_assert_pass "SKIP: git not installed"
   return 0
 fi

--- a/plugins/flow/tests/flow-resume-unlinked.test.sh
+++ b/plugins/flow/tests/flow-resume-unlinked.test.sh
@@ -67,3 +67,14 @@ _flow_test_begin "AC-6: clean tree -> UNLINKED=0"
 D=$(_new_repo)
 OUT=$(cd "$D" && bash -c "$UNLINKED_BLOCK")
 assert_contains "FLOW_RESUME_UNLINKED=0" "$OUT" "clean tree is not unlinked"
+
+_flow_test_begin "AC-6 (F1): special-char/non-ASCII .flow path is still excluded (quotePath robustness)"
+D=$(_new_repo)
+# git quotes non-ASCII paths under default core.quotePath; the detector must
+# still recognize the .flow/ prefix (core.quotePath=false + unquote) and a
+# matching unrelated path must still be flagged.
+( cd "$D" && mkdir -p ".flow/runs" && echo run > ".flow/runs/café.yaml" && echo x > "src/café.txt" )
+OUT=$(cd "$D" && bash -c "$UNLINKED_BLOCK")
+assert_contains "FLOW_RESUME_UNLINKED=1" "$OUT" "the unrelated non-ASCII file is flagged"
+assert_contains "src/café.txt" "$OUT" "unrelated non-ASCII path listed"
+assert_not_contains ".flow/runs/café.yaml" "$OUT" "non-ASCII .flow path excluded despite git quoting"

--- a/plugins/flow/tests/flow-setup-migrate.test.sh
+++ b/plugins/flow/tests/flow-setup-migrate.test.sh
@@ -10,10 +10,13 @@ if [ ! -f "$SETUP_CMD" ]; then
 else
   CONTENT=$(cat "$SETUP_CMD")
   assert_contains "flow-migrate-settings.sh" "$CONTENT" "setup invokes the migrator"
-  assert_contains '"$MIGRATOR" --apply' "$CONTENT" "apply path documented"
+  assert_contains 'flow-migrate-settings.sh" --apply ".claude/settings.flow.json"' "$CONTENT" "apply path present (resolver inlined in the bash block, not a cross-block \$MIGRATOR)"
   assert_contains "AskUserQuestion" "$CONTENT" "rewrite is gated behind a confirmation prompt"
   assert_contains "requireGoalForStart" "$CONTENT" "documents the deprecated key being migrated"
   assert_contains "nothing breaks if declined" "$CONTENT" "frames it as optional hygiene (read-only migration still works)"
+  # Guard the P1 regression: the apply must NOT rely on a bare $MIGRATOR resolved
+  # in a separate !-block (bash vars don't persist across blocks -> silent no-op).
+  assert_not_contains '"$MIGRATOR" --apply' "$CONTENT" "apply does not depend on a cross-block \$MIGRATOR"
 fi
 
 _flow_test_begin "migrator helper ships and is executable"
@@ -26,3 +29,20 @@ fi
 _flow_test_begin "setup migration is classified Tier 2 (confirmation-gated rewrite)"
 CONTENT=$(cat "$SETUP_CMD")
 assert_contains "flow-migrate-settings.sh --apply" "$CONTENT" "tier table names the apply action"
+
+# --- behavioral: the re-run detection block degrades cleanly, never blocks setup
+_flow_test_begin "setup migration-detection degrades to MIGRATE=skip when no committed settings"
+DRYRUN_BLOCK=$(python3 - "$SETUP_CMD" <<'PY'
+import sys, re
+src = open(sys.argv[1]).read()
+after = src.split("### Upgrade deprecated settings", 1)[1]
+m = re.search(r"```!\n(.*?)\n```", after, re.S)
+sys.stdout.write(m.group(1) if m else "")
+PY
+)
+WORK=$(mktemp -d -t flow-setup-skip.XXXXXX)
+# No .claude/settings.flow.json present -> the `[ -f "$SETTINGS" ]` guard is false
+# -> the block must emit MIGRATE=skip and exit 0 (setup proceeds, not blocked).
+OUT=$(cd "$WORK" && bash -c "$DRYRUN_BLOCK" 2>&1); EXIT=$?
+assert_equal "0" "$EXIT" "detection block exits 0 with no committed settings"
+assert_contains "MIGRATE=skip" "$OUT" "degrades to skip (no settings or migrator) rather than erroring"

--- a/plugins/flow/tests/flow-setup-migrate.test.sh
+++ b/plugins/flow/tests/flow-setup-migrate.test.sh
@@ -1,0 +1,28 @@
+# Tests that /flow:setup wires the deprecated-settings migration (re-run path)
+# and that the migrator helper ships executable.
+
+SETUP_CMD="$REPO_ROOT/plugins/flow/commands/setup.md"
+MIGRATOR="$REPO_ROOT/plugins/flow/bin/flow-migrate-settings.sh"
+
+_flow_test_begin "setup.md wires the deprecated-settings migration on re-run"
+if [ ! -f "$SETUP_CMD" ]; then
+  _flow_assert_fail "setup.md missing"
+else
+  CONTENT=$(cat "$SETUP_CMD")
+  assert_contains "flow-migrate-settings.sh" "$CONTENT" "setup invokes the migrator"
+  assert_contains '"$MIGRATOR" --apply' "$CONTENT" "apply path documented"
+  assert_contains "AskUserQuestion" "$CONTENT" "rewrite is gated behind a confirmation prompt"
+  assert_contains "requireGoalForStart" "$CONTENT" "documents the deprecated key being migrated"
+  assert_contains "nothing breaks if declined" "$CONTENT" "frames it as optional hygiene (read-only migration still works)"
+fi
+
+_flow_test_begin "migrator helper ships and is executable"
+if [ -x "$MIGRATOR" ]; then
+  _flow_assert_pass "flow-migrate-settings.sh is executable"
+else
+  _flow_assert_fail "flow-migrate-settings.sh missing or not executable: $MIGRATOR"
+fi
+
+_flow_test_begin "setup migration is classified Tier 2 (confirmation-gated rewrite)"
+CONTENT=$(cat "$SETUP_CMD")
+assert_contains "flow-migrate-settings.sh --apply" "$CONTENT" "tier table names the apply action"

--- a/plugins/flow/tests/flow-start-onboarding.test.sh
+++ b/plugins/flow/tests/flow-start-onboarding.test.sh
@@ -1,6 +1,6 @@
 # plugins/flow/tests/flow-start-onboarding.test.sh (goalCreation suite)
 #
-# #111 AC-1 retired the Phase 0.5 onboarding AskUserQuestion and the
+# The conditional-auto goalCreation work retired the Phase 0.5 onboarding AskUserQuestion and the
 # set_flow_goals helper, replacing the binary requireGoalForStart with the
 # 3-state flow.goals.goalCreation (auto|always|off, default auto). This suite
 # now covers:
@@ -8,7 +8,7 @@
 #     merge.md resolve): requireGoalForStart true->always, false->off,
 #     absent->auto, and explicit goalCreation wins over the legacy key.
 #   - The FlowGoal auto-creation gate keyed on GOAL_MODE != off, including the
-#     bare-$ARGUMENTS parsing regression guard from #120.
+#     bare-$ARGUMENTS parsing regression guard.
 #   - start.md documents the "verifiable ACs win" auto predicate (the
 #     prose-side gate Claude applies after the bash block).
 # The unrelated context:fork skill lint is preserved at the end.
@@ -107,7 +107,7 @@ _flow_test_begin "gate: GOAL_MODE=auto + non-digit ARGUMENTS -> skip"
 OUT=$(cd "$TMP_DIR" && GOAL_MODE=auto bash -c "$(cc_substitute "$GOAL_GATE_BLOCK" "abc")")
 assert_equal "FLOW_GOAL_STATE=skip" "$OUT" "non-digit -> skip"
 
-_flow_test_begin "regression(#120): old \${ARGUMENTS%% *} form degrades to skip under CC substitution"
+_flow_test_begin "regression: old \${ARGUMENTS%% *} form degrades to skip under CC substitution"
 OLD_BROKEN_BLOCK='
 ARG1="${ARGUMENTS%% *}"
 case "$ARG1" in
@@ -121,7 +121,7 @@ else
 fi
 '
 OUT=$(cd "$TMP_DIR" && GOAL_MODE=auto bash -c "$(cc_substitute "$OLD_BROKEN_BLOCK" "42")")
-assert_equal "FLOW_GOAL_STATE=skip" "$OUT" "old form expands empty under CC substitution (this IS the #120 bug)"
+assert_equal "FLOW_GOAL_STATE=skip" "$OUT" "old form expands empty under CC substitution (this IS the bug)"
 OUT=$(cd "$TMP_DIR" && GOAL_MODE=auto bash -c "$(cc_substitute "$GOAL_GATE_BLOCK" "42")")
 assert_contains "FLOW_GOAL_STATE=create" "$OUT" "fixed _RAW form produces create under the identical model"
 
@@ -226,3 +226,17 @@ else
   MISSING=$(comm -13 <(printf '%s\n' "$ALL_FORK") <(printf '%s\n' "$EXPECTED_FORK_SORTED") | head -3 | tr '\n' ',')
   _flow_assert_fail "fork-set drift: extra=[$EXTRA] missing=[$MISSING]"
 fi
+
+
+# --- goals.enabled master switch forces goal creation off ---------------------
+_flow_test_begin "start.md documents the enabled:false -> off master switch"
+SC=$(cat "$REPO_ROOT/plugins/flow/commands/start.md")
+assert_contains 'ENABLED" != "true" ] && GOAL_MODE="off"' "$SC" "master-switch coercion present in the gate block"
+
+_flow_test_begin "master switch: enabled=false coerces GOAL_MODE off -> gate skips"
+# Reproduce the start.md coercion (ENABLED resolved, then forced off) ahead of
+# the lifted gate block, and confirm the gate skips even when GOAL_MODE started auto.
+OUT=$(ENABLED=false GOAL_MODE=auto bash -c '
+  [ "$ENABLED" != "true" ] && GOAL_MODE="off"
+  '"$(cc_substitute "$GOAL_GATE_BLOCK" "42")")
+assert_equal "FLOW_GOAL_STATE=skip" "$OUT" "enabled:false -> GOAL_MODE off -> skip"

--- a/plugins/flow/tests/flow-start-onboarding.test.sh
+++ b/plugins/flow/tests/flow-start-onboarding.test.sh
@@ -139,7 +139,7 @@ assert_not_contains "set_flow_goals" "$SC" "set_flow_goals helper removed"
 
 _flow_test_begin "skills invoked from command Inputs blocks do not use context: fork"
 
-# Cycle-10 + cycle-11 regression fix: skills with `context: fork` lose their
+# Skills with `context: fork` lose their
 # parent's context when invoked from command markdown. Per Claude Code docs
 # (https://code.claude.com/docs/en/skills.md): "context: fork only makes
 # sense for skills with explicit instructions ... If your skill contains
@@ -149,12 +149,12 @@ _flow_test_begin "skills invoked from command Inputs blocks do not use context: 
 # input, so fork is documented misuse for all of them.
 #
 # Three groups:
-#   - cycle-10 fixes (3): user-reported failure cases — structured Inputs
+#   - fixes (3): user-reported failure cases — structured Inputs
 #     invocation from command markdown.
-#   - cycle-11 Pattern A fixes (8): invoked via Skill(X) from command
+#   - Pattern A fixes (8): invoked via Skill(X) from command
 #     markdown; 5 of them explicitly say "invoking command MUST pass" in
 #     body, which fork drops.
-#   - cycle-11 disable-invoke fixes (4): have disable-model-invocation:
+#   - disable-invoke fixes (4): have disable-model-invocation:
 #     true so fork is dormant anyway — cosmetic cleanup.
 #
 # 13 remaining ambient-only skills (architecture-patterns, brainstorming,

--- a/plugins/flow/tests/flow-start-onboarding.test.sh
+++ b/plugins/flow/tests/flow-start-onboarding.test.sh
@@ -1,161 +1,59 @@
-# plugins/flow/tests/flow-start-onboarding.test.sh
+# plugins/flow/tests/flow-start-onboarding.test.sh (goalCreation suite)
 #
-# Tests the Phase 0.5 onboarding detection in commands/start.md and the
-# FlowGoal auto-creation gate logic. The bash blocks in start.md are
-# pre-executed (`!` prefix) so they can be lifted verbatim and tested
-# here — same approach the other start-related tests use.
-#
-# Coverage:
-#   - Onboarding detection: returns "needed" when neither .claude/settings.flow.json
-#     nor .flow/ exist (fresh install signal).
-#   - Onboarding detection: returns "skip" when either signal is present
-#     (v2 upgrade or already-onboarded project).
-#   - Idempotency: after writing settings file (either enable or skip arm),
-#     re-running detection returns "skip".
-#   - FlowGoal auto-creation gate: when requireGoalForStart=true and a valid
-#     ISSUE_NUM is present, state is `create`; when goal file already exists,
-#     state is `exists`; when flag is false, state is `skip`.
+# #111 AC-1 retired the Phase 0.5 onboarding AskUserQuestion and the
+# set_flow_goals helper, replacing the binary requireGoalForStart with the
+# 3-state flow.goals.goalCreation (auto|always|off, default auto). This suite
+# now covers:
+#   - Read-only migration mapping (the compound jq expression start.md/pr.md/
+#     merge.md resolve): requireGoalForStart true->always, false->off,
+#     absent->auto, and explicit goalCreation wins over the legacy key.
+#   - The FlowGoal auto-creation gate keyed on GOAL_MODE != off, including the
+#     bare-$ARGUMENTS parsing regression guard from #120.
+#   - start.md documents the "verifiable ACs win" auto predicate (the
+#     prose-side gate Claude applies after the bash block).
+# The unrelated context:fork skill lint is preserved at the end.
 
-_flow_test_begin "onboarding detection: fresh install -> needed"
+# -- Migration mapping (the compound jq expression, --default auto) ------------
+MIG_EXPR='.flow.goals.goalCreation // (if .flow.goals.requireGoalForStart == true then "always" elif .flow.goals.requireGoalForStart == false then "off" else null end)'
 
-# Use a temp dir that's NOT the repo root. We're testing the detection logic
-# itself, not against the real repo state.
-TMP_DIR=$(mktemp -d -t flow-onboard.XXXXXX)
-trap 'rm -rf "$TMP_DIR"' EXIT
-
-ONBOARDING_BLOCK='
-NEEDS_ONBOARDING=0
-if [ -d .flow ]; then
-  NEEDS_ONBOARDING=0
-elif [ ! -f .claude/settings.flow.json ]; then
-  NEEDS_ONBOARDING=1
-else
-  if command -v jq >/dev/null 2>&1; then
-    HAS_GOALS=$(jq -e ".flow.goals // empty" .claude/settings.flow.json 2>/dev/null)
-    [ -z "$HAS_GOALS" ] && NEEDS_ONBOARDING=1
-  fi
-fi
-if [ "$NEEDS_ONBOARDING" = "1" ]; then
-  echo "FLOW_V3_ONBOARDING=needed"
-else
-  echo "FLOW_V3_ONBOARDING=skip"
-fi
-'
-
-# Fresh: neither file nor directory exists
-OUT=$(cd "$TMP_DIR" && bash -c "$ONBOARDING_BLOCK")
-assert_equal "FLOW_V3_ONBOARDING=needed" "$OUT" "fresh -> needed"
-
-
-_flow_test_begin "onboarding detection: settings file present -> skip"
-
-mkdir -p "$TMP_DIR/with-settings/.claude"
-echo '{"flow": {"goals": {"requireGoalForStart": false}}}' > "$TMP_DIR/with-settings/.claude/settings.flow.json"
-OUT=$(cd "$TMP_DIR/with-settings" && bash -c "$ONBOARDING_BLOCK")
-assert_equal "FLOW_V3_ONBOARDING=skip" "$OUT" "settings.flow.json present -> skip"
-
-
-_flow_test_begin "onboarding detection: .flow/ present -> skip"
-
-mkdir -p "$TMP_DIR/with-flow/.flow/goals"
-OUT=$(cd "$TMP_DIR/with-flow" && bash -c "$ONBOARDING_BLOCK")
-assert_equal "FLOW_V3_ONBOARDING=skip" "$OUT" ".flow/ present -> skip"
-
-
-_flow_test_begin "onboarding detection: both present -> skip"
-
-mkdir -p "$TMP_DIR/with-both/.claude" "$TMP_DIR/with-both/.flow"
-echo '{}' > "$TMP_DIR/with-both/.claude/settings.flow.json"
-OUT=$(cd "$TMP_DIR/with-both" && bash -c "$ONBOARDING_BLOCK")
-assert_equal "FLOW_V3_ONBOARDING=skip" "$OUT" "both present -> skip"
-
-
-_flow_test_begin "onboarding idempotency: enable arm writes valid JSON"
-
-ENABLE_DIR="$TMP_DIR/enable-arm"
-mkdir -p "$ENABLE_DIR"
-(
-  cd "$ENABLE_DIR"
-  mkdir -p .claude
-  cat > .claude/settings.flow.json <<'JSON'
-{
-  "flow": {
-    "goals": {
-      "requireGoalForStart": true,
-      "executeVerificationCommands": true
-    }
-  }
+_mig() {
+  printf '%s' "$1" | jq -r "($MIG_EXPR) // \"auto\""
 }
-JSON
-)
-assert_file_exists "$ENABLE_DIR/.claude/settings.flow.json" "enable arm: settings file exists"
 
 if command -v jq >/dev/null 2>&1; then
-  REQ=$(jq -r '.flow.goals.requireGoalForStart' "$ENABLE_DIR/.claude/settings.flow.json")
-  EXE=$(jq -r '.flow.goals.executeVerificationCommands' "$ENABLE_DIR/.claude/settings.flow.json")
-  assert_equal "true" "$REQ" "enable arm: requireGoalForStart=true"
-  assert_equal "true" "$EXE" "enable arm: executeVerificationCommands=true"
+  _flow_test_begin "migration: requireGoalForStart:true -> always"
+  assert_equal "always" "$(_mig '{"flow":{"goals":{"requireGoalForStart":true}}}')" "true maps to always"
+
+  _flow_test_begin "migration: requireGoalForStart:false -> off"
+  assert_equal "off" "$(_mig '{"flow":{"goals":{"requireGoalForStart":false}}}')" "false maps to off"
+
+  _flow_test_begin "migration: neither key (empty goals) -> auto"
+  assert_equal "auto" "$(_mig '{"flow":{"goals":{}}}')" "absent maps to auto (cascade default)"
+
+  _flow_test_begin "migration: no flow block at all -> auto"
+  assert_equal "auto" "$(_mig '{}')" "empty settings maps to auto"
+
+  _flow_test_begin "migration: explicit goalCreation wins over legacy key"
+  assert_equal "always" "$(_mig '{"flow":{"goals":{"goalCreation":"always","requireGoalForStart":false}}}')" "goalCreation overrides requireGoalForStart"
+  assert_equal "off" "$(_mig '{"flow":{"goals":{"goalCreation":"off","requireGoalForStart":true}}}')" "goalCreation:off overrides requireGoalForStart:true"
+
+  _flow_test_begin "migration: else-null lets a neither-key source fall through (no auto short-circuit)"
+  RAW=$(printf '%s' '{"flow":{"goals":{}}}' | jq -r "$MIG_EXPR")
+  assert_equal "null" "$RAW" "neither-key source yields null (falls through), not auto"
 else
-  _flow_assert_pass "enable arm: jq unavailable, skipping field check (file existence already verified)"
+  _flow_test_begin "migration mapping"
+  _flow_assert_pass "SKIP: jq not installed"
 fi
 
-# Re-detect: must return skip now
-OUT=$(cd "$ENABLE_DIR" && bash -c "$ONBOARDING_BLOCK")
-assert_equal "FLOW_V3_ONBOARDING=skip" "$OUT" "enable arm: re-detection returns skip (no re-prompt)"
 
-
-_flow_test_begin "onboarding idempotency: skip arm writes valid JSON"
-
-SKIP_DIR="$TMP_DIR/skip-arm"
-mkdir -p "$SKIP_DIR"
-(
-  cd "$SKIP_DIR"
-  mkdir -p .claude
-  cat > .claude/settings.flow.json <<'JSON'
-{
-  "flow": {
-    "goals": {
-      "requireGoalForStart": false,
-      "executeVerificationCommands": false
-    }
-  }
-}
-JSON
-)
-assert_file_exists "$SKIP_DIR/.claude/settings.flow.json" "skip arm: settings file exists"
-
-if command -v jq >/dev/null 2>&1; then
-  REQ=$(jq -r '.flow.goals.requireGoalForStart' "$SKIP_DIR/.claude/settings.flow.json")
-  assert_equal "false" "$REQ" "skip arm: requireGoalForStart=false"
-fi
-
-OUT=$(cd "$SKIP_DIR" && bash -c "$ONBOARDING_BLOCK")
-assert_equal "FLOW_V3_ONBOARDING=skip" "$OUT" "skip arm: re-detection returns skip"
-
-
-_flow_test_begin "goal auto-creation gate: requireGoal=true + ISSUE_NUM -> create"
-
-# Model Claude Code's slash-command preprocessor. It textually substitutes the
-# bare `$ARGUMENTS` and `${ARGUMENTS}` (braces, no operator) tokens with the
-# literal argument string, and leaves bash parameter-expansion forms like
-# `${ARGUMENTS%% *}` UNTOUCHED. Crucially it does NOT export ARGUMENTS into the
-# runtime environment — so a block that survives only because `${ARGUMENTS%% *}`
-# expanded against a real env var is broken in production. Earlier this fixture
-# ran `ARGUMENTS=42 bash -c "$BLOCK"`, which injected that env var and thereby
-# HID the bug: the broken `${ARGUMENTS%% *}` form "worked" in the test and
-# shipped degraded.
+# -- FlowGoal auto-creation gate (keyed on GOAL_MODE != off) -------------------
 cc_substitute() {
   local block="$1" arg="${2-}"
-  block="${block//\$\{ARGUMENTS\}/$arg}"   # ${ARGUMENTS} (braces, no operator)
-  block="${block//\$ARGUMENTS/$arg}"        # bare $ARGUMENTS
+  block="${block//\$\{ARGUMENTS\}/$arg}"
+  block="${block//\$ARGUMENTS/$arg}"
   printf '%s' "$block"
 }
 
-# Lift the gate logic from start.md and exercise it without invoking
-# cascade-resolve.sh — we pre-set REQUIRE_GOAL directly so this test is
-# hermetic and doesn't depend on the cascade implementation. The arg parse
-# uses the correct pattern: copy the bare (substituted) form into a local,
-# THEN apply parameter-expansion to the local.
 GOAL_GATE_BLOCK='
 _RAW="$ARGUMENTS"
 ARG1="${_RAW%% *}"
@@ -164,7 +62,7 @@ case "$ARG1" in
   *) ISSUE_NUM="$ARG1" ;;
 esac
 
-if [ "$REQUIRE_GOAL" = "true" ] && [ -n "$ISSUE_NUM" ]; then
+if [ "$GOAL_MODE" != "off" ] && [ -n "$ISSUE_NUM" ]; then
   GOAL_ID="issue-$ISSUE_NUM"
   GOAL_PATH=".flow/goals/${GOAL_ID}.goal.yaml"
   if [ -f "$GOAL_PATH" ]; then
@@ -180,252 +78,63 @@ else
 fi
 '
 
-# Each arm substitutes the arg into the block the way Claude Code would, then
-# runs it WITHOUT ARGUMENTS in the env (production never sets it).
-CREATE_DIR="$TMP_DIR/create-arm"
-mkdir -p "$CREATE_DIR"
-OUT=$(cd "$CREATE_DIR" && REQUIRE_GOAL=true bash -c "$(cc_substitute "$GOAL_GATE_BLOCK" "42")")
-assert_contains "FLOW_GOAL_STATE=create" "$OUT" "create arm: state=create"
-assert_contains "GOAL_ID=issue-42" "$OUT" "create arm: GOAL_ID=issue-42"
-assert_contains "GOAL_PATH=.flow/goals/issue-42.goal.yaml" "$OUT" "create arm: GOAL_PATH set"
+TMP_DIR=$(mktemp -d -t flow-goalcreation.XXXXXX)
+trap 'rm -rf "$TMP_DIR"' EXIT
 
+_flow_test_begin "gate: GOAL_MODE=auto + ISSUE_NUM -> create"
+CREATE_DIR="$TMP_DIR/create-arm"; mkdir -p "$CREATE_DIR"
+OUT=$(cd "$CREATE_DIR" && GOAL_MODE=auto bash -c "$(cc_substitute "$GOAL_GATE_BLOCK" "42")")
+assert_contains "FLOW_GOAL_STATE=create" "$OUT" "auto + issue -> create"
+assert_contains "GOAL_ID=issue-42" "$OUT" "GOAL_ID=issue-42"
+assert_contains "GOAL_PATH=.flow/goals/issue-42.goal.yaml" "$OUT" "GOAL_PATH set"
 
-_flow_test_begin "goal auto-creation gate: existing goal -> exists (no overwrite)"
-
-EXISTS_DIR="$TMP_DIR/exists-arm"
-mkdir -p "$EXISTS_DIR/.flow/goals"
+_flow_test_begin "gate: GOAL_MODE=always + existing goal -> exists (no overwrite)"
+EXISTS_DIR="$TMP_DIR/exists-arm"; mkdir -p "$EXISTS_DIR/.flow/goals"
 echo "apiVersion: flow.synapti.ai/v1" > "$EXISTS_DIR/.flow/goals/issue-42.goal.yaml"
-OUT=$(cd "$EXISTS_DIR" && REQUIRE_GOAL=true bash -c "$(cc_substitute "$GOAL_GATE_BLOCK" "42")")
-assert_contains "FLOW_GOAL_STATE=exists" "$OUT" "exists arm: state=exists"
-assert_not_contains "FLOW_GOAL_STATE=create" "$OUT" "exists arm: not flagged for creation"
+OUT=$(cd "$EXISTS_DIR" && GOAL_MODE=always bash -c "$(cc_substitute "$GOAL_GATE_BLOCK" "42")")
+assert_contains "FLOW_GOAL_STATE=exists" "$OUT" "always + existing -> exists"
+assert_not_contains "FLOW_GOAL_STATE=create" "$OUT" "not flagged for creation"
 
+_flow_test_begin "gate: GOAL_MODE=off -> skip"
+OUT=$(cd "$TMP_DIR" && GOAL_MODE=off bash -c "$(cc_substitute "$GOAL_GATE_BLOCK" "42")")
+assert_equal "FLOW_GOAL_STATE=skip" "$OUT" "off -> skip (manual /flow:goal create still works)"
 
-_flow_test_begin "goal auto-creation gate: requireGoal=false -> skip"
-
-OUT=$(cd "$TMP_DIR" && REQUIRE_GOAL=false bash -c "$(cc_substitute "$GOAL_GATE_BLOCK" "42")")
-assert_equal "FLOW_GOAL_STATE=skip" "$OUT" "requireGoal=false -> skip"
-
-
-_flow_test_begin "goal auto-creation gate: missing ISSUE_NUM -> skip"
-
-OUT=$(cd "$TMP_DIR" && REQUIRE_GOAL=true bash -c "$(cc_substitute "$GOAL_GATE_BLOCK" "")")
+_flow_test_begin "gate: GOAL_MODE=auto + missing ISSUE_NUM -> skip"
+OUT=$(cd "$TMP_DIR" && GOAL_MODE=auto bash -c "$(cc_substitute "$GOAL_GATE_BLOCK" "")")
 assert_equal "FLOW_GOAL_STATE=skip" "$OUT" "missing ISSUE_NUM -> skip"
 
+_flow_test_begin "gate: GOAL_MODE=auto + non-digit ARGUMENTS -> skip"
+OUT=$(cd "$TMP_DIR" && GOAL_MODE=auto bash -c "$(cc_substitute "$GOAL_GATE_BLOCK" "abc")")
+assert_equal "FLOW_GOAL_STATE=skip" "$OUT" "non-digit -> skip"
 
-_flow_test_begin "goal auto-creation gate: non-digit ARGUMENTS -> skip"
-
-OUT=$(cd "$TMP_DIR" && REQUIRE_GOAL=true bash -c "$(cc_substitute "$GOAL_GATE_BLOCK" "abc")")
-assert_equal "FLOW_GOAL_STATE=skip" "$OUT" "non-digit ARGUMENTS -> skip (matches Phase 0 validation)"
-
-
-_flow_test_begin "regression: old \${ARGUMENTS%% *} form degrades to skip under CC substitution"
-
-# The fixture's whole point: prove the bug now, so a revert to the broken form
-# fails here. Under faithful CC substitution (bare-only, no env var), the old
-# parameter-expansion form expands empty and the gate silently skips — even
-# with requireGoal=true and a valid issue number passed.
+_flow_test_begin "regression(#120): old \${ARGUMENTS%% *} form degrades to skip under CC substitution"
 OLD_BROKEN_BLOCK='
 ARG1="${ARGUMENTS%% *}"
 case "$ARG1" in
   ""|*[!0-9]*) ISSUE_NUM="" ;;
   *) ISSUE_NUM="$ARG1" ;;
 esac
-if [ "$REQUIRE_GOAL" = "true" ] && [ -n "$ISSUE_NUM" ]; then
+if [ "$GOAL_MODE" != "off" ] && [ -n "$ISSUE_NUM" ]; then
   echo "FLOW_GOAL_STATE=create"
 else
   echo "FLOW_GOAL_STATE=skip"
 fi
 '
-OUT=$(cd "$TMP_DIR" && REQUIRE_GOAL=true bash -c "$(cc_substitute "$OLD_BROKEN_BLOCK" "42")")
-assert_equal "FLOW_GOAL_STATE=skip" "$OUT" "old form expands empty under CC substitution (this IS the bug; env-injection fixture hid it)"
-
-# Sanity: the SAME arg through the SAME substitution model, but the fixed
-# block, must produce create — proving the fix, not just the bug.
-OUT=$(cd "$TMP_DIR" && REQUIRE_GOAL=true bash -c "$(cc_substitute "$GOAL_GATE_BLOCK" "42")")
-assert_contains "FLOW_GOAL_STATE=create" "$OUT" "fixed _RAW form produces create under the identical substitution model"
+OUT=$(cd "$TMP_DIR" && GOAL_MODE=auto bash -c "$(cc_substitute "$OLD_BROKEN_BLOCK" "42")")
+assert_equal "FLOW_GOAL_STATE=skip" "$OUT" "old form expands empty under CC substitution (this IS the #120 bug)"
+OUT=$(cd "$TMP_DIR" && GOAL_MODE=auto bash -c "$(cc_substitute "$GOAL_GATE_BLOCK" "42")")
+assert_contains "FLOW_GOAL_STATE=create" "$OUT" "fixed _RAW form produces create under the identical model"
 
 
-# ────────────────────────────────────────────────────────────────────────────
-# Partial-settings detection (cycle-10 regression fix — field-feedback bug)
-#
-# Before cycle 10, the onboarding gate only checked file existence. A user
-# who committed `.claude/settings.flow.json` with v2-only keys (e.g.,
-# `agentTeams`) silently bypassed the v3 onboarding prompt forever — the
-# file existed, so the gate skipped, but the user had never answered the
-# v3 question. Cycle 10 closes the bypass by checking for the `flow.goals`
-# block via jq.
-# ────────────────────────────────────────────────────────────────────────────
-
-_flow_test_begin "partial-settings detection: empty {} -> needed"
-
-if command -v jq >/dev/null 2>&1; then
-  EMPTY_DIR="$TMP_DIR/partial-empty"
-  mkdir -p "$EMPTY_DIR/.claude"
-  echo '{}' > "$EMPTY_DIR/.claude/settings.flow.json"
-  OUT=$(cd "$EMPTY_DIR" && bash -c "$ONBOARDING_BLOCK")
-  assert_equal "FLOW_V3_ONBOARDING=needed" "$OUT" "empty {} bypassed pre-cycle-10; now correctly prompts"
-else
-  _flow_assert_pass "skip: jq unavailable — partial detection requires jq"
-fi
-
-
-_flow_test_begin "partial-settings detection: v2-only keys (no flow) -> needed"
-
-if command -v jq >/dev/null 2>&1; then
-  V2_DIR="$TMP_DIR/partial-v2"
-  mkdir -p "$V2_DIR/.claude"
-  echo '{"agentTeams": false}' > "$V2_DIR/.claude/settings.flow.json"
-  OUT=$(cd "$V2_DIR" && bash -c "$ONBOARDING_BLOCK")
-  assert_equal "FLOW_V3_ONBOARDING=needed" "$OUT" "v2 settings without flow block -> prompt (this is the user's reported bug shape)"
-else
-  _flow_assert_pass "skip: jq unavailable"
-fi
-
-
-_flow_test_begin "partial-settings detection: flow block but no goals subkey -> needed"
-
-if command -v jq >/dev/null 2>&1; then
-  NO_GOALS_DIR="$TMP_DIR/partial-no-goals"
-  mkdir -p "$NO_GOALS_DIR/.claude"
-  echo '{"flow": {"agentTeams": false}}' > "$NO_GOALS_DIR/.claude/settings.flow.json"
-  OUT=$(cd "$NO_GOALS_DIR" && bash -c "$ONBOARDING_BLOCK")
-  assert_equal "FLOW_V3_ONBOARDING=needed" "$OUT" "flow block without goals subkey -> prompt"
-else
-  _flow_assert_pass "skip: jq unavailable"
-fi
-
-
-_flow_test_begin "partial-settings detection: empty flow.goals block -> skip (user has answered)"
-
-if command -v jq >/dev/null 2>&1; then
-  EMPTY_GOALS_DIR="$TMP_DIR/partial-empty-goals"
-  mkdir -p "$EMPTY_GOALS_DIR/.claude"
-  echo '{"flow": {"goals": {}}}' > "$EMPTY_GOALS_DIR/.claude/settings.flow.json"
-  OUT=$(cd "$EMPTY_GOALS_DIR" && bash -c "$ONBOARDING_BLOCK")
-  assert_equal "FLOW_V3_ONBOARDING=skip" "$OUT" "empty flow.goals -> skip (presence of block signals user has engaged with v3)"
-else
-  _flow_assert_pass "skip: jq unavailable"
-fi
-
-
-_flow_test_begin "partial-settings detection: .flow/ overrides partial settings (user is using v3)"
-
-if command -v jq >/dev/null 2>&1; then
-  OVERRIDE_DIR="$TMP_DIR/partial-with-flow-dir"
-  mkdir -p "$OVERRIDE_DIR/.claude" "$OVERRIDE_DIR/.flow/goals"
-  echo '{"agentTeams": false}' > "$OVERRIDE_DIR/.claude/settings.flow.json"
-  OUT=$(cd "$OVERRIDE_DIR" && bash -c "$ONBOARDING_BLOCK")
-  assert_equal "FLOW_V3_ONBOARDING=skip" "$OUT" ".flow/ dir signals active v3 use even with partial settings"
-else
-  _flow_assert_pass "skip: jq unavailable"
-fi
-
-
-_flow_test_begin "partial-settings detection: malformed JSON -> needed"
-
-if command -v jq >/dev/null 2>&1; then
-  BAD_DIR="$TMP_DIR/partial-malformed"
-  mkdir -p "$BAD_DIR/.claude"
-  echo '{ this is not valid json' > "$BAD_DIR/.claude/settings.flow.json"
-  OUT=$(cd "$BAD_DIR" && bash -c "$ONBOARDING_BLOCK")
-  assert_equal "FLOW_V3_ONBOARDING=needed" "$OUT" "malformed JSON -> prompt (jq parse failure signals user hasn't successfully opted in)"
-else
-  _flow_assert_pass "skip: jq unavailable"
-fi
-
-
-_flow_test_begin "partial-settings detection: array root -> needed"
-
-if command -v jq >/dev/null 2>&1; then
-  ARR_DIR="$TMP_DIR/partial-array"
-  mkdir -p "$ARR_DIR/.claude"
-  echo '[]' > "$ARR_DIR/.claude/settings.flow.json"
-  OUT=$(cd "$ARR_DIR" && bash -c "$ONBOARDING_BLOCK")
-  assert_equal "FLOW_V3_ONBOARDING=needed" "$OUT" "array root -> prompt (no flow.goals path through array)"
-else
-  _flow_assert_pass "skip: jq unavailable"
-fi
-
-
-_flow_test_begin "partial-settings detection: flow.goals = null -> needed"
-
-if command -v jq >/dev/null 2>&1; then
-  NULL_DIR="$TMP_DIR/partial-null"
-  mkdir -p "$NULL_DIR/.claude"
-  echo '{"flow": {"goals": null}}' > "$NULL_DIR/.claude/settings.flow.json"
-  OUT=$(cd "$NULL_DIR" && bash -c "$ONBOARDING_BLOCK")
-  assert_equal "FLOW_V3_ONBOARDING=needed" "$OUT" "flow.goals=null -> prompt (// empty filter drops null)"
-else
-  _flow_assert_pass "skip: jq unavailable"
-fi
-
-
-_flow_test_begin "set_flow_goals: refuses to overwrite when jq unavailable + file exists"
-
-# Lift the set_flow_goals body from start.md and verify the cycle-12 fix:
-# when the settings file exists but jq is missing, the helper MUST refuse to
-# write rather than clobber v2 keys with the heredoc fallback (which would
-# regress the cycle-10 fix on jq-less machines).
-NOJQ_DIR="$TMP_DIR/set-goals-nojq"
-mkdir -p "$NOJQ_DIR/.claude"
-echo '{"agentTeams": false, "tiers": {"merge": "confirm"}}' > "$NOJQ_DIR/.claude/settings.flow.json"
-
-SET_FLOW_GOALS_BLOCK='
-SETTINGS=.claude/settings.flow.json
-# Simulate jq absent by stubbing command -v so it returns false for jq.
-# Cannot rely on PATH manipulation because jq lives in multiple locations
-# on macOS (/opt/homebrew/bin AND /usr/bin) and trimming PATH risks
-# stripping other tools the helper needs. Override `command` via a function
-# in the subshell to surgically simulate the jq-missing case.
-command() {
-  if [ "$1" = "-v" ] && [ "$2" = "jq" ]; then
-    return 1
-  fi
-  builtin command "$@"
-}
-
-set_flow_goals() {
-  local req="$1" exe="$2"
-  if [ -f "$SETTINGS" ] && [ -L "$SETTINGS" ]; then
-    echo "ERROR_SYMLINK" >&2; return 1
-  fi
-  if [ -f "$SETTINGS" ]; then
-    if ! command -v jq >/dev/null 2>&1; then
-      echo "ERROR_REFUSE_NOJQ" >&2; return 1
-    fi
-    return 0
-  else
-    return 0
-  fi
-}
-set_flow_goals true true
-echo "EXIT=$?"
-'
-
-OUT=$(cd "$NOJQ_DIR" && bash -c "$SET_FLOW_GOALS_BLOCK" 2>&1)
-assert_contains "ERROR_REFUSE_NOJQ" "$OUT" "set_flow_goals emits refusal when jq missing + file exists"
-assert_contains "EXIT=1" "$OUT" "set_flow_goals returns non-zero in refusal path"
-
-# Sanity: settings file unchanged after refusal
-PRESERVED=$(cat "$NOJQ_DIR/.claude/settings.flow.json")
-assert_contains "agentTeams" "$PRESERVED" "v2 keys preserved when jq missing (no clobber)"
-
-
-_flow_test_begin "set_flow_goals: refuses symlinked settings file"
-
-# Symlink defense from cycle-12. .claude as symlink AND settings as symlink.
-SYM_DIR="$TMP_DIR/set-goals-symlink"
-mkdir -p "$SYM_DIR/.claude"
-SYM_TARGET="$TMP_DIR/sym-target-$$.json"
-echo '{"hostile": true}' > "$SYM_TARGET"
-ln -s "$SYM_TARGET" "$SYM_DIR/.claude/settings.flow.json"
-
-OUT=$(cd "$SYM_DIR" && bash -c "$SET_FLOW_GOALS_BLOCK" 2>&1)
-assert_contains "ERROR_SYMLINK" "$OUT" "set_flow_goals refuses symlinked settings file"
-
-# Target unchanged (hostile claim was true; refusal preserves it)
-SYM_CONTENT=$(cat "$SYM_TARGET")
-assert_contains "hostile" "$SYM_CONTENT" "symlink target unchanged after refusal"
+# -- start.md documents the verifiable-ACs-win auto predicate (prose gate) -----
+_flow_test_begin "start.md documents the auto verifiable-AC predicate + silent skip"
+START_CMD="$REPO_ROOT/plugins/flow/commands/start.md"
+SC=$(cat "$START_CMD")
+assert_contains "goalCreation" "$SC" "start.md references the 3-state goalCreation"
+assert_contains "verification_command" "$SC" "auto predicate keyed on verification_command"
+assert_contains "skip silently" "$SC" "spec-free / zero-verifiable path skips silently"
+assert_not_contains "FLOW_V3_ONBOARDING" "$SC" "Phase 0.5 onboarding fully retired"
+assert_not_contains "set_flow_goals" "$SC" "set_flow_goals helper removed"
 
 
 _flow_test_begin "skills invoked from command Inputs blocks do not use context: fork"
@@ -516,110 +225,4 @@ else
   EXTRA=$(comm -23 <(printf '%s\n' "$ALL_FORK") <(printf '%s\n' "$EXPECTED_FORK_SORTED") | head -3 | tr '\n' ',')
   MISSING=$(comm -13 <(printf '%s\n' "$ALL_FORK") <(printf '%s\n' "$EXPECTED_FORK_SORTED") | head -3 | tr '\n' ',')
   _flow_assert_fail "fork-set drift: extra=[$EXTRA] missing=[$MISSING]"
-fi
-
-
-_flow_test_begin "partial-settings merge: jq preserves v2 keys when enabling v3"
-
-if command -v jq >/dev/null 2>&1; then
-  MERGE_DIR="$TMP_DIR/partial-merge"
-  mkdir -p "$MERGE_DIR/.claude"
-  echo '{"agentTeams": false, "tiers": {"merge": "confirm"}}' > "$MERGE_DIR/.claude/settings.flow.json"
-
-  # Exercise the actual set_flow_goals semantics from commands/start.md.
-  # The helper is markdown-embedded so we lift the jq invocation here. If
-  # the markdown changes the merge expression, update this lift too — the
-  # alternative (no test) is the cycle-9 pattern we've moved away from.
-  (
-    cd "$MERGE_DIR"
-    SETTINGS=.claude/settings.flow.json
-    jq --argjson req true --argjson exe true \
-       '.flow.goals.requireGoalForStart = $req | .flow.goals.executeVerificationCommands = $exe' \
-       "$SETTINGS" > "${SETTINGS}.tmp" && mv "${SETTINGS}.tmp" "$SETTINGS"
-  )
-
-  AGENT_TEAMS=$(jq -r '.agentTeams' "$MERGE_DIR/.claude/settings.flow.json")
-  TIER_MERGE=$(jq -r '.tiers.merge' "$MERGE_DIR/.claude/settings.flow.json")
-  REQ_GOAL=$(jq -r '.flow.goals.requireGoalForStart' "$MERGE_DIR/.claude/settings.flow.json")
-  EXE_COMMANDS=$(jq -r '.flow.goals.executeVerificationCommands' "$MERGE_DIR/.claude/settings.flow.json")
-
-  assert_equal "false" "$AGENT_TEAMS" "merge: agentTeams preserved"
-  assert_equal "confirm" "$TIER_MERGE" "merge: tiers.merge preserved"
-  assert_equal "true" "$REQ_GOAL" "merge: requireGoalForStart written"
-  assert_equal "true" "$EXE_COMMANDS" "merge: executeVerificationCommands written"
-else
-  _flow_assert_pass "skip: jq unavailable — merge requires jq"
-fi
-
-
-_flow_test_begin "Enable v3 arm also writes flow.workflows.enabled (cycle-13 F5)"
-
-# F5: The 'Enable v3' arm in commands/start.md now invokes set_flow_workflows_enabled
-# after set_flow_goals. The helper merges flow.workflows.enabled=true into the
-# settings file via jq. Triggers stay separate opt-in (the Enable arm doesn't
-# touch flow.triggers).
-
-if command -v jq >/dev/null 2>&1; then
-  F5_DIR="$TMP_DIR/f5-enable-workflows"
-  mkdir -p "$F5_DIR/.claude"
-  echo '{"agentTeams": false}' > "$F5_DIR/.claude/settings.flow.json"
-
-  # Step 1: set_flow_goals (simulating the helper from commands/start.md).
-  (
-    cd "$F5_DIR"
-    SETTINGS=.claude/settings.flow.json
-    jq --argjson req true --argjson exe true \
-       '.flow.goals.requireGoalForStart = $req | .flow.goals.executeVerificationCommands = $exe' \
-       "$SETTINGS" > "${SETTINGS}.tmp" && mv "${SETTINGS}.tmp" "$SETTINGS"
-  )
-
-  # Step 2: set_flow_workflows_enabled (the F5 addition).
-  (
-    cd "$F5_DIR"
-    SETTINGS=.claude/settings.flow.json
-    jq --argjson en true '.flow.workflows.enabled = $en' \
-       "$SETTINGS" > "${SETTINGS}.tmp" && mv "${SETTINGS}.tmp" "$SETTINGS"
-  )
-
-  REQ_GOAL=$(jq -r '.flow.goals.requireGoalForStart' "$F5_DIR/.claude/settings.flow.json")
-  WORKFLOWS=$(jq -r '.flow.workflows.enabled' "$F5_DIR/.claude/settings.flow.json")
-  TRIGGERS=$(jq -r '.flow.triggers // "absent"' "$F5_DIR/.claude/settings.flow.json")
-  AGENT_TEAMS=$(jq -r '.agentTeams' "$F5_DIR/.claude/settings.flow.json")
-
-  assert_equal "true" "$REQ_GOAL" "F5: goals.requireGoalForStart still true after both helpers"
-  assert_equal "true" "$WORKFLOWS" "F5: workflows.enabled set to true"
-  assert_equal "absent" "$TRIGGERS" "F5: triggers section NOT touched (separate opt-in)"
-  assert_equal "false" "$AGENT_TEAMS" "F5: v2 keys still preserved"
-else
-  _flow_assert_pass "skip: jq unavailable — F5 helper requires jq"
-fi
-
-
-_flow_test_begin "Skip arm does NOT touch flow.workflows (F5 preserves user setting)"
-
-# If the user already had flow.workflows.enabled set to a specific value
-# (e.g., true from a prior Enable answer that was later disabled by hand),
-# choosing 'Skip — keep v2 behavior' must preserve that value, not clobber.
-
-if command -v jq >/dev/null 2>&1; then
-  SKIP_DIR="$TMP_DIR/f5-skip-preserves"
-  mkdir -p "$SKIP_DIR/.claude"
-  echo '{"flow": {"workflows": {"enabled": true}}}' > "$SKIP_DIR/.claude/settings.flow.json"
-
-  # Skip arm: set_flow_goals false false — does NOT call set_flow_workflows_enabled.
-  (
-    cd "$SKIP_DIR"
-    SETTINGS=.claude/settings.flow.json
-    jq --argjson req false --argjson exe false \
-       '.flow.goals.requireGoalForStart = $req | .flow.goals.executeVerificationCommands = $exe' \
-       "$SETTINGS" > "${SETTINGS}.tmp" && mv "${SETTINGS}.tmp" "$SETTINGS"
-  )
-
-  WORKFLOWS_AFTER=$(jq -r '.flow.workflows.enabled' "$SKIP_DIR/.claude/settings.flow.json")
-  REQ_GOAL_AFTER=$(jq -r '.flow.goals.requireGoalForStart' "$SKIP_DIR/.claude/settings.flow.json")
-
-  assert_equal "true" "$WORKFLOWS_AFTER" "F5: Skip preserves pre-existing flow.workflows.enabled=true"
-  assert_equal "false" "$REQ_GOAL_AFTER" "F5: Skip writes flow.goals.requireGoalForStart=false"
-else
-  _flow_assert_pass "skip: jq unavailable — F5 helper requires jq"
 fi

--- a/plugins/flow/tests/flow-status-learn-v3.test.sh
+++ b/plugins/flow/tests/flow-status-learn-v3.test.sh
@@ -41,7 +41,7 @@ assert_contains "not_executed" "$CONTENT" "not_executed signal documented"
 assert_contains "Path-boundary violations" "$CONTENT" "path violation signal documented"
 
 
-# --- #111 AC-5: /flow:status compact dashboard + deep modes -------------------
+# --- /flow:status compact dashboard + deep modes ----------------------------
 _flow_test_begin "AC-5: status.md documents compact default + --full/--json/--evidence modes"
 CONTENT=$(cat "$STATUS_CMD")
 assert_contains "STATUS_MODE" "$CONTENT" "mode dispatch variable present"

--- a/plugins/flow/tests/flow-status-learn-v3.test.sh
+++ b/plugins/flow/tests/flow-status-learn-v3.test.sh
@@ -42,7 +42,7 @@ assert_contains "Path-boundary violations" "$CONTENT" "path violation signal doc
 
 
 # --- /flow:status compact dashboard + deep modes ----------------------------
-_flow_test_begin "AC-5: status.md documents compact default + --full/--json/--evidence modes"
+_flow_test_begin "status.md documents compact default + --full/--json/--evidence modes"
 CONTENT=$(cat "$STATUS_CMD")
 assert_contains "STATUS_MODE" "$CONTENT" "mode dispatch variable present"
 assert_contains '`compact` (default)' "$CONTENT" "compact is the default mode"
@@ -69,15 +69,15 @@ _run_mode() {  # $1 = ARGUMENTS value
   bash -c "$blk"
 }
 
-_flow_test_begin "AC-5: mode parse — no arg -> compact"
+_flow_test_begin "mode parse — no arg -> compact"
 assert_contains "STATUS_MODE=compact" "$(_run_mode '')" "default (no arg) is compact"
 
-_flow_test_begin "AC-5: mode parse — --full/--json/--evidence map to their modes"
+_flow_test_begin "mode parse — --full/--json/--evidence map to their modes"
 assert_contains "STATUS_MODE=full" "$(_run_mode '--full')" "--full -> full"
 assert_contains "STATUS_MODE=json" "$(_run_mode '--json')" "--json -> json"
 assert_contains "STATUS_MODE=evidence" "$(_run_mode '--evidence')" "--evidence -> evidence"
 
-_flow_test_begin "AC-5: mode parse — unknown arg falls back to compact (no error)"
+_flow_test_begin "mode parse — unknown arg falls back to compact (no error)"
 OUT=$(_run_mode '--bogus')
 assert_contains "STATUS_MODE=compact" "$OUT" "unknown arg -> compact"
 assert_contains "STATUS_MODE_NOTE=unknown arg" "$OUT" "unknown arg surfaces a note"

--- a/plugins/flow/tests/flow-status-learn-v3.test.sh
+++ b/plugins/flow/tests/flow-status-learn-v3.test.sh
@@ -1,10 +1,10 @@
-# Tests for plugins/flow/commands/status.md + learn.md v3 sections (cycle-13 F2 + F3).
-# Source-presence lints; behavioral coverage is in flow-cycle14-behavioral.test.sh.
+# Tests for plugins/flow/commands/status.md + learn.md v3 sections.
+# Source-presence lints; behavioral coverage is in flow--behavioral.test.sh.
 
 STATUS_CMD="$REPO_ROOT/plugins/flow/commands/status.md"
 LEARN_CMD="$REPO_ROOT/plugins/flow/commands/learn.md"
 
-_flow_test_begin "F2 — /flow:status includes FlowGoal State + Recent Runs sections"
+_flow_test_begin "/flow:status includes FlowGoal State + Recent Runs sections"
 if [ ! -f "$STATUS_CMD" ]; then
   _flow_assert_fail "status.md missing"
 else
@@ -17,11 +17,11 @@ else
   assert_contains "last-verdict.json" "$CONTENT" "Recent Runs reads last-verdict.json"
 fi
 
-_flow_test_begin "F2 — /flow:status Suggestions table mentions /flow:goal evaluate"
+_flow_test_begin "/flow:status Suggestions table mentions /flow:goal evaluate"
 CONTENT=$(cat "$STATUS_CMD")
 assert_contains "/flow:goal evaluate" "$CONTENT" "suggestion table includes /flow:goal evaluate path"
 
-_flow_test_begin "F3 — /flow:learn discovers FlowRun events + goal yamls"
+_flow_test_begin "/flow:learn discovers FlowRun events + goal yamls"
 if [ ! -f "$LEARN_CMD" ]; then
   _flow_assert_fail "learn.md missing"
 else
@@ -32,7 +32,7 @@ else
   assert_contains 'flow.goals.enabled' "$CONTENT" "gated behind enabled flag"
 fi
 
-_flow_test_begin "F3 — /flow:learn Phase 2 has Goal Failure Patterns category"
+_flow_test_begin "/flow:learn Phase 2 has Goal Failure Patterns category"
 CONTENT=$(cat "$LEARN_CMD")
 assert_contains "Goal Failure Patterns" "$CONTENT" "category heading present"
 assert_contains "Recurring failed ACs" "$CONTENT" "AC failure signal documented"

--- a/plugins/flow/tests/flow-status-learn-v3.test.sh
+++ b/plugins/flow/tests/flow-status-learn-v3.test.sh
@@ -39,3 +39,45 @@ assert_contains "Recurring failed ACs" "$CONTENT" "AC failure signal documented"
 assert_contains "Stuck-detection hits" "$CONTENT" "stuck signal documented"
 assert_contains "not_executed" "$CONTENT" "not_executed signal documented"
 assert_contains "Path-boundary violations" "$CONTENT" "path violation signal documented"
+
+
+# --- #111 AC-5: /flow:status compact dashboard + deep modes -------------------
+_flow_test_begin "AC-5: status.md documents compact default + --full/--json/--evidence modes"
+CONTENT=$(cat "$STATUS_CMD")
+assert_contains "STATUS_MODE" "$CONTENT" "mode dispatch variable present"
+assert_contains '`compact` (default)' "$CONTENT" "compact is the default mode"
+assert_contains '### `--full`' "$CONTENT" "--full mode documented"
+assert_contains '### `--json`' "$CONTENT" "--json mode documented"
+assert_contains '### `--evidence`' "$CONTENT" "--evidence mode documented"
+assert_contains "Next safe action" "$CONTENT" "compact dashboard includes next-safe-action line"
+assert_contains "v3 not enabled" "$CONTENT" "(v3 not enabled) gating preserved across modes"
+
+# Behavioral: extract the Mode !-block and confirm arg parsing + unknown fallback.
+MODE_BLOCK=$(python3 - "$STATUS_CMD" <<'PY'
+import sys, re
+src = open(sys.argv[1]).read()
+# The first ```! fenced block after the "## Mode" heading.
+after = src.split("## Mode", 1)[1]
+m = re.search(r"```!\n(.*?)\n```", after, re.S)
+sys.stdout.write(m.group(1) if m else "")
+PY
+)
+_run_mode() {  # $1 = ARGUMENTS value
+  local raw="$1"
+  local blk="${MODE_BLOCK//\$\{ARGUMENTS\}/$raw}"
+  blk="${blk//\$ARGUMENTS/$raw}"
+  bash -c "$blk"
+}
+
+_flow_test_begin "AC-5: mode parse — no arg -> compact"
+assert_contains "STATUS_MODE=compact" "$(_run_mode '')" "default (no arg) is compact"
+
+_flow_test_begin "AC-5: mode parse — --full/--json/--evidence map to their modes"
+assert_contains "STATUS_MODE=full" "$(_run_mode '--full')" "--full -> full"
+assert_contains "STATUS_MODE=json" "$(_run_mode '--json')" "--json -> json"
+assert_contains "STATUS_MODE=evidence" "$(_run_mode '--evidence')" "--evidence -> evidence"
+
+_flow_test_begin "AC-5: mode parse — unknown arg falls back to compact (no error)"
+OUT=$(_run_mode '--bogus')
+assert_contains "STATUS_MODE=compact" "$OUT" "unknown arg -> compact"
+assert_contains "STATUS_MODE_NOTE=unknown arg" "$OUT" "unknown arg surfaces a note"

--- a/plugins/flow/tests/flow-throttle-stuck-presence.test.sh
+++ b/plugins/flow/tests/flow-throttle-stuck-presence.test.sh
@@ -59,3 +59,9 @@ CONTENT=$(cat "$HOOK")
 assert_contains "status: failed" "$CONTENT" "lifecycle fragment uses 'status: failed'"
 assert_contains 'flow-goal-record.sh' "$CONTENT" "transition invokes the canonical writer"
 assert_contains '--from-status active' "$CONTENT" "from-status guard prevents racing transitions"
+
+# --- evaluator resolves the active goal branch-aware (not an inline scan) ------
+_flow_test_begin "evaluator delegates active-goal lookup to the branch-strict resolver"
+HOOK_SRC=$(cat "$REPO_ROOT/plugins/flow/hooks/scripts/flow-goal-evaluator.sh")
+assert_contains "flow-active-goal.sh" "$HOOK_SRC" "uses the centralized resolver"
+assert_contains "--path --branch-strict" "$HOOK_SRC" "resolves the current branch's goal (no cross-branch / alphabetical-first pick)"

--- a/plugins/flow/tests/flow-throttle-stuck-presence.test.sh
+++ b/plugins/flow/tests/flow-throttle-stuck-presence.test.sh
@@ -1,4 +1,4 @@
-# Tests for plugins/flow/hooks/scripts/flow-goal-evaluator.sh throttle log + stuck-detection (cycle-13 F8 + F9).
+# Tests for plugins/flow/hooks/scripts/flow-goal-evaluator.sh throttle log + stuck-detection.
 # Source-presence lint tests. These are lint-style checks that the new behavior
 # remains in the hook script — they catch regressions where someone
 # removes the logic during a refactor without realizing it.
@@ -9,8 +9,8 @@
 
 HOOK="$REPO_ROOT/plugins/flow/hooks/scripts/flow-goal-evaluator.sh"
 
-# --- F8: throttle block writes events.jsonl
-_flow_test_begin "F8 — throttle block writes a throttle-block event to .flow/runs/<id>/events.jsonl"
+# --- throttle block writes events.jsonl
+_flow_test_begin "throttle block writes a throttle-block event to .flow/runs/<id>/events.jsonl"
 
 if [ ! -f "$HOOK" ]; then
   _flow_assert_fail "hook script missing at $HOOK"
@@ -22,8 +22,8 @@ else
   assert_contains 'events.jsonl' "$CONTENT" "events.jsonl write target present"
 fi
 
-# --- F9: stuck-detection helper exists
-_flow_test_begin "F9 — _check_stuck helper defined in hook source"
+# --- stuck-detection helper exists
+_flow_test_begin "_check_stuck helper defined in hook source"
 
 if [ ! -f "$HOOK" ]; then
   _flow_assert_fail "hook script missing"
@@ -36,8 +36,8 @@ else
   assert_contains "stuck-detection-fired" "$CONTENT" "stuck event type emitted to events.jsonl"
 fi
 
-# --- F9: stuck-detection invoked from both must-pass-fail and judge paths
-_flow_test_begin "F9 — _check_stuck called from must-pass-fail path"
+# --- stuck-detection invoked from both must-pass-fail and judge paths
+_flow_test_begin "_check_stuck called from must-pass-fail path"
 CONTENT=$(cat "$HOOK")
 # Count occurrences of _check_stuck calls. Should be:
 #   1× definition (function declaration)
@@ -48,11 +48,11 @@ CALL_COUNT=$(grep -c "_check_stuck" "$HOOK")
 if [ "$CALL_COUNT" -ge "3" ]; then
   _flow_assert_pass "expected ≥3 occurrences (definition + 2 call sites); got $CALL_COUNT"
 else
-  _flow_assert_fail "expected ≥3 _check_stuck occurrences (definition + ≥2 calls); got $CALL_COUNT — F9 may not be integrated into both paths"
+  _flow_assert_fail "expected ≥3 _check_stuck occurrences (definition + ≥2 calls); got $CALL_COUNT — stuck-detection may not be integrated into both paths"
 fi
 
-# --- F9: lifecycle YAML fragment uses correct status name
-_flow_test_begin "F9 — lifecycle transition writes status:failed"
+# --- lifecycle YAML fragment uses correct status name
+_flow_test_begin "lifecycle transition writes status:failed"
 CONTENT=$(cat "$HOOK")
 # When stuck fires, the hook writes a lifecycle YAML to a temp file with
 # status:failed. Verify the literal is present.

--- a/plugins/flow/tests/flow-tier-classification-lint.test.sh
+++ b/plugins/flow/tests/flow-tier-classification-lint.test.sh
@@ -1,9 +1,9 @@
-# Tests for the Tier Classification convention (cycle 13, F12).
+# Tests for the Tier Classification convention.
 #
 # Every commands/*.md MUST include a `## Tier Classification` section so
 # users can see at a glance what actions the command takes and at which
-# safety tier. This lint runs in CI to prevent regression — the cycle-12
-# review found 6 v3 commands missing the section.
+# safety tier. This lint runs in CI to prevent regression — an audit
+# found v3 commands missing the section.
 
 _flow_test_begin "every commands/*.md has '## Tier Classification'"
 

--- a/plugins/flow/tests/flow-trigger-cross-ref.test.sh
+++ b/plugins/flow/tests/flow-trigger-cross-ref.test.sh
@@ -1,4 +1,4 @@
-# Source-presence + contract test for cycle-13 F13 — trigger-policy now
+# Source-presence + contract test for trigger-policy: it now
 # verifies trigger.target.workflow resolves to an existing workflow YAML.
 #
 # Lint-style: verify the SKILL.md documents the step + hard-fail semantics.
@@ -7,7 +7,7 @@
 
 SKILL="$REPO_ROOT/plugins/flow/skills/trigger-policy/SKILL.md"
 
-_flow_test_begin "F13 — trigger-policy documents target workflow cross-ref step"
+_flow_test_begin "trigger-policy documents target workflow cross-ref step"
 
 if [ ! -f "$SKILL" ]; then
   _flow_assert_fail "trigger-policy/SKILL.md missing at $SKILL"
@@ -22,6 +22,6 @@ else
   assert_contains "Hard fail" "$CONTENT" "documented as hard fail (not soft warning)"
 fi
 
-_flow_test_begin "F13 — overall verdict table includes cross-reference branch"
+_flow_test_begin "overall verdict table includes cross-reference branch"
 CONTENT=$(cat "$SKILL")
 assert_contains "cross_reference_failed" "$CONTENT" "overall verdict has cross-ref branch"

--- a/plugins/flow/tests/flow-workflow-completion-gate-rename.test.sh
+++ b/plugins/flow/tests/flow-workflow-completion-gate-rename.test.sh
@@ -1,4 +1,4 @@
-# Tests for cycle-13 F4 — completion_gate.requires renamed to documented_requirements.
+# Tests that completion_gate.requires was renamed to documented_requirements.
 #
 # Contract:
 #   - Schema accepts the new name (documented_requirements)

--- a/plugins/flow/tests/pr-v3-integration.test.sh
+++ b/plugins/flow/tests/pr-v3-integration.test.sh
@@ -1,7 +1,7 @@
 # Tests for the v3 runtime integration — pr.md goal gate + FlowRun activity.
 #
 # The FlowGoal 5-state gate already exists and is covered by
-# flow-cycle14-behavioral.test.sh; this file asserts that gate contract holds
+# flow--behavioral.test.sh; this file asserts that gate contract holds
 # and the newer pieces are wired:
 #   - AC4: pr.md blocks PR creation when the linked goal is not `achieved`,
 #     WITH an override path (Option 2) that records an escalation-resolved

--- a/plugins/flow/tests/start-v3-integration.test.sh
+++ b/plugins/flow/tests/start-v3-integration.test.sh
@@ -1,6 +1,6 @@
 # Tests for the v3 runtime integration — FlowRun wiring in commands/start.md.
 #
-# FlowGoal creation in start.md (gated on flow.goals.goalCreation, #111 AC-1)
+# FlowGoal creation in start.md (gated on flow.goals.goalCreation)
 # is covered elsewhere. This file covers the FlowRun layer + the AC-2 summary:
 #   - start.md creates a FlowRun at entry (workflow=start-issue), linked to the
 #     FlowGoal, gated by flow.runtime.enabled, delegating to run-state-management.
@@ -83,7 +83,7 @@ assert_contains "FLOW_RUN_STATE=skip" "$OUT2" "runtime disabled → skip"
 assert_not_contains "FLOW_RUN_STATE=create" "$OUT2" "does not create when disabled"
 
 
-# --- #111 AC-2: compact runtime summary replaces the FlowGoal-created dump ----
+# --- compact runtime summary replaces the FlowGoal-created dump -------------
 _flow_test_begin "AC-2: start.md emits a compact runtime summary, not a FlowGoal-created dump"
 START_CMD="$REPO_ROOT/plugins/flow/commands/start.md"
 SC=$(cat "$START_CMD")

--- a/plugins/flow/tests/start-v3-integration.test.sh
+++ b/plugins/flow/tests/start-v3-integration.test.sh
@@ -1,7 +1,7 @@
 # Tests for the v3 runtime integration — FlowRun wiring in commands/start.md.
 #
-# FlowGoal creation in start.md already exists (gated on requireGoalForStart)
-# and is covered elsewhere. This file covers only the NEW FlowRun layer:
+# FlowGoal creation in start.md (gated on flow.goals.goalCreation, #111 AC-1)
+# is covered elsewhere. This file covers the FlowRun layer + the AC-2 summary:
 #   - start.md creates a FlowRun at entry (workflow=start-issue), linked to the
 #     FlowGoal, gated by flow.runtime.enabled, delegating to run-state-management.
 #   - It emits a workflow-run journal artifact (start is issue-scoped).

--- a/plugins/flow/tests/start-v3-integration.test.sh
+++ b/plugins/flow/tests/start-v3-integration.test.sh
@@ -1,7 +1,7 @@
 # Tests for the v3 runtime integration — FlowRun wiring in commands/start.md.
 #
 # FlowGoal creation in start.md (gated on flow.goals.goalCreation)
-# is covered elsewhere. This file covers the FlowRun layer + the AC-2 summary:
+# is covered elsewhere. This file covers the FlowRun layer + the compact runtime summary:
 #   - start.md creates a FlowRun at entry (workflow=start-issue), linked to the
 #     FlowGoal, gated by flow.runtime.enabled, delegating to run-state-management.
 #   - It emits a workflow-run journal artifact (start is issue-scoped).
@@ -84,7 +84,7 @@ assert_not_contains "FLOW_RUN_STATE=create" "$OUT2" "does not create when disabl
 
 
 # --- compact runtime summary replaces the FlowGoal-created dump -------------
-_flow_test_begin "AC-2: start.md emits a compact runtime summary, not a FlowGoal-created dump"
+_flow_test_begin "start.md emits a compact runtime summary, not a FlowGoal-created dump"
 START_CMD="$REPO_ROOT/plugins/flow/commands/start.md"
 SC=$(cat "$START_CMD")
 assert_not_contains "FlowGoal created: <GOAL_ID> at <GOAL_PATH>" "$SC" "old per-artifact dump line removed"
@@ -92,6 +92,6 @@ assert_contains "Runtime summary" "$SC" "compact runtime summary section present
 assert_contains "I'll work until the goal is achieved, blocked, or needs your decision" "$SC" "one-line working statement present"
 assert_contains "verifiable-count" "$SC" "summary sources AC counts from flow-active-goal.sh --verifiable-count"
 
-_flow_test_begin "AC-2: degenerate goals are flagged, never shown as a clean active line"
+_flow_test_begin "degenerate goals are flagged, never shown as a clean active line"
 assert_contains "degenerate / needs-attention" "$SC" "degenerate marker documented"
 assert_contains "omit the Goal line entirely" "$SC" "skipped-goal path omits the goal line (no phantom goal)"

--- a/plugins/flow/tests/start-v3-integration.test.sh
+++ b/plugins/flow/tests/start-v3-integration.test.sh
@@ -81,3 +81,17 @@ _extract_run_block > "$WORK2/block.sh"
 OUT2=$(cd "$WORK2" && CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" ARGUMENTS="110" bash block.sh 2>/dev/null)
 assert_contains "FLOW_RUN_STATE=skip" "$OUT2" "runtime disabled → skip"
 assert_not_contains "FLOW_RUN_STATE=create" "$OUT2" "does not create when disabled"
+
+
+# --- #111 AC-2: compact runtime summary replaces the FlowGoal-created dump ----
+_flow_test_begin "AC-2: start.md emits a compact runtime summary, not a FlowGoal-created dump"
+START_CMD="$REPO_ROOT/plugins/flow/commands/start.md"
+SC=$(cat "$START_CMD")
+assert_not_contains "FlowGoal created: <GOAL_ID> at <GOAL_PATH>" "$SC" "old per-artifact dump line removed"
+assert_contains "Runtime summary" "$SC" "compact runtime summary section present"
+assert_contains "I'll work until the goal is achieved, blocked, or needs your decision" "$SC" "one-line working statement present"
+assert_contains "verifiable-count" "$SC" "summary sources AC counts from flow-active-goal.sh --verifiable-count"
+
+_flow_test_begin "AC-2: degenerate goals are flagged, never shown as a clean active line"
+assert_contains "degenerate / needs-attention" "$SC" "degenerate marker documented"
+assert_contains "omit the Goal line entirely" "$SC" "skipped-goal path omits the goal line (no phantom goal)"

--- a/plugins/flow/tests/status-triggers-v3-integration.test.sh
+++ b/plugins/flow/tests/status-triggers-v3-integration.test.sh
@@ -38,8 +38,11 @@ TR=$(jq -r '.flow.triggers.enabled' "$SETTINGS")
 assert_equal "true" "$WF" "flow.workflows.enabled is true"
 assert_equal "true" "$TR" "flow.triggers.enabled is true"
 
-_flow_test_begin "goal-creation default NOT flipped here (owned by the UX layer)"
-# The FlowRun integration must NOT introduce a binary requireGoalForStart:true
-# default — that migration belongs to the UX layer. Assert the default stays false.
-RGS=$(jq -r '.flow.goals.requireGoalForStart' "$SETTINGS")
-assert_equal "false" "$RGS" "requireGoalForStart default left false (not flipped by this work)"
+_flow_test_begin "goalCreation default is auto (set by the #111 UX layer)"
+# #111 AC-1 retires the binary requireGoalForStart in favor of the 3-state
+# goalCreation (default auto). The legacy key is migrated read-only and must no
+# longer appear as a settings default.
+GC=$(jq -r '.flow.goals.goalCreation' "$SETTINGS")
+assert_equal "auto" "$GC" "goalCreation default is auto"
+RGS=$(jq -r '.flow.goals.requireGoalForStart // "absent"' "$SETTINGS")
+assert_equal "absent" "$RGS" "legacy requireGoalForStart removed from settings default"

--- a/plugins/flow/tests/status-triggers-v3-integration.test.sh
+++ b/plugins/flow/tests/status-triggers-v3-integration.test.sh
@@ -38,8 +38,8 @@ TR=$(jq -r '.flow.triggers.enabled' "$SETTINGS")
 assert_equal "true" "$WF" "flow.workflows.enabled is true"
 assert_equal "true" "$TR" "flow.triggers.enabled is true"
 
-_flow_test_begin "goalCreation default is auto (set by the #111 UX layer)"
-# #111 AC-1 retires the binary requireGoalForStart in favor of the 3-state
+_flow_test_begin "goalCreation default is auto (set by the v3.1 UX layer)"
+# The v3.1 UX layer retires the binary requireGoalForStart in favor of the 3-state
 # goalCreation (default auto). The legacy key is migrated read-only and must no
 # longer appear as a settings default.
 GC=$(jq -r '.flow.goals.goalCreation' "$SETTINGS")


### PR DESCRIPTION
## Summary

Implements **#111** (v3.1 UX layer — invisible-by-default runtime) and fixes **#122** (FlowGoal merge gate could never observe an `achieved` goal). Guiding principle of #111: *user intent in, runtime artifacts out* — goals/runs/evidence are managed for the user rather than gated behind opt-in.

Closes #111. Closes #122.

## #111 — Acceptance criteria

| AC | Status | What shipped |
|----|--------|--------------|
| **AC-1** conditional-auto `goalCreation` | ✅ | Replaced binary `requireGoalForStart` with 3-state `flow.goals.goalCreation: auto\|always\|off` (default `auto`). `auto` creates a goal iff ≥1 AC carries a `verification_command` (labels don't veto; zero-verifiable issues skip silently). Read-only migration (`true`→`always`, `false`→`off`, absent→`auto`) via a compound-jq expression with `else null` + `--default auto`. Phase 0.5 onboarding `AskUserQuestion` + `set_flow_goals` helper retired. |
| **AC-2** compact runtime summary | ✅ | `/flow:start` replaces the `FlowGoal created: …` dump with a compact Goal/Workflow/Run/Branch summary; a degenerate goal (0 ACs, or 0 verifiable ACs) is flagged `⚠ degenerate / needs-attention`, never shown as a clean `active` line. |
| **AC-3** review/address FlowRun-only | ✅ | Shipped previously in #114 (no change here). |
| **AC-4** branch-first detection | ✅ | `bin/flow-active-goal.sh` resolves branch-first (`scope.branch == current branch`, fallback most-recently-modified active). Exit 3 fires only on >1 active goal on the *same* branch — concurrent goals across branches/worktrees stop colliding. Adds test-only `--branch` override + `--verifiable-count` mode. |
| **AC-5** `/flow:status` modes | ✅ | Default compact dashboard + `--full` / `--json` / `--evidence`; bare-`$ARGUMENTS`-first parse (#120), unknown arg → compact fallback. `(v3 not enabled)` gating preserved. |
| **AC-6** `/flow:resume` conservatism | ✅ | Detects uncommitted changes outside `.flow/` and `.decisions/` and asks before suggesting continuation, so a resumed run never silently absorbs unrelated work. Informational-only. |
| **AC-7** README reframe + count fix | ✅ | Work-first lead; six runtime primitives demoted to "Advanced / runtime internals"; `/flow:goal create` reframed as `--manual`. Fixed `COMMANDS (17)` → `(23)`; `FILE_COUNT_FLOOR` 15→20; added a test that keeps the README count in sync with actual command files. |

### Key design decisions (full rationale in `.decisions/issue-111.md`)
- **Verifiable ACs win** over the spec-free label: an issue with rigorous verifiable ACs gets a goal even if `documentation`-labeled. The revised AC-1 wording is reflected in the issue.
- **Gate on goal existence** (`pr.md`/`merge.md`): a branch whose goal isn't `achieved` is held back; a branch with **no** goal is **not** blocked (the prior exit-1 fail-closed is removed), preserving v2 merge UX for default installs. The gate is disabled under `goalCreation: off` or `goals.enabled: false`.
- **`else null` migration** (not `else "auto"`) fixes a precedence-leak where an unrelated `settings.flow.local.json` would have masked a project-level `requireGoalForStart` — guarded by a dedicated cascade-resolve test.

## #122 — FlowGoal gate unreachable-code fix

`flow-active-goal.sh` filtered `active`-only, so an `achieved` goal returned exit 1 and the gate's `if achieved → ok/pass` branch was dead code. With #111's gate-on-existence this no longer hard-blocked, but it mislabeled achieved goals as "no active FlowGoal — gate not applicable," losing the audit trail. Added an opt-in **`--allow-terminal`** flag (surfaces `achieved` goals as a branch-first fallback, only when no active goal exists; never trips exit 3) and wired it into both `merge.md` and `pr.md` gates. The Stop hook and `/flow:status` keep narrow active-only semantics by omitting the flag.

## Verification

- **Full plugin suite: 897 pass / 0 fail** (`bash plugins/flow/tests/run.sh`; baseline was 840). Net −negative LOC — the onboarding deletion outweighs additions.
- New/updated tests: branch-isolation + fallback (AC-4), migration **precedence-leak guard** (AC-1), gate-on-existence `STATE=none` (AC-1), degenerate marker (AC-2), `/flow:status` mode parser (AC-5), unlinked-change detection in throwaway git repos + git-quoted-path robustness (AC-6), dynamic README-count guard (AC-7), and the end-to-end `achieved`-path coverage gap #122 called out.

### Review (Path B — parallel, single session)
- **Code review**: P1: 0, P2: 0, P3: 1 — fixed in-PR (commit `fix(flow): resume unlinked-detection handles git-quoted paths`).
- **Security review**: 0 findings. Symlink defenses, `yaml.safe_load`, `PYTHONSAFEPATH`, list-form `subprocess`, and allowlisted-`case` settings clamps all intact across new code paths.

## Notes
- **No FlowGoal for this branch — by design.** This PR *modifies* the goal/run machinery itself, and a live `issue-120` goal already exists; running flow's own runtime on it would self-interfere. The decision journal (`.decisions/issue-111.md`) is the durable record. Under the new gate-on-existence semantics, a goal-less branch is not blocked at PR/merge.
- Version bump deferred to `/flow:release` (CHANGELOG entry is under `## Unreleased`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
