### PR TITLE
fix(flow): /flow:merge gate false-blocks + diagnostics (#124, #125, #126)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Synapti plugin marketplace",
-    "version": "4.6.0"
+    "version": "4.6.1"
   },
   "plugins": [
     {
@@ -109,7 +109,7 @@
       "name": "flow",
       "source": "./plugins/flow",
       "description": "Skill-driven workflow plugin for GitHub development with excellence-by-default quality gates. Encodes team knowledge as composable skills, enforces safety through hooks, compounds learning across sessions, and provides durable goals, workflows, triggers, and runs at .flow/.",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "author": {
         "name": "Daniel Bentes"
       },

--- a/plugins/flow/.claude-plugin/plugin.json
+++ b/plugins/flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Skill-driven workflow plugin for GitHub development with excellence-by-default quality gates. Encodes team knowledge as composable skills, enforces safety through hooks, and compounds learning across sessions. Strict TDD, Stranger Test, holdout validation, and evidence-based verification built in. Durable goals, workflows, triggers, and runs at .flow/.",
   "author": {
     "name": "Synapti AI",

--- a/plugins/flow/CHANGELOG.md
+++ b/plugins/flow/CHANGELOG.md
@@ -17,10 +17,11 @@
 - **Finding-ledger seed scans both marker streams (#126).** The merge assessment's diagnostic seed
   scanned only the issue-comments stream, so a PR whose only marker was a `FLOW_REVIEW_CYCLE` in a
   review body reported `SEED_MARKER_COUNT=0`. The seed now queries both the reviews and
-  issue-comments streams (matching the authoritative gate), emits `SEED_SCANNED` naming the surfaces,
-  and distinguishes a truly-absent marker (`SEED_MARKER_COUNT=0`) from a present-but-malformed one
-  (`SEED_FORMAT_INVALID`). Diagnostic-only — the gate already scanned both streams, so gate behavior
-  is unchanged.
+  issue-comments streams and emits `SEED_SCANNED` naming the surfaces. A marker is defined precisely
+  as `FLOW_*_CYCLE:<digits>`, so bare prose mentions and unsubstituted `:{N}` placeholders are not
+  counted (`SEED_MARKER_COUNT=0` means genuinely absent), and both the union and count jq steps fail
+  closed to `STATE=unavailable` on unreadable input rather than collapsing to a false `STATE=empty`.
+  Diagnostic-only — the authoritative gate already scanned both streams, so gate behavior is unchanged.
 
 ### Tests
 

--- a/plugins/flow/CHANGELOG.md
+++ b/plugins/flow/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 3.2.1 (2026-05-27)
+
+### Fixed: /flow:merge gate false-blocks + diagnostics
+
+- **Self-reviewed PRs no longer false-block at the finding-ledger gate (#124).** The self-review
+  fix-forward path fixes every finding in-PR but only posted a `FLOW_REVIEW_CYCLE` marker (status
+  `open`) with no `FLOW_RESOLUTION_CYCLE`. The merge gate balances `FINDINGS − RESOLVED` and reads
+  `RESOLVED` only from a `FLOW_RESOLUTION_CYCLE` issue comment, so a solo/agent-authored PR whose
+  findings were all fixed in-PR blocked at merge and required a manual Tier-3 override. Self-review
+  now emits the same `FLOW_RESOLUTION_CYCLE` marker `/flow:address` emits (issue-comments stream),
+  recording fix-forwarded IDs as `RESOLVED` and any unfixable finding as `ESCALATED` — unifying solo
+  and two-actor flows on the mechanism the gate already trusts, with **zero change to the gate's
+  classification logic**. Also adds the previously-missing `FLOW_REVIEW_CYCLE` marker to
+  `templates/self-review-comment.md`.
+- **Finding-ledger seed scans both marker streams (#126).** The merge assessment's diagnostic seed
+  scanned only the issue-comments stream, so a PR whose only marker was a `FLOW_REVIEW_CYCLE` in a
+  review body reported `SEED_MARKER_COUNT=0`. The seed now queries both the reviews and
+  issue-comments streams (matching the authoritative gate), emits `SEED_SCANNED` naming the surfaces,
+  and distinguishes a truly-absent marker (`SEED_MARKER_COUNT=0`) from a present-but-malformed one
+  (`SEED_FORMAT_INVALID`). Diagnostic-only — the gate already scanned both streams, so gate behavior
+  is unchanged.
+
+### Tests
+
+- **Regression guard for the terminal/achieved FlowGoal merge gate (#125).** #125's primary bug — an
+  `achieved` (terminal) goal read as "no active FlowGoal" and false-blocking merge — was already fixed
+  in 3.2.0 (`flow-active-goal.sh --allow-terminal --branch-strict`), but nothing pinned the
+  lifecycle→state mapping. Adds a consolidated guard asserting `achieved → ok`, `active → blocked`,
+  and `failed`/`cancelled`/no-goal `→ not-applicable`. Note: `failed`/`cancelled` resolve to
+  not-applicable **by design** (only `achieved` is a gate-relevant terminal state); #125's
+  failed/cancelled-should-block wishlist item is intentionally not implemented in 3.2.x — the merge
+  gate keys on an *active, incomplete* obligation, and an abandoned/closed goal defers to the PR's own
+  review state and the finding-ledger gate.
+
 ## 3.2.0 (2026-05-26)
 
 ### Added: v3.1 UX layer — invisible-by-default runtime (#111)

--- a/plugins/flow/commands/merge.md
+++ b/plugins/flow/commands/merge.md
@@ -102,28 +102,51 @@ else
   # Section: Finding-ledger seed (full gate runs in next ! block)
   echo ""
   echo "### Finding-Ledger Seed"
-  # Capture gh exit separately. Same reason as the Reviews section: the merge
-  # gate must close (STATE=unavailable) rather than open (STATE=empty) when
+  # DIAGNOSTIC PREVIEW ONLY — the authoritative gate runs in the next ! block and
+  # scans both streams with trust filtering. This seed exists so the assessment can
+  # report what markers are reachable before the gate runs.
+  #
+  # Markers live on TWO different GitHub objects (see references/finding-ledger-parser.md):
+  #   - FLOW_REVIEW_CYCLE     → PR review bodies     (repos/.../pulls/N/reviews)
+  #   - FLOW_RESOLUTION_CYCLE → PR/issue comments    (repos/.../issues/N/comments)
+  # Scanning only one stream (the historical bug, #126) undercounts: a PR whose only
+  # marker is a FLOW_REVIEW_CYCLE in a review body reported SEED_MARKER_COUNT=0 even
+  # though the gate would find it. Scan both and union the hits.
+  #
+  # Capture gh exit separately per endpoint. Same reason as the Reviews section: the
+  # merge gate must close (STATE=unavailable) rather than open (STATE=empty) when
   # markers can't be read.
-  SEED_JSON=$(gh api "repos/$REPO/issues/$PR_NUM/comments" --jq '[.[] | select(.body | test("FLOW_RESOLUTION_CYCLE|FLOW_REVIEW_CYCLE")) | {id, body}]' 2>/dev/null); GH_EXIT=$?
-  if [ $GH_EXIT -ne 0 ]; then
+  SEED_COMMENTS=$(gh api "repos/$REPO/issues/$PR_NUM/comments" --jq '[.[] | select(.body | test("FLOW_RESOLUTION_CYCLE|FLOW_REVIEW_CYCLE")) | {id, body, surface: "issue-comments"}]' 2>/dev/null); GH_EXIT_C=$?
+  SEED_REVIEWS=$(gh api "repos/$REPO/pulls/$PR_NUM/reviews" --jq '[.[] | select(.body | test("FLOW_RESOLUTION_CYCLE|FLOW_REVIEW_CYCLE")) | {id, body, surface: "reviews"}]' 2>/dev/null); GH_EXIT_R=$?
+  echo "SEED_SCANNED=reviews,issue-comments"
+  if [ $GH_EXIT_C -ne 0 ] || [ $GH_EXIT_R -ne 0 ]; then
     echo "SEED_MARKER_COUNT=0"
     echo "STATE=unavailable"
+    echo "SEED_UNAVAILABLE=comments_exit=$GH_EXIT_C reviews_exit=$GH_EXIT_R"
   else
+    # Union both streams into one array for counting + per-marker emission.
+    SEED_JSON=$(printf '%s\n%s' "$SEED_COMMENTS" "$SEED_REVIEWS" | jq -s 'add // []' 2>/dev/null)
     SEED_COUNT=$(echo "$SEED_JSON" | jq 'length' 2>/dev/null)
     [ -z "$SEED_COUNT" ] && SEED_COUNT=0
     echo "SEED_MARKER_COUNT=$SEED_COUNT"
     if [ "$SEED_COUNT" = "0" ]; then
+      # Truly absent on both surfaces — distinct from "present but malformed" below.
       echo "STATE=empty"
     else
       # `scan` is a generator that yields each match; wrap in `[...]` to collect
       # all matches into an array, then take `last` (the actual marker —
       # typically in an HTML comment at end-of-body — earlier occurrences are
       # usually prose references). Two capture groups (kind, cycle) so each
-      # element is `[kind, cycle]`.
+      # element is `[kind, cycle]`. A marker line whose cycle is non-numeric (or
+      # whose kind/cycle won't parse) surfaces as SEED_FORMAT_INVALID so the
+      # operator can tell a malformed marker from an absent one.
       echo "$SEED_JSON" | jq -r '.[] | (
-        ([.body | scan("FLOW_(RESOLUTION|REVIEW)_CYCLE:([0-9]+)")] | last // ["?","?"]) as $last |
-        "SEED=id=\(.id) kind=\($last[0]) cycle=\($last[1])"
+        ([.body | scan("FLOW_(RESOLUTION|REVIEW)_CYCLE:([0-9]+)")] | last) as $last |
+        if $last == null then
+          "SEED_FORMAT_INVALID=id=\(.id) surface=\(.surface) (marker present but cycle not parseable)"
+        else
+          "SEED=id=\(.id) surface=\(.surface) kind=\($last[0]) cycle=\($last[1])"
+        end
       )' 2>/dev/null
     fi
   fi

--- a/plugins/flow/commands/merge.md
+++ b/plugins/flow/commands/merge.md
@@ -116,16 +116,32 @@ else
   # Capture gh exit separately per endpoint. Same reason as the Reviews section: the
   # merge gate must close (STATE=unavailable) rather than open (STATE=empty) when
   # markers can't be read.
-  SEED_COMMENTS=$(gh api "repos/$REPO/issues/$PR_NUM/comments" --jq '[.[] | select(.body | test("FLOW_RESOLUTION_CYCLE|FLOW_REVIEW_CYCLE")) | {id, body, surface: "issue-comments"}]' 2>/dev/null); GH_EXIT_C=$?
-  SEED_REVIEWS=$(gh api "repos/$REPO/pulls/$PR_NUM/reviews" --jq '[.[] | select(.body | test("FLOW_RESOLUTION_CYCLE|FLOW_REVIEW_CYCLE")) | {id, body, surface: "reviews"}]' 2>/dev/null); GH_EXIT_R=$?
+  # The select pattern requires the `:` form (FLOW_*_CYCLE:) so it matches what the
+  # authoritative gate selects (test("FLOW_REVIEW_CYCLE:") / test("FLOW_RESOLUTION_CYCLE:"))
+  # and never selects a bare prose mention of the marker NAME — otherwise a comment that
+  # merely references "FLOW_REVIEW_CYCLE" in prose would be flagged SEED_FORMAT_INVALID,
+  # a false positive the gate never raises.
+  SEED_COMMENTS=$(gh api "repos/$REPO/issues/$PR_NUM/comments" --jq '[.[] | select(.body | test("FLOW_RESOLUTION_CYCLE:|FLOW_REVIEW_CYCLE:")) | {id, body, surface: "issue-comments"}]' 2>/dev/null); GH_EXIT_C=$?
+  SEED_REVIEWS=$(gh api "repos/$REPO/pulls/$PR_NUM/reviews" --jq '[.[] | select(.body | test("FLOW_RESOLUTION_CYCLE:|FLOW_REVIEW_CYCLE:")) | {id, body, surface: "reviews"}]' 2>/dev/null); GH_EXIT_R=$?
   echo "SEED_SCANNED=reviews,issue-comments"
   if [ $GH_EXIT_C -ne 0 ] || [ $GH_EXIT_R -ne 0 ]; then
     echo "SEED_MARKER_COUNT=0"
     echo "STATE=unavailable"
     echo "SEED_UNAVAILABLE=comments_exit=$GH_EXIT_C reviews_exit=$GH_EXIT_R"
   else
-    # Union both streams into one array for counting + per-marker emission.
-    SEED_JSON=$(printf '%s\n%s' "$SEED_COMMENTS" "$SEED_REVIEWS" | jq -s 'add // []' 2>/dev/null)
+    # Union both streams into one array for counting + per-marker emission. Capture jq's
+    # exit so a malformed-JSON operand fails CLOSED (STATE=unavailable) rather than open:
+    # without this, a jq error swallowed by 2>/dev/null leaves SEED_JSON empty and the
+    # block would mislabel a real marker stream as STATE=empty ("no markers"). Mirrors the
+    # per-endpoint fail-closed posture above. `add // []` still tolerates an empty/null
+    # operand (the normal "one stream has no markers" case) without erroring.
+    SEED_JSON=$(printf '%s\n%s\n' "$SEED_COMMENTS" "$SEED_REVIEWS" | jq -s 'add // []' 2>/dev/null); SEED_JQ_EXIT=$?
+    if [ $SEED_JQ_EXIT -ne 0 ]; then
+      echo "SEED_MARKER_COUNT=0"
+      echo "STATE=unavailable"
+      echo "SEED_UNAVAILABLE=union_jq_exit=$SEED_JQ_EXIT"
+      true; exit 0
+    fi
     SEED_COUNT=$(echo "$SEED_JSON" | jq 'length' 2>/dev/null)
     [ -z "$SEED_COUNT" ] && SEED_COUNT=0
     echo "SEED_MARKER_COUNT=$SEED_COUNT"

--- a/plugins/flow/commands/merge.md
+++ b/plugins/flow/commands/merge.md
@@ -109,20 +109,23 @@ else
   # Markers live on TWO different GitHub objects (see references/finding-ledger-parser.md):
   #   - FLOW_REVIEW_CYCLE     → PR review bodies     (repos/.../pulls/N/reviews)
   #   - FLOW_RESOLUTION_CYCLE → PR/issue comments    (repos/.../issues/N/comments)
-  # Scanning only one stream (the historical bug, #126) undercounts: a PR whose only
-  # marker is a FLOW_REVIEW_CYCLE in a review body reported SEED_MARKER_COUNT=0 even
-  # though the gate would find it. Scan both and union the hits.
+  # A seed that scans only one stream undercounts: a PR whose only marker is a
+  # FLOW_REVIEW_CYCLE in a review body would report SEED_MARKER_COUNT=0 even though the
+  # gate would find it. Scan both and union the hits.
+  #
+  # The select requires a digit after the colon (FLOW_*_CYCLE:[0-9]) so a "marker" is, by
+  # definition, NAME:<cycle-number>. This excludes both bare prose mentions of the marker
+  # NAME and unsubstituted-placeholder prose like `FLOW_REVIEW_CYCLE:{N}` (which the new
+  # self-review template carries in its format-guide comment), so neither inflates the
+  # count nor produces a spurious diagnostic. The seed is intentionally a touch stricter
+  # than the gate's `test("FLOW_*_CYCLE:")` select — the gate tolerates prose by extracting
+  # an empty FINDINGS list, whereas a human-facing preview should only count real markers.
   #
   # Capture gh exit separately per endpoint. Same reason as the Reviews section: the
   # merge gate must close (STATE=unavailable) rather than open (STATE=empty) when
   # markers can't be read.
-  # The select pattern requires the `:` form (FLOW_*_CYCLE:) so it matches what the
-  # authoritative gate selects (test("FLOW_REVIEW_CYCLE:") / test("FLOW_RESOLUTION_CYCLE:"))
-  # and never selects a bare prose mention of the marker NAME — otherwise a comment that
-  # merely references "FLOW_REVIEW_CYCLE" in prose would be flagged SEED_FORMAT_INVALID,
-  # a false positive the gate never raises.
-  SEED_COMMENTS=$(gh api "repos/$REPO/issues/$PR_NUM/comments" --jq '[.[] | select(.body | test("FLOW_RESOLUTION_CYCLE:|FLOW_REVIEW_CYCLE:")) | {id, body, surface: "issue-comments"}]' 2>/dev/null); GH_EXIT_C=$?
-  SEED_REVIEWS=$(gh api "repos/$REPO/pulls/$PR_NUM/reviews" --jq '[.[] | select(.body | test("FLOW_RESOLUTION_CYCLE:|FLOW_REVIEW_CYCLE:")) | {id, body, surface: "reviews"}]' 2>/dev/null); GH_EXIT_R=$?
+  SEED_COMMENTS=$(gh api "repos/$REPO/issues/$PR_NUM/comments" --jq '[.[] | select(.body | test("FLOW_RESOLUTION_CYCLE:[0-9]|FLOW_REVIEW_CYCLE:[0-9]")) | {id, body, surface: "issue-comments"}]' 2>/dev/null); GH_EXIT_C=$?
+  SEED_REVIEWS=$(gh api "repos/$REPO/pulls/$PR_NUM/reviews" --jq '[.[] | select(.body | test("FLOW_RESOLUTION_CYCLE:[0-9]|FLOW_REVIEW_CYCLE:[0-9]")) | {id, body, surface: "reviews"}]' 2>/dev/null); GH_EXIT_R=$?
   echo "SEED_SCANNED=reviews,issue-comments"
   if [ $GH_EXIT_C -ne 0 ] || [ $GH_EXIT_R -ne 0 ]; then
     echo "SEED_MARKER_COUNT=0"
@@ -140,30 +143,30 @@ else
       echo "SEED_MARKER_COUNT=0"
       echo "STATE=unavailable"
       echo "SEED_UNAVAILABLE=union_jq_exit=$SEED_JQ_EXIT"
-      true; exit 0
-    fi
-    SEED_COUNT=$(echo "$SEED_JSON" | jq 'length' 2>/dev/null)
-    [ -z "$SEED_COUNT" ] && SEED_COUNT=0
-    echo "SEED_MARKER_COUNT=$SEED_COUNT"
-    if [ "$SEED_COUNT" = "0" ]; then
-      # Truly absent on both surfaces — distinct from "present but malformed" below.
-      echo "STATE=empty"
     else
-      # `scan` is a generator that yields each match; wrap in `[...]` to collect
-      # all matches into an array, then take `last` (the actual marker —
-      # typically in an HTML comment at end-of-body — earlier occurrences are
-      # usually prose references). Two capture groups (kind, cycle) so each
-      # element is `[kind, cycle]`. A marker line whose cycle is non-numeric (or
-      # whose kind/cycle won't parse) surfaces as SEED_FORMAT_INVALID so the
-      # operator can tell a malformed marker from an absent one.
-      echo "$SEED_JSON" | jq -r '.[] | (
-        ([.body | scan("FLOW_(RESOLUTION|REVIEW)_CYCLE:([0-9]+)")] | last) as $last |
-        if $last == null then
-          "SEED_FORMAT_INVALID=id=\(.id) surface=\(.surface) (marker present but cycle not parseable)"
+      # Capture the count's jq exit too, for the same fail-closed reason — a length()
+      # failure must not collapse to a false STATE=empty.
+      SEED_COUNT=$(echo "$SEED_JSON" | jq 'length' 2>/dev/null); SEED_COUNT_EXIT=$?
+      if [ $SEED_COUNT_EXIT -ne 0 ]; then
+        echo "SEED_MARKER_COUNT=0"
+        echo "STATE=unavailable"
+        echo "SEED_UNAVAILABLE=count_jq_exit=$SEED_COUNT_EXIT"
+      else
+        [ -z "$SEED_COUNT" ] && SEED_COUNT=0
+        echo "SEED_MARKER_COUNT=$SEED_COUNT"
+        if [ "$SEED_COUNT" = "0" ]; then
+          # Genuinely absent on both surfaces (no NAME:<digits> marker reachable).
+          echo "STATE=empty"
         else
-          "SEED=id=\(.id) surface=\(.surface) kind=\($last[0]) cycle=\($last[1])"
-        end
-      )' 2>/dev/null
+          # The select guarantees every row has FLOW_*_CYCLE:<digits>, so scan always
+          # matches; `last` takes the real marker (typically the end-of-body HTML comment)
+          # when a body also carries prose references earlier.
+          echo "$SEED_JSON" | jq -r '.[] |
+            ([.body | scan("FLOW_(RESOLUTION|REVIEW)_CYCLE:([0-9]+)")] | last) as $last |
+            "SEED=id=\(.id) surface=\(.surface) kind=\($last[0]) cycle=\($last[1])"
+          ' 2>/dev/null
+        fi
+      fi
     fi
   fi
 fi

--- a/plugins/flow/commands/review.md
+++ b/plugins/flow/commands/review.md
@@ -652,6 +652,7 @@ TaskUpdate each review task as agents complete.
    - No follow-up issue creation for fixable items — finding triage is NEVER a valid escalation trigger; fix in this PR
    - Approaching the iteration ceiling without convergence is a signal to re-check the findings (are two findings in tension? misunderstood scope?), not to escalate
    - TaskCreate("Post self-review comment", "Post review findings summary to PR via gh pr review --comment")
+   - TaskCreate("Post self-review resolution marker", "Post a FLOW_RESOLUTION_CYCLE issue comment (gh pr comment) recording the fix-forwarded finding IDs as RESOLVED — required so the merge finding-ledger gate balances for self-reviewed PRs. Skip only when zero findings were raised.")
 
 6. **External review (someone else's PR — PR_AUTHOR != CURRENT_USER)**:
 
@@ -710,6 +711,41 @@ TaskUpdate each review task as agents complete.
 
    TaskUpdate(postCommentTaskId, status: "completed", result: "PASS — review posted as {approve/request-changes/comment}")
 
+   **Self-review resolution marker (MANDATORY when `PR_AUTHOR == CURRENT_USER`):**
+
+   Self-review is *raise + resolve in one action* — fix-forward (step 5) already fixed every
+   finding in-PR. The `FLOW_REVIEW_CYCLE` marker posted above records what was **found** (review
+   body, reviews stream, status `open`); it does NOT, on its own, tell the merge gate the findings
+   were **resolved**. The merge finding-ledger gate balances `FINDINGS − RESOLVED` and reads
+   `RESOLVED` only from a `FLOW_RESOLUTION_CYCLE` marker in the issue-comments stream
+   (`references/finding-ledger-parser.md` §3; `commands/merge.md` finding-ledger gate). Without
+   this marker, a self-reviewed PR whose every finding was fix-forwarded would false-block at merge.
+
+   So after posting the review body, emit a `FLOW_RESOLUTION_CYCLE` marker as a **PR issue comment**
+   — the same marker and placement `/flow:address` uses (`commands/address.md` step 9), built from
+   `templates/resolution-comment.md`. This is what collapses the two-actor flow (reviewer raises →
+   author resolves) into a single self-review action. Skip ONLY when there were zero findings (an
+   approve-style self-review with an empty `FINDINGS:[]` — nothing to resolve).
+
+   - `RESOLVED:[...]` — every finding ID that fix-forward fixed in-PR (the common case: all of them).
+   - `ESCALATED:[...]` — any finding that could NOT be fixed in-PR and was escalated with the
+     six-field structure (step 5 / `self-review-comment.md` "Escalated for Human Judgment"). The
+     merge gate blocks on a non-empty `ESCALATED`, which is correct — an escalated finding is an
+     open product decision, not a shipped fix.
+   - `DISPUTED:[]` — empty for self-review (there is no second actor to dispute).
+
+   ```bash
+   # $CYCLE_NUMBER is the same cycle the FLOW_REVIEW_CYCLE marker above used.
+   # RESOLVED/ESCALATED are comma-separated finding IDs (e.g. F1,F2,F3).
+   RES_BODY="$(build from templates/resolution-comment.md with the self-review cycle metrics)"
+   gh pr comment "$PR_NUM" --body "$RES_BODY"
+   ```
+
+   The resolution comment body MUST end with:
+   `<!-- FLOW_RESOLUTION_CYCLE:{CYCLE_NUMBER} RESOLVED:[{ids}] ESCALATED:[{ids}] DISPUTED:[] -->`
+
+   TaskUpdate(resolutionCommentTaskId, status: "completed", result: "PASS — self-review resolution marker posted")
+
    **Manifest emit** — record the review-cycle artifact in the issue's journal manifest. Use the issue number associated with this PR (parse from PR body: `gh pr view "$PR_NUM" --json body --jq '.body' | grep -oE '#[0-9]+' | head -1 | tr -d '#'`):
 
    ```bash
@@ -745,4 +781,5 @@ TaskUpdate each review task as agents complete.
 | Holdout validation (skill, parallel) | 1 | Autonomous |
 | Self-review fix-forward (when reviewing own PR) | 1 | File edits + commits autonomous; push is Tier 2 |
 | `gh pr review --comment / --request-changes / --approve` | 2 | Journal-and-proceed |
+| `gh pr comment` (self-review `FLOW_RESOLUTION_CYCLE` marker) | 2 | Journal-and-proceed |
 | Follow-up issue creation (cosmetic P3 in untouched files, external PR review only) | 2 | Journal-and-proceed |

--- a/plugins/flow/commands/review.md
+++ b/plugins/flow/commands/review.md
@@ -738,16 +738,17 @@ TaskUpdate each review task as agents complete.
    # $CYCLE_NUMBER is the same cycle the FLOW_REVIEW_CYCLE marker above used.
    # RESOLVED/ESCALATED are comma-separated finding IDs (e.g. F1,F2,F3).
    RES_BODY="$(build from templates/resolution-comment.md with the self-review cycle metrics)"
-   gh pr comment "$PR_NUM" --body "$RES_BODY"
+   [ -n "$RES_BODY" ] || { echo "ERROR: empty resolution body — refusing to post a marker-less comment" >&2; }
+   gh pr comment "$PR_NUM" --body "$RES_BODY"; RES_EXIT=$?
    ```
 
    The resolution comment body MUST end with:
    `<!-- FLOW_RESOLUTION_CYCLE:{CYCLE_NUMBER} RESOLVED:[{ids}] ESCALATED:[{ids}] DISPUTED:[] -->`
 
-   Mark the task completed ONLY if `gh pr comment` succeeded (exit 0 and a comment URL returned).
-   If it failed (auth/network/rate-limit), leave the task `in_progress`, retry, and do NOT advance
-   to step 9 — a silently-absent resolution marker re-introduces the merge false-block this emission
-   exists to prevent.
+   Mark the task completed ONLY if `RES_EXIT` is `0` (the `gh pr comment` succeeded and returned a
+   comment URL). If it is non-zero (auth/network/rate-limit) or `RES_BODY` was empty, leave the task
+   `in_progress`, retry, and do NOT advance to step 9 — a silently-absent resolution marker
+   re-introduces the merge false-block this emission exists to prevent.
 
    TaskUpdate(resolutionCommentTaskId, status: "completed", result: "PASS — self-review resolution marker posted")
 
@@ -769,6 +770,8 @@ TaskUpdate each review task as agents complete.
    The `path` value is `A` when paired-reviewer mode produced the findings (7-field marker), `B` when Path B (5-field marker) produced them. `findings_count` is the total across P1+P2+P3 in the cycle. If the PR body does not link an issue, skip the emit (the marker on the PR comment is sufficient for that PR's own state; the manifest is keyed by issue, not PR).
 
 8. **Verify posting**: TaskList — confirm the posting task(s) are completed. Do NOT proceed to step 9 until verified. For external review: "Post review comment". For self-review: BOTH "Post self-review comment" AND "Post self-review resolution marker" must be `completed` — the resolution marker is what balances the merge finding-ledger gate, so a self-review that posted the review body but not the resolution marker is NOT done (it would false-block at merge). Mirror `commands/address.md` step 11's "ALL tasks including the resolution comment" gate.
+
+   **Zero-findings exception**: when the self-review raised zero findings (the review posts an empty `FINDINGS:[]` and there is nothing to resolve), the resolution marker is correctly skipped (per step 5 and step 7). In that case mark the "Post self-review resolution marker" task `completed` with `result: "SKIP — no findings to resolve"` so the gate is satisfied. A balanced ledger with no findings needs no resolution marker; only DO post one when at least one finding was fix-forwarded.
 
 9. **Post-review**: If self-review fixed everything, suggest `/flow:pr`. If external review, suggest `/flow:address $PR_NUM` for the PR author.
 

--- a/plugins/flow/commands/review.md
+++ b/plugins/flow/commands/review.md
@@ -744,6 +744,11 @@ TaskUpdate each review task as agents complete.
    The resolution comment body MUST end with:
    `<!-- FLOW_RESOLUTION_CYCLE:{CYCLE_NUMBER} RESOLVED:[{ids}] ESCALATED:[{ids}] DISPUTED:[] -->`
 
+   Mark the task completed ONLY if `gh pr comment` succeeded (exit 0 and a comment URL returned).
+   If it failed (auth/network/rate-limit), leave the task `in_progress`, retry, and do NOT advance
+   to step 9 — a silently-absent resolution marker re-introduces the merge false-block this emission
+   exists to prevent.
+
    TaskUpdate(resolutionCommentTaskId, status: "completed", result: "PASS — self-review resolution marker posted")
 
    **Manifest emit** — record the review-cycle artifact in the issue's journal manifest. Use the issue number associated with this PR (parse from PR body: `gh pr view "$PR_NUM" --json body --jq '.body' | grep -oE '#[0-9]+' | head -1 | tr -d '#'`):
@@ -763,7 +768,7 @@ TaskUpdate each review task as agents complete.
 
    The `path` value is `A` when paired-reviewer mode produced the findings (7-field marker), `B` when Path B (5-field marker) produced them. `findings_count` is the total across P1+P2+P3 in the cycle. If the PR body does not link an issue, skip the emit (the marker on the PR comment is sufficient for that PR's own state; the manifest is keyed by issue, not PR).
 
-8. **Verify posting**: TaskList — confirm "Post review comment" or "Post self-review comment" task is completed. Do NOT proceed to step 9 until this is verified.
+8. **Verify posting**: TaskList — confirm the posting task(s) are completed. Do NOT proceed to step 9 until verified. For external review: "Post review comment". For self-review: BOTH "Post self-review comment" AND "Post self-review resolution marker" must be `completed` — the resolution marker is what balances the merge finding-ledger gate, so a self-review that posted the review body but not the resolution marker is NOT done (it would false-block at merge). Mirror `commands/address.md` step 11's "ALL tasks including the resolution comment" gate.
 
 9. **Post-review**: If self-review fixed everything, suggest `/flow:pr`. If external review, suggest `/flow:address $PR_NUM` for the PR author.
 

--- a/plugins/flow/references/finding-ledger-parser.md
+++ b/plugins/flow/references/finding-ledger-parser.md
@@ -60,6 +60,21 @@ Source: `templates/resolution-comment.md`. Reports the disposition of cycle `N`'
 
 Arrays carry IDs only; priority must be looked up from the matching `FLOW_REVIEW_CYCLE`.
 
+**Two emitters, one mechanism.** This marker is emitted by both paths that close findings:
+
+- **Two-actor flow** — `/flow:address` (`commands/address.md` step 9) posts it after the PR author
+  resolves a reviewer's findings.
+- **Self-review / fix-forward** — `/flow:review` (and the inline review in `/flow:pr`) on your *own*
+  PR posts it too (`commands/review.md` Phase 4 step 7, self-review branch). Self-review is raise +
+  resolve in one action: the `FLOW_REVIEW_CYCLE` marker in the review body records what was found
+  (status `open`), and this `FLOW_RESOLUTION_CYCLE` issue comment records the fix-forwarded IDs as
+  `RESOLVED`. Without it, a solo/agent-authored PR whose every finding was fixed in-PR would
+  false-block at the merge finding-ledger gate (it reads `RESOLVED` only from this marker, never from
+  an inline `FLOW_REVIEW_CYCLE` status field).
+
+In both cases the marker lands in the **issue-comments stream** (`gh pr comment`) — never a review
+body — so the merge gate's resolution query (§3 below) finds it regardless of which command emitted it.
+
 ## Finding State Classification
 
 For a single PR, after reading the **latest** marker of each kind:

--- a/plugins/flow/templates/self-review-comment.md
+++ b/plugins/flow/templates/self-review-comment.md
@@ -43,3 +43,18 @@ Verdict: N/A (independent verdict not enabled)
 - [x] Quality commands pass after fixes
 - [x] No new issues introduced
 - [x] All P1/P2/P3 findings in touched files fixed in-PR or escalated
+
+<!--
+This review body carries the FLOW_REVIEW_CYCLE marker (what was FOUND, status `open`).
+Self-review is raise + resolve in one action: the fix-forwarded findings are recorded as
+RESOLVED in a separate FLOW_RESOLUTION_CYCLE marker, posted as a PR issue comment via
+`gh pr comment` (built from templates/resolution-comment.md) — the same marker/placement
+/flow:address uses, and the only surface the merge finding-ledger gate reads RESOLVED from.
+Marker has two valid forms — see references/finding-ledger-parser.md:
+  Legacy 5-field (single-session reviews):
+    FLOW_REVIEW_CYCLE:{N} FINDINGS:[{ID}|{priority}|{category}|{file:line}|{status},...]
+  Extended 7-field (paired-reviewer mode only):
+    FLOW_REVIEW_CYCLE:{N} FINDINGS:[{ID}|{priority}|{category}|{file:line}|{status}|{confidence}|{disposition},...]
+Parsers tolerate both.
+-->
+<!-- FLOW_REVIEW_CYCLE:{cycle_number} FINDINGS:[{F1}|{priority}|{category}|{file:line}|{open}{|HIGH|consensus},{F2}|{priority}|{category}|{file:line}|{open}{|LOW|kept}] -->

--- a/plugins/flow/tests/flow-active-goal.test.sh
+++ b/plugins/flow/tests/flow-active-goal.test.sh
@@ -462,3 +462,38 @@ _fag_write_goal "$DIR/.flow/goals/issue-only.goal.yaml" "active" "issue-only" "f
 OUT=$(cd "$DIR" && bash "$HELPER" --id --branch-strict 2>/dev/null); EXIT=$?
 assert_equal "0" "$EXIT" "unknown branch + strict still resolves (exit 0)"
 assert_equal "issue-only" "$OUT" "falls back to the most-recent active goal when the branch is unknown"
+
+# --- #125 regression guard: the FULL lifecycle -> (exit, status) contract the ---
+# merge FlowGoal gate depends on. The gate (commands/merge.md) invokes the helper
+# with `--status --allow-terminal --branch-strict` and maps:
+#   exit 0 + "achieved"        -> FLOW_GOAL_GATE_STATE=ok      (shipment complete)
+#   exit 0 + other (e.g active) -> FLOW_GOAL_GATE_STATE=blocked (incomplete shipment)
+#   exit 1 (no goal on branch)  -> FLOW_GOAL_GATE_STATE=ok      (gate not applicable)
+# #125 was the achieved->ok branch regressing to "no active goal" and false-blocking.
+# This asserts every lifecycle in one place so the precompute block cannot silently
+# break the mapping again. NOTE: `failed`/`cancelled` resolve to exit 1 here BY DESIGN
+# (only `achieved` is a gate-relevant terminal state — see the "failed/cancelled goals
+# are NOT surfaced" test above); the gate therefore treats them as not-applicable, not
+# as a block. That is intentional in v3.2.x; see CHANGELOG 3.2.1.
+_fag_gate_status() { # status, branch-owner -> echoes "exit|status" as the gate would observe
+  local st="$1" owner="$2" dir out exit
+  dir=$(_fag_mkdir); mkdir -p "$dir/.flow/goals"
+  _fag_write_goal "$dir/.flow/goals/issue-g.goal.yaml" "$st" "issue-g" "$owner"
+  out=$(cd "$dir" && bash "$HELPER" --status --allow-terminal --branch-strict --branch feature/cur 2>/dev/null); exit=$?
+  printf '%s|%s' "$exit" "$out"
+}
+
+_flow_test_begin "#125: achieved goal on current branch -> exit 0 / 'achieved' (gate maps to ok)"
+assert_equal "0|achieved" "$(_fag_gate_status achieved feature/cur)" "achieved -> exit 0 + status achieved"
+
+_flow_test_begin "#125: active (not achieved) goal on current branch -> exit 0 / 'active' (gate maps to blocked)"
+assert_equal "0|active" "$(_fag_gate_status active feature/cur)" "active -> exit 0 + status active"
+
+_flow_test_begin "#125: failed goal on current branch -> exit 1 (gate not applicable, by design)"
+assert_equal "1|" "$(_fag_gate_status failed feature/cur)" "failed -> exit 1 (out of gate window)"
+
+_flow_test_begin "#125: cancelled goal on current branch -> exit 1 (gate not applicable, by design)"
+assert_equal "1|" "$(_fag_gate_status cancelled feature/cur)" "cancelled -> exit 1 (out of gate window)"
+
+_flow_test_begin "#125: no goal owning the current branch -> exit 1 (gate not applicable)"
+assert_equal "1|" "$(_fag_gate_status active feature/elsewhere)" "goal on another branch -> exit 1 under strict"

--- a/plugins/flow/tests/flow-merge-seed.test.sh
+++ b/plugins/flow/tests/flow-merge-seed.test.sh
@@ -5,8 +5,11 @@
 #     stream (repos/.../pulls/N/reviews, where FLOW_REVIEW_CYCLE lives) AND the issue-comments
 #     stream (repos/.../issues/N/comments, where FLOW_RESOLUTION_CYCLE lives), then unions the
 #     hits. Scanning only issue-comments (the bug) undercounted review-body markers to zero.
-#   - The seed names the scanned surfaces (SEED_SCANNED) and distinguishes a truly-absent marker
-#     (SEED_MARKER_COUNT=0) from a present-but-malformed one (SEED_FORMAT_INVALID).
+#   - A "marker" is NAME:<digits>. The select requires FLOW_*_CYCLE:[0-9] so prose mentions
+#     and unsubstituted placeholders (FLOW_REVIEW_CYCLE:{N}) are NOT counted and never produce
+#     a spurious diagnostic. SEED_MARKER_COUNT=0 then means genuinely absent.
+#   - The union and count jq steps fail CLOSED (STATE=unavailable) on malformed JSON, never
+#     collapsing to a false STATE=empty.
 #   - The seed is a diagnostic preview; the authoritative gate (next block) already scans both.
 
 if ! command -v jq >/dev/null 2>&1; then
@@ -18,7 +21,7 @@ fi
 PLUGIN_DIR="$REPO_ROOT/plugins/flow"
 MERGE_MD="$PLUGIN_DIR/commands/merge.md"
 
-# --- source-presence: seed scans both streams + better diagnostics -----------
+# --- source-presence: seed scans both streams + fail-closed diagnostics ------
 _flow_test_begin "merge.md seed scans the reviews stream (not only issue comments)"
 if [ ! -f "$MERGE_MD" ]; then
   _flow_assert_fail "merge.md missing"
@@ -27,37 +30,34 @@ else
   assert_contains 'repos/$REPO/pulls/$PR_NUM/reviews' "$CONTENT" "seed queries the reviews stream"
   assert_contains 'repos/$REPO/issues/$PR_NUM/comments' "$CONTENT" "seed queries the issue-comments stream"
   assert_contains "SEED_SCANNED=reviews,issue-comments" "$CONTENT" "seed names both scanned surfaces"
-  assert_contains "SEED_FORMAT_INVALID" "$CONTENT" "seed distinguishes malformed markers from absent"
   assert_contains "DIAGNOSTIC PREVIEW ONLY" "$CONTENT" "seed documents it is a preview, not the gate"
-  # The select must require the `:` form so a bare prose mention of the marker NAME is not
-  # selected (and so the seed's selection matches the authoritative gate's test("...:")).
-  assert_contains 'test("FLOW_RESOLUTION_CYCLE:|FLOW_REVIEW_CYCLE:")' "$CONTENT" "seed select requires the colon form (matches the gate, ignores prose)"
-  # The union must fail closed on a malformed-JSON operand, not collapse to STATE=empty.
+  # A marker is NAME:<digits> — the select requires a digit after the colon so prose and
+  # `:{N}` placeholders are excluded (no false count, no spurious diagnostic).
+  assert_contains 'test("FLOW_RESOLUTION_CYCLE:[0-9]|FLOW_REVIEW_CYCLE:[0-9]")' "$CONTENT" "seed select requires a digit after the colon"
+  # Both jq steps (union + count) fail closed on malformed JSON, not STATE=empty.
   assert_contains "SEED_JQ_EXIT" "$CONTENT" "union jq exit captured (fail-closed on malformed JSON)"
-  assert_contains "union_jq_exit=" "$CONTENT" "malformed union surfaces as STATE=unavailable, not empty"
+  assert_contains "union_jq_exit=" "$CONTENT" "malformed union surfaces as STATE=unavailable"
+  assert_contains "SEED_COUNT_EXIT" "$CONTENT" "count jq exit captured (fail-closed)"
 fi
 
-# --- functional: the select + union + classification logic the seed uses -----
-# Mirrors the seed block end-to-end: apply the per-stream `:`-form select (so a prose
-# mention is excluded), union both streams, count, and classify each row as a valid SEED
-# line or SEED_FORMAT_INVALID. Proves a review-body-only marker is counted (the #126
-# regression), a digit-less marker is flagged malformed, and a prose mention is ignored.
+# --- functional: the select + union + count + classification the seed uses ---
+# Mirrors the seed block end-to-end: apply the per-stream :[0-9] select, union both
+# streams, capture the union exit (fail closed), count, and classify each row. Proves a
+# review-body-only marker is counted (#126), prose/placeholders are excluded, a mixed body
+# resolves to the real marker, and a malformed-JSON union fails closed.
 _seed_classify() {
   local comments="$1" reviews="$2"
-  local sel='[.[] | select(.body | test("FLOW_RESOLUTION_CYCLE:|FLOW_REVIEW_CYCLE:"))]'
-  local c r seed_json
+  local sel='[.[] | select(.body | test("FLOW_RESOLUTION_CYCLE:[0-9]|FLOW_REVIEW_CYCLE:[0-9]"))]'
+  local c r seed_json jqx
   c=$(printf '%s' "$comments" | jq "$sel")
   r=$(printf '%s' "$reviews"  | jq "$sel")
-  seed_json=$(printf '%s\n%s\n' "$c" "$r" | jq -s 'add // []')
+  seed_json=$(printf '%s\n%s\n' "$c" "$r" | jq -s 'add // []' 2>/dev/null); jqx=$?
+  if [ $jqx -ne 0 ]; then echo "STATE=unavailable"; return; fi
   echo "COUNT=$(echo "$seed_json" | jq 'length')"
-  echo "$seed_json" | jq -r '.[] | (
+  echo "$seed_json" | jq -r '.[] |
     ([.body | scan("FLOW_(RESOLUTION|REVIEW)_CYCLE:([0-9]+)")] | last) as $last |
-    if $last == null then
-      "SEED_FORMAT_INVALID=id=\(.id) surface=\(.surface)"
-    else
-      "SEED=id=\(.id) surface=\(.surface) kind=\($last[0]) cycle=\($last[1])"
-    end
-  )'
+    "SEED=id=\(.id) surface=\(.surface) kind=\($last[0]) cycle=\($last[1])"
+  '
 }
 
 _flow_test_begin "review-body-only marker is counted (the #126 regression)"
@@ -75,20 +75,37 @@ assert_contains "COUNT=2" "$OUT" "both streams contribute to the count"
 assert_contains "kind=RESOLUTION" "$OUT" "resolution marker seen"
 assert_contains "kind=REVIEW" "$OUT" "review marker seen"
 
-_flow_test_begin "present-but-malformed marker is flagged SEED_FORMAT_INVALID"
+_flow_test_begin "prose mention (no colon) and placeholder (:{N}) are NOT counted"
+# Neither a bare prose mention of the marker NAME nor an unsubstituted :{N} placeholder
+# (which the self-review template carries in its format-guide comment) is a real marker;
+# both must be excluded by the select so they never inflate the count or alarm the operator.
+OUT=$(_seed_classify \
+  '[{"id":11,"body":"This body carries the FLOW_REVIEW_CYCLE marker (what was FOUND)."},
+    {"id":13,"body":"guide: FLOW_REVIEW_CYCLE:{N} FINDINGS:[...]"}]' \
+  '[{"id":12,"body":"<!-- FLOW_REVIEW_CYCLE:3 FINDINGS:[F1|P2|x|a:1|open] -->","surface":"reviews"}]')
+assert_contains "COUNT=1" "$OUT" "prose + placeholder excluded; only the real marker counts"
+assert_contains "kind=REVIEW cycle=3" "$OUT" "the genuine marker is still parsed"
+
+_flow_test_begin "mixed body (placeholder prose + real marker) resolves to the real cycle"
+# A single body that contains both the :{N} format guide and the real numbered marker must
+# classify by the real marker — scan over the whole body picks the digit-bearing match.
 OUT=$(_seed_classify \
   '[]' \
-  '[{"id":10,"body":"FLOW_REVIEW_CYCLE: no digits here","surface":"reviews"}]')
-assert_contains "COUNT=1" "$OUT" "malformed marker still counted as present"
-assert_contains "SEED_FORMAT_INVALID=id=10" "$OUT" "malformed marker flagged, not silently dropped"
+  '[{"id":14,"surface":"reviews","body":"guide FLOW_REVIEW_CYCLE:{N} ... real <!-- FLOW_REVIEW_CYCLE:5 FINDINGS:[] -->"}]')
+assert_contains "COUNT=1" "$OUT" "mixed body counts once"
+assert_contains "cycle=5" "$OUT" "the real numbered marker wins over the placeholder"
 
-_flow_test_begin "prose mention of a marker name (no colon) is NOT selected (no false SEED_FORMAT_INVALID)"
-# A body that names the marker in prose, with no real :N marker, must be excluded by the
-# select so it never produces a spurious SEED_FORMAT_INVALID line. self-review-comment.md
-# adds exactly such prose, so this guards a real false-positive path.
-OUT=$(_seed_classify \
-  '[{"id":11,"body":"This body carries the FLOW_REVIEW_CYCLE marker (what was FOUND).","surface":"issue-comments"}]' \
-  '[{"id":12,"body":"<!-- FLOW_REVIEW_CYCLE:3 FINDINGS:[F1|P2|x|a:1|open] -->","surface":"reviews"}]')
-assert_contains "COUNT=1" "$OUT" "prose mention excluded; only the real marker counts"
-assert_not_contains "SEED_FORMAT_INVALID" "$OUT" "prose mention does not produce a false malformed flag"
-assert_contains "kind=REVIEW cycle=3" "$OUT" "the genuine marker is still parsed"
+_flow_test_begin "malformed-JSON union fails closed (jq exits non-zero -> STATE=unavailable)"
+# Mirrors the seed's union line directly (the real seed feeds the raw per-stream gh output,
+# which on a weird gh-exit-0 case may be non-JSON, into `jq -s 'add // []'`). The fail-closed
+# guard keys on the captured jq exit, so prove that a non-JSON operand makes jq exit non-zero
+# rather than silently producing an empty array.
+SEED_JSON=$(printf '%s\n%s\n' 'not-json' '[{"id":1}]' | jq -s 'add // []' 2>/dev/null); SEED_JQ_EXIT=$?
+if [ "$SEED_JQ_EXIT" != "0" ]; then
+  _flow_assert_pass "malformed operand makes the union jq exit non-zero (caught by SEED_JQ_EXIT)"
+else
+  _flow_assert_fail "malformed operand should make the union jq exit non-zero, got exit 0"
+fi
+# And the normal one-empty-stream case must NOT trip the guard (exit 0).
+printf '%s\n%s\n' '[]' '[{"id":1}]' | jq -s 'add // []' >/dev/null 2>&1
+assert_equal "0" "$?" "an empty stream + a populated stream unions cleanly (exit 0)"

--- a/plugins/flow/tests/flow-merge-seed.test.sh
+++ b/plugins/flow/tests/flow-merge-seed.test.sh
@@ -29,16 +29,26 @@ else
   assert_contains "SEED_SCANNED=reviews,issue-comments" "$CONTENT" "seed names both scanned surfaces"
   assert_contains "SEED_FORMAT_INVALID" "$CONTENT" "seed distinguishes malformed markers from absent"
   assert_contains "DIAGNOSTIC PREVIEW ONLY" "$CONTENT" "seed documents it is a preview, not the gate"
+  # The select must require the `:` form so a bare prose mention of the marker NAME is not
+  # selected (and so the seed's selection matches the authoritative gate's test("...:")).
+  assert_contains 'test("FLOW_RESOLUTION_CYCLE:|FLOW_REVIEW_CYCLE:")' "$CONTENT" "seed select requires the colon form (matches the gate, ignores prose)"
+  # The union must fail closed on a malformed-JSON operand, not collapse to STATE=empty.
+  assert_contains "SEED_JQ_EXIT" "$CONTENT" "union jq exit captured (fail-closed on malformed JSON)"
+  assert_contains "union_jq_exit=" "$CONTENT" "malformed union surfaces as STATE=unavailable, not empty"
 fi
 
-# --- functional: the union + classification logic the seed uses --------------
-# Mirrors the jq in the seed block: union both streams, count, and classify each marker
-# row as a valid SEED line or SEED_FORMAT_INVALID. Proves a review-body-only marker is
-# counted (the #126 regression) and a digit-less marker is flagged malformed.
+# --- functional: the select + union + classification logic the seed uses -----
+# Mirrors the seed block end-to-end: apply the per-stream `:`-form select (so a prose
+# mention is excluded), union both streams, count, and classify each row as a valid SEED
+# line or SEED_FORMAT_INVALID. Proves a review-body-only marker is counted (the #126
+# regression), a digit-less marker is flagged malformed, and a prose mention is ignored.
 _seed_classify() {
   local comments="$1" reviews="$2"
-  local seed_json
-  seed_json=$(printf '%s\n%s' "$comments" "$reviews" | jq -s 'add // []')
+  local sel='[.[] | select(.body | test("FLOW_RESOLUTION_CYCLE:|FLOW_REVIEW_CYCLE:"))]'
+  local c r seed_json
+  c=$(printf '%s' "$comments" | jq "$sel")
+  r=$(printf '%s' "$reviews"  | jq "$sel")
+  seed_json=$(printf '%s\n%s\n' "$c" "$r" | jq -s 'add // []')
   echo "COUNT=$(echo "$seed_json" | jq 'length')"
   echo "$seed_json" | jq -r '.[] | (
     ([.body | scan("FLOW_(RESOLUTION|REVIEW)_CYCLE:([0-9]+)")] | last) as $last |
@@ -71,3 +81,14 @@ OUT=$(_seed_classify \
   '[{"id":10,"body":"FLOW_REVIEW_CYCLE: no digits here","surface":"reviews"}]')
 assert_contains "COUNT=1" "$OUT" "malformed marker still counted as present"
 assert_contains "SEED_FORMAT_INVALID=id=10" "$OUT" "malformed marker flagged, not silently dropped"
+
+_flow_test_begin "prose mention of a marker name (no colon) is NOT selected (no false SEED_FORMAT_INVALID)"
+# A body that names the marker in prose, with no real :N marker, must be excluded by the
+# select so it never produces a spurious SEED_FORMAT_INVALID line. self-review-comment.md
+# adds exactly such prose, so this guards a real false-positive path.
+OUT=$(_seed_classify \
+  '[{"id":11,"body":"This body carries the FLOW_REVIEW_CYCLE marker (what was FOUND).","surface":"issue-comments"}]' \
+  '[{"id":12,"body":"<!-- FLOW_REVIEW_CYCLE:3 FINDINGS:[F1|P2|x|a:1|open] -->","surface":"reviews"}]')
+assert_contains "COUNT=1" "$OUT" "prose mention excluded; only the real marker counts"
+assert_not_contains "SEED_FORMAT_INVALID" "$OUT" "prose mention does not produce a false malformed flag"
+assert_contains "kind=REVIEW cycle=3" "$OUT" "the genuine marker is still parsed"

--- a/plugins/flow/tests/flow-merge-seed.test.sh
+++ b/plugins/flow/tests/flow-merge-seed.test.sh
@@ -1,0 +1,73 @@
+# Tests for #126 — the merge finding-ledger seed must scan BOTH marker streams.
+#
+# Contract under test:
+#   - commands/merge.md's "Finding-Ledger Seed" diagnostic block queries both the reviews
+#     stream (repos/.../pulls/N/reviews, where FLOW_REVIEW_CYCLE lives) AND the issue-comments
+#     stream (repos/.../issues/N/comments, where FLOW_RESOLUTION_CYCLE lives), then unions the
+#     hits. Scanning only issue-comments (the bug) undercounted review-body markers to zero.
+#   - The seed names the scanned surfaces (SEED_SCANNED) and distinguishes a truly-absent marker
+#     (SEED_MARKER_COUNT=0) from a present-but-malformed one (SEED_FORMAT_INVALID).
+#   - The seed is a diagnostic preview; the authoritative gate (next block) already scans both.
+
+if ! command -v jq >/dev/null 2>&1; then
+  _flow_test_begin "jq prerequisite"
+  _flow_assert_pass "SKIP: jq not installed"
+  return 0
+fi
+
+PLUGIN_DIR="$REPO_ROOT/plugins/flow"
+MERGE_MD="$PLUGIN_DIR/commands/merge.md"
+
+# --- source-presence: seed scans both streams + better diagnostics -----------
+_flow_test_begin "merge.md seed scans the reviews stream (not only issue comments)"
+if [ ! -f "$MERGE_MD" ]; then
+  _flow_assert_fail "merge.md missing"
+else
+  CONTENT=$(cat "$MERGE_MD")
+  assert_contains 'repos/$REPO/pulls/$PR_NUM/reviews' "$CONTENT" "seed queries the reviews stream"
+  assert_contains 'repos/$REPO/issues/$PR_NUM/comments' "$CONTENT" "seed queries the issue-comments stream"
+  assert_contains "SEED_SCANNED=reviews,issue-comments" "$CONTENT" "seed names both scanned surfaces"
+  assert_contains "SEED_FORMAT_INVALID" "$CONTENT" "seed distinguishes malformed markers from absent"
+  assert_contains "DIAGNOSTIC PREVIEW ONLY" "$CONTENT" "seed documents it is a preview, not the gate"
+fi
+
+# --- functional: the union + classification logic the seed uses --------------
+# Mirrors the jq in the seed block: union both streams, count, and classify each marker
+# row as a valid SEED line or SEED_FORMAT_INVALID. Proves a review-body-only marker is
+# counted (the #126 regression) and a digit-less marker is flagged malformed.
+_seed_classify() {
+  local comments="$1" reviews="$2"
+  local seed_json
+  seed_json=$(printf '%s\n%s' "$comments" "$reviews" | jq -s 'add // []')
+  echo "COUNT=$(echo "$seed_json" | jq 'length')"
+  echo "$seed_json" | jq -r '.[] | (
+    ([.body | scan("FLOW_(RESOLUTION|REVIEW)_CYCLE:([0-9]+)")] | last) as $last |
+    if $last == null then
+      "SEED_FORMAT_INVALID=id=\(.id) surface=\(.surface)"
+    else
+      "SEED=id=\(.id) surface=\(.surface) kind=\($last[0]) cycle=\($last[1])"
+    end
+  )'
+}
+
+_flow_test_begin "review-body-only marker is counted (the #126 regression)"
+OUT=$(_seed_classify \
+  '[]' \
+  '[{"id":9,"body":"<!-- FLOW_REVIEW_CYCLE:2 FINDINGS:[F1|P2|correctness|src/x.ts:8|open] -->","surface":"reviews"}]')
+assert_contains "COUNT=1" "$OUT" "a marker only in a review body is found (not undercounted to 0)"
+assert_contains "kind=REVIEW cycle=2" "$OUT" "review-cycle marker parsed from the reviews stream"
+
+_flow_test_begin "markers in both streams union (no double-loss)"
+OUT=$(_seed_classify \
+  '[{"id":1,"body":"<!-- FLOW_RESOLUTION_CYCLE:2 RESOLVED:[F1] ESCALATED:[] DISPUTED:[] -->","surface":"issue-comments"}]' \
+  '[{"id":9,"body":"<!-- FLOW_REVIEW_CYCLE:2 FINDINGS:[F1|P2|correctness|src/x.ts:8|open] -->","surface":"reviews"}]')
+assert_contains "COUNT=2" "$OUT" "both streams contribute to the count"
+assert_contains "kind=RESOLUTION" "$OUT" "resolution marker seen"
+assert_contains "kind=REVIEW" "$OUT" "review marker seen"
+
+_flow_test_begin "present-but-malformed marker is flagged SEED_FORMAT_INVALID"
+OUT=$(_seed_classify \
+  '[]' \
+  '[{"id":10,"body":"FLOW_REVIEW_CYCLE: no digits here","surface":"reviews"}]')
+assert_contains "COUNT=1" "$OUT" "malformed marker still counted as present"
+assert_contains "SEED_FORMAT_INVALID=id=10" "$OUT" "malformed marker flagged, not silently dropped"

--- a/plugins/flow/tests/flow-pr-merge-goal-gate.test.sh
+++ b/plugins/flow/tests/flow-pr-merge-goal-gate.test.sh
@@ -62,3 +62,20 @@ assert_contains "--id --allow-terminal" "$CONTENT" "pr gate --id uses --allow-te
 _flow_test_begin "pr.md + merge.md gate resolve with --branch-strict"
 assert_contains "--branch-strict" "$(cat "$PR_CMD")" "pr gate passes --branch-strict to the resolver"
 assert_contains "--branch-strict" "$(cat "$MERGE_CMD")" "merge gate passes --branch-strict to the resolver"
+
+# --- #125 regression guard: merge gate maps lifecycle -> FLOW_GOAL_GATE_STATE ---
+# The achieved-reads-as-no-active-goal false-block (#125) lives in the precompute
+# block's lifecycle->state mapping. Assert all three arms are present so the mapping
+# can't silently regress: achieved->ok, exit-0-not-achieved->blocked, exit-1->ok.
+_flow_test_begin "#125: merge gate maps an achieved goal to FLOW_GOAL_GATE_STATE=ok"
+MCONTENT=$(cat "$MERGE_CMD")
+assert_contains '[ "$GOAL_STATUS" = "achieved" ]' "$MCONTENT" "gate branches on achieved status"
+assert_contains "FLOW_GOAL_GATE_STATE=ok" "$MCONTENT" "achieved (and not-applicable) arms emit ok"
+
+_flow_test_begin "#125: merge gate blocks an active (not-achieved) goal"
+assert_contains "FLOW_GOAL_GATE_STATE=blocked" "$MCONTENT" "non-achieved active goal is a block"
+assert_contains "lifecycle is" "$MCONTENT" "block reason names the offending lifecycle status"
+
+_flow_test_begin "#125: merge gate treats exit-1 (no goal on branch) as not-applicable, not a block"
+assert_contains "gate not applicable" "$MCONTENT" "exit-1 maps to ok with a not-applicable note"
+assert_contains "FLOW_GOAL_GATE_NOTE=no active FlowGoal for this branch" "$MCONTENT" "not-applicable note is explicit"

--- a/plugins/flow/tests/flow-self-review-resolution.test.sh
+++ b/plugins/flow/tests/flow-self-review-resolution.test.sh
@@ -36,6 +36,13 @@ _flow_test_begin "review.md creates the resolution-post task in the self-review 
 CONTENT=$(cat "$REVIEW_MD")
 assert_contains "Post self-review resolution marker" "$CONTENT" "TaskCreate for resolution marker present"
 
+_flow_test_begin "review.md gates step 8 on the resolution-marker task (no silent skip on gh failure)"
+# A failed `gh pr comment` must NOT advance the workflow — otherwise the resolution marker
+# is silently absent and the merge gate false-blocks again (the bug this whole change fixes).
+CONTENT=$(cat "$REVIEW_MD")
+assert_contains 'BOTH "Post self-review comment" AND "Post self-review resolution marker"' "$CONTENT" "step 8 requires both self-review posting tasks"
+assert_contains "leave the task" "$CONTENT" "resolution post has a failure backstop (retry, do not advance)"
+
 _flow_test_begin "review.md self-review still posts FLOW_REVIEW_CYCLE in the review body"
 CONTENT=$(cat "$REVIEW_MD")
 assert_contains "FLOW_REVIEW_CYCLE" "$CONTENT" "review-body marker retained (records what was found)"

--- a/plugins/flow/tests/flow-self-review-resolution.test.sh
+++ b/plugins/flow/tests/flow-self-review-resolution.test.sh
@@ -1,0 +1,72 @@
+# Tests for #124 — self-reviewed PRs must not false-block at the merge finding-ledger gate.
+#
+# Contract under test:
+#   - The self-review path of commands/review.md emits a FLOW_RESOLUTION_CYCLE marker as a
+#     PR issue comment (gh pr comment), recording fix-forwarded finding IDs as RESOLVED — the
+#     same marker/placement /flow:address uses and the only surface the merge gate reads RESOLVED
+#     from. Without it, a solo-authored PR whose every finding was fix-forwarded false-blocks.
+#   - templates/self-review-comment.md carries the FLOW_REVIEW_CYCLE marker (previously missing).
+#   - references/finding-ledger-parser.md documents the two-emitter (address + self-review) model.
+#   - The merge gate's classification logic is UNCHANGED — the fix is purely on the emit side.
+#
+# These are source-presence lints (the repo convention for command/template markdown); the actual
+# emission happens when Claude runs the command. See flow-pr-merge-goal-gate.test.sh for the pattern.
+
+PLUGIN_DIR="$REPO_ROOT/plugins/flow"
+REVIEW_MD="$PLUGIN_DIR/commands/review.md"
+SELF_TMPL="$PLUGIN_DIR/templates/self-review-comment.md"
+PARSER_REF="$PLUGIN_DIR/references/finding-ledger-parser.md"
+MERGE_MD="$PLUGIN_DIR/commands/merge.md"
+
+# --- review.md: self-review emits the resolution marker ----------------------
+_flow_test_begin "review.md self-review path emits a FLOW_RESOLUTION_CYCLE marker"
+if [ ! -f "$REVIEW_MD" ]; then
+  _flow_assert_fail "review.md missing"
+else
+  CONTENT=$(cat "$REVIEW_MD")
+  assert_contains "Self-review resolution marker" "$CONTENT" "self-review resolution step present"
+  assert_contains "FLOW_RESOLUTION_CYCLE" "$CONTENT" "names the resolution marker"
+  assert_contains 'gh pr comment "$PR_NUM"' "$CONTENT" "posts via issue-comments stream (gh pr comment)"
+  assert_contains "templates/resolution-comment.md" "$CONTENT" "builds body from the resolution template"
+  assert_contains "RESOLVED:[" "$CONTENT" "records fix-forwarded IDs as RESOLVED"
+  assert_contains "resolutionCommentTaskId" "$CONTENT" "tracks the resolution-post task"
+fi
+
+_flow_test_begin "review.md creates the resolution-post task in the self-review path"
+CONTENT=$(cat "$REVIEW_MD")
+assert_contains "Post self-review resolution marker" "$CONTENT" "TaskCreate for resolution marker present"
+
+_flow_test_begin "review.md self-review still posts FLOW_REVIEW_CYCLE in the review body"
+CONTENT=$(cat "$REVIEW_MD")
+assert_contains "FLOW_REVIEW_CYCLE" "$CONTENT" "review-body marker retained (records what was found)"
+
+# --- self-review template carries the review marker --------------------------
+_flow_test_begin "self-review-comment.md carries the FLOW_REVIEW_CYCLE marker"
+if [ ! -f "$SELF_TMPL" ]; then
+  _flow_assert_fail "self-review-comment.md missing"
+else
+  TMPL=$(cat "$SELF_TMPL")
+  assert_contains "FLOW_REVIEW_CYCLE:" "$TMPL" "template emits the review-cycle marker"
+  assert_contains "FLOW_RESOLUTION_CYCLE" "$TMPL" "template explains the separate resolution marker"
+fi
+
+# --- parser reference documents the two-emitter model ------------------------
+_flow_test_begin "finding-ledger-parser.md documents self-review as a FLOW_RESOLUTION_CYCLE emitter"
+if [ ! -f "$PARSER_REF" ]; then
+  _flow_assert_fail "finding-ledger-parser.md missing"
+else
+  REF=$(cat "$PARSER_REF")
+  assert_contains "Two emitters" "$REF" "documents both emitters of the resolution marker"
+  assert_contains "Self-review" "$REF" "names the self-review emitter"
+  assert_contains "issue-comments stream" "$REF" "documents placement (issue comments, not review body)"
+fi
+
+# --- the gate classification logic is unchanged (guard against accidental edits) ---
+_flow_test_begin "merge.md finding-ledger gate still balances FINDINGS - RESOLVED unchanged"
+if [ ! -f "$MERGE_MD" ]; then
+  _flow_assert_fail "merge.md missing"
+else
+  MCONTENT=$(cat "$MERGE_MD")
+  assert_contains "comm -23" "$MCONTENT" "gate still uses comm -23 FINDINGS vs RESOLVED"
+  assert_contains "Unresolved findings:" "$MCONTENT" "gate still blocks on unmatched findings"
+fi

--- a/plugins/flow/tests/flow-self-review-resolution.test.sh
+++ b/plugins/flow/tests/flow-self-review-resolution.test.sh
@@ -34,14 +34,24 @@ fi
 
 _flow_test_begin "review.md creates the resolution-post task in the self-review path"
 CONTENT=$(cat "$REVIEW_MD")
-assert_contains "Post self-review resolution marker" "$CONTENT" "TaskCreate for resolution marker present"
+# Assert on the TaskCreate form specifically (not the bare label, which also appears in the
+# step-8 gate prose) so removing the step-5 TaskCreate would actually fail this test.
+assert_contains 'TaskCreate("Post self-review resolution marker"' "$CONTENT" "step-5 TaskCreate for resolution marker present"
 
 _flow_test_begin "review.md gates step 8 on the resolution-marker task (no silent skip on gh failure)"
 # A failed `gh pr comment` must NOT advance the workflow — otherwise the resolution marker
 # is silently absent and the merge gate false-blocks again (the bug this whole change fixes).
 CONTENT=$(cat "$REVIEW_MD")
 assert_contains 'BOTH "Post self-review comment" AND "Post self-review resolution marker"' "$CONTENT" "step 8 requires both self-review posting tasks"
+assert_contains "RES_EXIT" "$CONTENT" "resolution post captures gh exit for a machine-checkable backstop"
 assert_contains "leave the task" "$CONTENT" "resolution post has a failure backstop (retry, do not advance)"
+
+_flow_test_begin "review.md step 8 has a zero-findings carve-out (no deadlock when nothing to resolve)"
+# A zero-findings self-review legitimately skips the resolution marker; step 8 must allow the
+# task to be completed as SKIP rather than deadlocking on the both-tasks gate.
+CONTENT=$(cat "$REVIEW_MD")
+assert_contains "Zero-findings exception" "$CONTENT" "step 8 documents the zero-findings carve-out"
+assert_contains "SKIP — no findings to resolve" "$CONTENT" "zero-findings path completes the task as SKIP"
 
 _flow_test_begin "review.md self-review still posts FLOW_REVIEW_CYCLE in the review body"
 CONTENT=$(cat "$REVIEW_MD")


### PR DESCRIPTION
## Summary

Fixes three `/flow:merge` gate defects (all verified against `flow@3.2.0` source). They touch the same files, so they land together.

| Issue | What was wrong | Fix |
|-------|----------------|-----|
| **#124** | The self-review fix-forward path fixes every finding in-PR but posted only a `FLOW_REVIEW_CYCLE` marker (status `open`) and **no** `FLOW_RESOLUTION_CYCLE`. The merge gate balances `FINDINGS − RESOLVED` and reads `RESOLVED` only from a `FLOW_RESOLUTION_CYCLE` issue comment → every fix-forwarded finding read as unresolved → false-block, forcing a manual Tier-3 override. | Self-review now emits the **same `FLOW_RESOLUTION_CYCLE` marker `/flow:address` emits** (issue-comments stream), recording fix-forwarded IDs as `RESOLVED` (and unfixable ones as `ESCALATED`). **Zero change to the gate's classification logic.** |
| **#126** | The merge assessment's diagnostic seed scanned only `issues/N/comments`, but `FLOW_REVIEW_CYCLE` markers live in `pulls/N/reviews` → `SEED_MARKER_COUNT=0` despite present markers. | Seed now scans **both** streams, unions hits, emits `SEED_SCANNED` naming surfaces, and distinguishes absent (`SEED_MARKER_COUNT=0`) from malformed (`SEED_FORMAT_INVALID`). Diagnostic-only; the authoritative gate already scanned both. |
| **#125** | Primary bug (an `achieved`/terminal goal read as "no active FlowGoal" and false-blocking) was **already fixed in 3.2.0** via `flow-active-goal.sh --allow-terminal --branch-strict`, but nothing pinned the mapping. | Adds a **regression guard** asserting the full lifecycle→state contract. |

## Design decision for #124 (why B, not the issue's recommended A)

The issue recommended fix **(A)**: have the parser honor an inline `|resolved` status on `FLOW_REVIEW_CYCLE` rows. **Rejected** — it contradicts the documented design:

- `references/finding-schema.md` *defines* status `resolved` as **"closed in `FLOW_RESOLUTION_CYCLE` with the same ID"** — resolution is defined by resolution-marker membership, not an inline review field.
- `references/finding-ledger-parser.md` documents the review-marker status as `open` at review time.
- (A) would force changes to the security-sensitive, trust-filtered gate parser.

Fix **(B)** is design-faithful: `templates/self-review-comment.md` is framed **"Findings Found & Fixed"** — self-review is raise + resolve in one action — so it emits the canonical resolution marker. This also fixes a latent bug: the self-review template carried **no marker at all**.

## A note on #125's failed/cancelled wishlist

The issue's "expected behavior" also wanted `failed`/`cancelled` goals to **block**. They currently resolve to **not-applicable** (exit 1) — intentionally (`flow-active-goal.test.sh:354-359`: "only `achieved` is a gate-relevant terminal state"). The merge gate keys on an *active, incomplete* obligation; an abandoned/closed goal defers to the PR's own review state + the finding-ledger gate. This is **intentionally not changed** in 3.2.x (documented in the CHANGELOG). The regression guard asserts actual, intended behavior rather than the unimplemented wishlist.

## Testing

- New `tests/flow-self-review-resolution.test.sh` (#124) — 15 assertions.
- New `tests/flow-merge-seed.test.sh` (#126) — 12 assertions, including functional jq tests proving a review-body-only marker is counted and malformed markers are flagged.
- Extended `tests/flow-active-goal.test.sh` + `tests/flow-pr-merge-goal-gate.test.sh` (#125) — consolidated lifecycle→state guard.
- **Full suite: 1010 pass, 0 fail** (`plugins/flow/tests/run.sh`).

## Release

`flow 3.2.0 → 3.2.1` (patch); marketplace `4.6.0 → 4.6.1`. CHANGELOG updated.

Closes #124
Closes #125
Closes #126
