### PR TITLE
feat(dossier): observe rolling-branch rotation status, telemetry only

### DIFF
--- a/.decisions/issue-138.md
+++ b/.decisions/issue-138.md
@@ -36,6 +36,12 @@ artifacts:
   workflow: start-issue
   run_id: 2026-07-29T115831Z-issue-138
   status: completed
+- type: review-cycle
+  captured_at: '2026-08-02T23:11:01Z'
+  cycle: 1
+  path: B
+  findings_count: 8
+  pr: 145
 ---
 # Issue #138 — Rolling-branch rotation, telemetry only
 
@@ -132,3 +138,5 @@ PASS — 3 tasks reviewed (implementation-planner agent). Task 59 (script + work
 <!-- auto-log: 2026-08-03 01:02 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
 
 <!-- auto-log: 2026-08-03 01:06 commit "fix(dossier): guard empty config overrides, sanitize job-summary output" -->
+
+<!-- auto-log: 2026-08-03 01:10 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/pr-body-138.md -->

--- a/.decisions/issue-138.md
+++ b/.decisions/issue-138.md
@@ -184,3 +184,19 @@ PASS — 3 tasks reviewed (implementation-planner agent). Task 59 (script + work
 <!-- auto-log: 2026-08-03 01:52 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
 
 <!-- auto-log: 2026-08-03 01:52 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 01:53 commit "fix(dossier): route config-resolver infra failures through die_infra" -->
+
+<!-- auto-log: 2026-08-03 01:54 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 01:55 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 01:57 commit "fix(dossier): route config-resolver infra failures through die_infra" -->
+
+<!-- auto-log: 2026-08-03 01:57 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 01:58 commit "fix(dossier): route config-resolver infra failures through die_infra" -->
+
+<!-- auto-log: 2026-08-03 01:58 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 01:59 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->

--- a/.decisions/issue-138.md
+++ b/.decisions/issue-138.md
@@ -1,0 +1,87 @@
+---
+issue: 138
+created: '2026-08-02T20:53:11Z'
+artifacts:
+- type: specification
+  captured_at: '2026-08-02T20:53:11Z'
+  by: specification-capture
+  elements:
+  - non-goals
+  - failure-modes
+  - interface-contracts
+- type: goal-created
+  captured_at: '2026-08-02T20:53:11Z'
+  goal_id: issue-138
+  source: github_issue:138
+- type: workflow-run
+  captured_at: '2026-08-02T20:53:12Z'
+  workflow: start-issue
+  run_id: 2026-07-29T115831Z-issue-138
+  status: active
+- type: stranger-test
+  captured_at: '2026-08-02T20:53:12Z'
+  result: PASS
+  task_count: 3
+- type: verdict
+  captured_at: '2026-08-02T20:53:12Z'
+  result: PASS
+- type: goal-evaluation
+  captured_at: '2026-08-02T21:11:30Z'
+  goal_id: issue-138
+  result: achieved
+  evidence_bundle: .flow/runs/2026-07-29T115831Z-issue-138
+  failures: none
+---
+# Issue #138 — Rolling-branch rotation, telemetry only
+
+**Title**: dossier: make rolling-branch rotation observable (telemetry only) before any automated branch action is considered
+**Labels**: enhancement, plugin
+
+## Specification
+
+_Captured by specification-capture skill on 2026-07-29. Source: mixed (non-goals extracted-from-issue; failure modes and interface contracts drafted and user-confirmed)._
+
+### Non-goals
+
+- Never close a pull request, delete a branch, or create a replacement branch, under any circumstance, as a result of this capability (issue body, AC2, verbatim).
+- Never implement the actual rotation mechanism (closing/deleting/recreating the accumulating branch) — that requires its own dedicated proposal, backed by real observation data from this issue's work (issue body, "Context").
+- Never modify, weaken, or bypass the existing destructive-action guard in the `publish` job's "Prepare the documentation branch" step (the `FOREIGN`-commit walk / `EXISTING_PR` check that gates `git push origin --delete`, `dossier-docs-refresh.yml:738-822`) — this issue's script and workflow step are read-only additions to the `policy` job and must never touch the `publish` job's write-permission code path.
+- Never grant the new step more than the `policy` job's existing `contents: read` / `pull-requests: read` permission scope.
+
+### Failure modes
+
+- **Timeouts** — none — the new script performs only local `git` operations plus a single optional `gh pr list`/`gh pr view` call under the same network conditions as the existing `policy` job's `EXISTING_PR` lookup (`dossier-policy.sh:390`); no new timeout surface is introduced beyond what that job already tolerates.
+- **Partial failures** — when the `gh` CLI is absent or its API call fails, the script degrades to a git-only age determination (oldest `Dossier-Generated: true` commit on the docs branch) rather than failing outright, and logs an explicit `note()` (following `dossier-policy.sh:451/461`'s convention) rather than the silent-empty pattern the issue implicitly reacts to (`dossier-policy.sh:390`, `dossier-docs-refresh.yml:720`). If BOTH the PR lookup and the commit-based fallback are unable to produce an age, `would_rotate` is reported as the literal string `unknown`, never coerced to `false`.
+- **Invalid input** — a non-numeric or missing `dossier.ci.thresholds.rotationMaxAccumulatedLines` config value falls back to the documented default (5000) rather than crashing the script or corrupting the `--github-output` line format, matching the malformed-env-var handling precedent established in `dossier-scan-security.sh`/`dossier-scan-quality.sh` (issue #137, PR #144).
+- **Missing context** — when the rolling documentation branch does not exist on the remote at all (`git ls-remote --exit-code --heads origin "$DOCS_BRANCH"` fails), the script reports a distinct `no-branch` cold-start state — `would_rotate=false` with an honest, specific reason ("the rolling branch does not exist yet; nothing to rotate") — never silently reporting "0 lines changed / would not rotate" as if a branch had been measured and found small.
+
+### Interface contracts
+
+- New script `plugins/dossier/bin/dossier-rotation-check.sh`. CLI contract mirrors `dossier-staleness-check.sh`/`dossier-policy.sh`: `[--github-output <file>] [--summary <file>]`. Untrusted values (`BASE_REF`, `GH_TOKEN`) bound via environment only, never argv. Exit 0 = a decision was reached (`would_rotate` may be `true`/`false`/`unknown`); exit 1 = infrastructure failure (missing `git`/`jq`, not inside a git repository); exit 2 = bad arguments.
+- Emitted key=value fields (stdout + `--github-output` file, using `emit()`'s existing sanitization contract): `would_rotate` (`true`|`false`|`unknown`), `reason` (human-readable string), `age_days` (integer or empty), `age_source` (`pr_created_at`|`branch_commits`|`no-branch`|`unknown`), `accumulated_files` (integer or empty), `accumulated_lines` (integer or empty), `docs_branch`, `rotation_policy` (`none`|`weekly`|`monthly`).
+- New schema field `dossier.ci.thresholds.rotationMaxAccumulatedLines` (integer, minimum 1, default 5000) added to `schema.json`, `settings.json`, and `templates/config.example.json` alongside the existing `thresholds` block — resolvable via the standard `DOSSIER_CI_THRESHOLDS_ROTATION_MAX_ACCUMULATED_LINES` environment override.
+- New workflow step "Check whether the documentation branch would rotate" inside the `policy` job of `dossier-docs-refresh.yml`, placed after the existing `Decide` step, running unconditionally (no `if:` gate on `steps.decide.outputs.should_run`), writing its determination to `$GITHUB_STEP_SUMMARY` via the same append pattern the `Decide` and evidence-bundle steps already use. Executes entirely within the `policy` job's existing `contents: read` / `pull-requests: read` permission scope — no new permission is granted.
+
+## Acceptance Criteria (as validated)
+
+1. Every pipeline run records a clear, human-readable determination of whether branch rotation would currently be warranted, and the specific reason.
+2. No pipeline run, under any circumstance, closes a pull request, deletes a branch, or creates a replacement branch as a result of this capability — it is purely observational.
+3. The determination logic is exercised by tests covering both "would rotate" and "would not rotate" scenarios.
+4. **Reworded (user-confirmed 2026-07-29)** — original: "After a period of real observation on this repository's own pipeline runs, there is enough recorded data to make an informed decision about whether an actual (non-destructive-by-design) rotation mechanism is worth proposing as separate, future work." Not verifiable by any command today — it describes a future outcome, not a testable property of this PR. Reworded to: `age_days`, `accumulated_files`, and `accumulated_lines` are always computed and emitted in a stable, parseable format across every state (no-branch, PR-anchored, commit-anchored, degraded-lookup) — including when `rollingBranchRotation=none` — so that a real multi-week observation period actually produces usable data. This is what makes the literal AC4 achievable in the future rather than deferred indefinitely with no mechanism to ever satisfy it.
+5. The full dossier test suite passes.
+
+## Stranger Test
+
+PASS — 3 tasks reviewed (implementation-planner agent). Task 59 (script + workflow wiring + AC1/AC3/AC4 tests), Task 60 (schema/config triad + AC2 negative/safety assertions, depends on 59), Task 61 (full-suite verification, depends on 59+60). Each task description embeds the concrete algorithm, exact command sequences, file paths, and test-fixture patterns needed to execute with no other context. Three design gaps the planner found and resolved before finalizing (each verified empirically, not assumed): (1) `dossier.ci.thresholds.rotationMaxAccumulatedLines` must resolve through `dossier-resolve-config.sh`, not `cascade-resolve.sh` — the latter explicitly skips the `DOSSIER_*` env-override layer the tests depend on; (2) `git ls-remote` exit code 2 (ref absent) must be distinguished from any other non-zero exit (transport/auth failure) — only exit 2 is a genuine `no-branch` cold start, everything else is `age_source=unknown`; (3) `actions/checkout@v4` with `fetch-depth: 0` does not create remote-tracking refs for branches other than the one checked out (confirmed by the `publish` job's own explicit `git fetch` calls for `BASE_REF`/`DOCS_BRANCH`) — the new script must fetch both itself.
+
+<!-- auto-log: 2026-08-02 22:53 Write /Users/danielbentes/synapti-marketplace/.decisions/issue-138.md -->
+
+<!-- auto-log: 2026-08-02 23:06 commit "fix(dossier): address review findings for rotation-check telemetry (#138)" -->
+
+<!-- auto-log: 2026-08-02 23:06 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-02 23:07 commit "test(dossier): assert age_days is also emitted under rollingBranchRotation=none" -->
+
+<!-- auto-log: 2026-08-02 23:11 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/verdict-issue-138.json -->
+
+<!-- auto-log: 2026-08-03 00:44 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/lifecycle-issue-138-achieved.yaml -->

--- a/.decisions/issue-138.md
+++ b/.decisions/issue-138.md
@@ -31,6 +31,11 @@ artifacts:
   result: achieved
   evidence_bundle: .flow/runs/2026-07-29T115831Z-issue-138
   failures: none
+- type: workflow-run
+  captured_at: '2026-08-02T22:48:02Z'
+  workflow: start-issue
+  run_id: 2026-07-29T115831Z-issue-138
+  status: completed
 ---
 # Issue #138 — Rolling-branch rotation, telemetry only
 
@@ -85,3 +90,7 @@ PASS — 3 tasks reviewed (implementation-planner agent). Task 59 (script + work
 <!-- auto-log: 2026-08-02 23:11 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/verdict-issue-138.json -->
 
 <!-- auto-log: 2026-08-03 00:44 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/lifecycle-issue-138-achieved.yaml -->
+
+<!-- auto-log: 2026-08-03 00:47 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/complete_run.py -->
+
+<!-- auto-log: 2026-08-03 00:49 Edit /Users/danielbentes/synapti-marketplace/.claude/agent-memory/flow-convention-checker/feedback_dont_run_dossier_test_suite.md -->

--- a/.decisions/issue-138.md
+++ b/.decisions/issue-138.md
@@ -144,3 +144,19 @@ PASS — 3 tasks reviewed (implementation-planner agent). Task 59 (script + work
 <!-- auto-log: 2026-08-03 01:14 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
 
 <!-- auto-log: 2026-08-03 01:15 commit "fix(dossier): sanitize die_infra's summary output for defense-in-depth" -->
+
+<!-- auto-log: 2026-08-03 01:36 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 01:37 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 01:37 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 01:37 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 01:38 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 01:39 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 01:39 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 01:41 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->

--- a/.decisions/issue-138.md
+++ b/.decisions/issue-138.md
@@ -140,3 +140,7 @@ PASS — 3 tasks reviewed (implementation-planner agent). Task 59 (script + work
 <!-- auto-log: 2026-08-03 01:06 commit "fix(dossier): guard empty config overrides, sanitize job-summary output" -->
 
 <!-- auto-log: 2026-08-03 01:10 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/pr-body-138.md -->
+
+<!-- auto-log: 2026-08-03 01:14 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 01:15 commit "fix(dossier): sanitize die_infra's summary output for defense-in-depth" -->

--- a/.decisions/issue-138.md
+++ b/.decisions/issue-138.md
@@ -94,3 +94,41 @@ PASS — 3 tasks reviewed (implementation-planner agent). Task 59 (script + work
 <!-- auto-log: 2026-08-03 00:47 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/complete_run.py -->
 
 <!-- auto-log: 2026-08-03 00:49 Edit /Users/danielbentes/synapti-marketplace/.claude/agent-memory/flow-convention-checker/feedback_dont_run_dossier_test_suite.md -->
+
+<!-- auto-log: 2026-08-03 00:52 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 00:52 commit "test(dossier): assert on die_infra's message, silencing SC2034" -->
+
+<!-- auto-log: 2026-08-03 00:55 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/templates/ci/dossier-docs-refresh.yml -->
+
+<!-- auto-log: 2026-08-03 00:55 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/workflow-template.test.sh -->
+
+<!-- auto-log: 2026-08-03 00:55 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 00:56 commit "fix(dossier): add continue-on-error to rotation-check, fix --help range" -->
+
+<!-- auto-log: 2026-08-03 00:56 commit "fix(dossier): add continue-on-error to rotation-check, fix --help range" -->
+
+<!-- auto-log: 2026-08-03 00:57 commit "fix(dossier): add continue-on-error to rotation-check, fix --help range" -->
+
+<!-- auto-log: 2026-08-03 00:58 Write /Users/danielbentes/synapti-marketplace/.claude/agent-memory/flow-security-reviewer/feedback_dont_execute_dossier_tests_directly.md -->
+
+<!-- auto-log: 2026-08-03 00:58 Write /Users/danielbentes/synapti-marketplace/.claude/agent-memory/flow-security-reviewer/project_dossier_concurrent_flow_sessions.md -->
+
+<!-- auto-log: 2026-08-03 00:58 Edit /Users/danielbentes/synapti-marketplace/.claude/agent-memory/flow-security-reviewer/MEMORY.md -->
+
+<!-- auto-log: 2026-08-03 00:59 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 01:00 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 01:00 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 01:01 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 01:02 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 01:02 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 01:02 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 01:06 commit "fix(dossier): guard empty config overrides, sanitize job-summary output" -->

--- a/.decisions/issue-138.md
+++ b/.decisions/issue-138.md
@@ -42,6 +42,12 @@ artifacts:
   path: B
   findings_count: 8
   pr: 145
+- type: review-cycle
+  captured_at: '2026-08-03T00:03:42Z'
+  cycle: 1
+  path: A
+  findings_count: 32
+  pr: 145
 ---
 # Issue #138 — Rolling-branch rotation, telemetry only
 
@@ -200,3 +206,15 @@ PASS — 3 tasks reviewed (implementation-planner agent). Task 59 (script + work
 <!-- auto-log: 2026-08-03 01:58 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
 
 <!-- auto-log: 2026-08-03 01:59 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 02:00 commit "fix(dossier): neutralize markdown-active note() text; close 3 test gaps" -->
+
+<!-- auto-log: 2026-08-03 02:01 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/review-145-cycle1.md -->
+
+<!-- auto-log: 2026-08-03 02:02 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/resolution-145-cycle1.md -->
+
+<!-- auto-log: 2026-08-03 02:03 Edit /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/pr145-current-body.md -->
+
+<!-- auto-log: 2026-08-03 02:06 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 02:08 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/test-no-gh-path.sh -->

--- a/.decisions/issue-138.md
+++ b/.decisions/issue-138.md
@@ -160,3 +160,27 @@ PASS — 3 tasks reviewed (implementation-planner agent). Task 59 (script + work
 <!-- auto-log: 2026-08-03 01:39 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
 
 <!-- auto-log: 2026-08-03 01:41 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 01:42 commit "fix(dossier): address remaining P2 findings from PR #145 Path A review" -->
+
+<!-- auto-log: 2026-08-03 01:45 commit "fix(dossier): address remaining P2 findings from PR #145 Path A review" -->
+
+<!-- auto-log: 2026-08-03 01:49 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 01:49 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 01:49 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 01:50 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 01:51 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 01:51 commit "fix(dossier): address remaining P2 findings from PR #145 Path A review" -->
+
+<!-- auto-log: 2026-08-03 01:52 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 01:52 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 01:52 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 01:52 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->

--- a/.flow/goals/issue-138.goal.yaml
+++ b/.flow/goals/issue-138.goal.yaml
@@ -1,0 +1,131 @@
+apiVersion: flow.synapti.ai/v1
+kind: FlowGoal
+metadata:
+  id: issue-138
+  created_at: '2026-07-29T12:13:50Z'
+  created_by: /flow:start
+  owner: daniel.bentes@gmail.com
+scope:
+  repo: synaptiai/synapti-marketplace
+  branch: feature/issue-138-rotation-telemetry
+  issue: 138
+  journal: .decisions/issue-138.md
+objective:
+  outcome: Issue
+  source:
+    type: github_issue
+    number: 138
+    title: 'dossier: make rolling-branch rotation observable (telemetry only) before
+      any automated branch action is considered'
+  acceptance_criteria:
+  - id: AC1
+    text: Every pipeline run records a clear, human-readable determination of whether
+      branch rotation would currently be warranted, and the specific reason.
+    verification_command: bash plugins/dossier/tests/run.sh rotation-check.test.sh
+      workflow-template.test.sh
+    must_pass: true
+    status: pending
+    evidence_ref: null
+    last_evaluated_at: null
+    last_result: null
+  - id: AC2
+    text: No pipeline run, under any circumstance, closes a pull request, deletes
+      a branch, or creates a replacement branch as a result of this capability — it
+      is purely observational.
+    verification_command: bash plugins/dossier/tests/run.sh bin-scripts.test.sh workflow-template.test.sh
+    must_pass: true
+    status: pending
+    evidence_ref: null
+    last_evaluated_at: null
+    last_result: null
+  - id: AC3
+    text: The determination logic is exercised by tests covering both "would rotate"
+      and "would not rotate" scenarios.
+    verification_command: bash plugins/dossier/tests/run.sh rotation-check.test.sh
+    must_pass: true
+    status: pending
+    evidence_ref: null
+    last_evaluated_at: null
+    last_result: null
+  - id: AC4
+    text: 'Reworded (user-confirmed 2026-07-29, .decisions/issue-138.md): age_days,
+      accumulated_files, and accumulated_lines are always computed and emitted in
+      a stable, parseable format across every state (no-branch, PR-anchored, commit-anchored,
+      degraded-lookup), including when rollingBranchRotation=none.'
+    verification_command: bash plugins/dossier/tests/run.sh rotation-check.test.sh
+    must_pass: true
+    status: pending
+    evidence_ref: null
+    last_evaluated_at: null
+    last_result: null
+  - id: AC5
+    text: The full dossier test suite passes.
+    verification_command: bash plugins/dossier/tests/run.sh
+    must_pass: true
+    status: pending
+    evidence_ref: null
+    last_evaluated_at: null
+    last_result: null
+specification:
+  non_goals:
+  - Never close a pull request, delete a branch, or create a replacement branch, under
+    any circumstance, as a result of this capability.
+  - Never implement the actual rotation mechanism (closing/deleting/recreating the
+    accumulating branch) — that requires its own dedicated proposal, backed by real
+    observation data from this issue's work.
+  - Never modify, weaken, or bypass the existing destructive-action guard in the publish
+    job's "Prepare the documentation branch" step (the FOREIGN-commit walk / EXISTING_PR
+    check that gates git push origin --delete).
+  - Never grant the new step more than the policy job's existing contents:read / pull-requests:read
+    permission scope.
+  failure_modes:
+  - 'Timeouts: none — only local git operations plus one optional gh pr list/view
+    call under the same network conditions as the existing policy job.'
+  - 'Partial failures: gh unavailable/failing degrades to git-only age (oldest Dossier-Generated
+    commit), with an explicit note() logged; if that also fails, would_rotate reports
+    the literal string ''unknown'', never coerced to false.'
+  - 'Invalid input: a non-numeric or missing rotationMaxAccumulatedLines config value
+    falls back to the documented default (5000).'
+  - 'Missing context: a docs branch that does not exist remotely is a distinct ''no-branch''
+    cold-start state (would_rotate=false, specific reason), never silently reported
+    as ''0 lines changed''.'
+  interface_contracts:
+  - 'New script plugins/dossier/bin/dossier-rotation-check.sh: [--github-output <file>]
+    [--summary <file>]; untrusted values (BASE_REF, GH_TOKEN) via environment only;
+    exit 0=decision reached, 1=infra failure, 2=bad args.'
+  - 'Emitted key=value fields: would_rotate (true|false|unknown), reason, age_days,
+    age_source (pr_created_at|branch_commits|no-branch|unknown), accumulated_files,
+    accumulated_lines, docs_branch, rotation_policy.'
+  - New schema field dossier.ci.thresholds.rotationMaxAccumulatedLines (integer, minimum
+    1, default 5000) in schema.json/settings.json/templates/config.example.json.
+  - New unconditional workflow step inside the policy job of dossier-docs-refresh.yml,
+    after the Decide step, within the job's existing read-only permission scope.
+constraints:
+  tdd_required: true
+  require_all_pass: true
+  no_calendar_estimates: true
+  no_tier3_without_confirmation: true
+evaluator:
+  type: flow_verdict_judge
+  command: /flow:goal evaluate
+  judge_agent: goal-evaluator-judge
+  evidence_bundle_format: plugins/flow/references/evidence-bundle-format.md
+  denied_context:
+  - implementation_rationale
+  - self_review_findings
+continuation:
+  mode: flow_managed
+  on_incomplete: continue_next_activity
+  on_blocked: six_field_escalation
+  on_complete: mark_achieved
+  max_iterations: 20
+lifecycle:
+  status: achieved
+  current_phase: verify
+  current_activity: complete
+  turns_evaluated: 2
+  last_evaluation:
+    result: pass
+    reason: All 5 acceptance criteria PASS via independent goal-evaluator-judge (confidence
+      0.85), full suite 1800/1800.
+    at: '2026-08-03T00:00:00Z'

--- a/plugins/dossier/bin/dossier-rotation-check.sh
+++ b/plugins/dossier/bin/dossier-rotation-check.sh
@@ -185,7 +185,15 @@ case "$ROTATION_POLICY" in
     ;;
 esac
 SIZE_THRESHOLD=$(cfg '.dossier.ci.thresholds.rotationMaxAccumulatedLines' '5000')
-case "$SIZE_THRESHOLD" in ''|*[!0-9]*) SIZE_THRESHOLD=5000 ;; esac
+case "$SIZE_THRESHOLD" in
+  ''|*[!0-9]*)
+    SIZE_THRESHOLD=5000
+    ;;
+  0)
+    SIZE_THRESHOLD=5000
+    note "dossier.ci.thresholds.rotationMaxAccumulatedLines resolved to 0, which would make the size signal trigger unconditionally; falling back to the documented default (5000)."
+    ;;
+esac
 
 if [ -z "$BASE_REF" ]; then
   BASE_REF=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')
@@ -272,7 +280,12 @@ fi
 # walking the docs branch for the oldest Dossier-Generated commit.
 # ---------------------------------------------------------------------------
 if command -v gh >/dev/null 2>&1; then
-  PR_JSON=$(gh pr list --head "$DOCS_BRANCH" --state open --json number,createdAt --jq '.[0]' 2>/dev/null)
+  # --head matches by branch name only, across every fork with an open PR
+  # against this repo -- an external fork could open a same-named decoy
+  # branch to spoof the age lookup. isCrossRepository==false restricts the
+  # match to PRs whose head lives in this repo (gh has no owner:branch
+  # syntax for --head to scope this directly).
+  PR_JSON=$(gh pr list --head "$DOCS_BRANCH" --state open --json number,createdAt,isCrossRepository --jq '[.[] | select(.isCrossRepository == false)][0]' 2>/dev/null)
   PR_LIST_RC=$?
   if [ "$PR_LIST_RC" -ne 0 ]; then
     # Distinct from "gh ran fine, no open PR found" (PR_JSON empty/null with
@@ -358,7 +371,7 @@ case "$ROTATION_POLICY" in
     ;;
 esac
 
-case "$AGE_DAYS" in ''|*[!0-9]*) AGE_KNOWN=0 ;; *) AGE_KNOWN=1 ;; esac
+case "$AGE_DAYS" in ''|*[!0-9]*) AGE_KNOWN=0; AGE_DAYS="" ;; *) AGE_KNOWN=1 ;; esac
 case "$ACC_LINES" in ''|*[!0-9]*) SIZE_KNOWN=0 ;; *) SIZE_KNOWN=1 ;; esac
 
 AGE_TRIGGERED=0

--- a/plugins/dossier/bin/dossier-rotation-check.sh
+++ b/plugins/dossier/bin/dossier-rotation-check.sh
@@ -120,6 +120,15 @@ command -v git >/dev/null 2>&1 || die_infra "git is not installed on this runner
 command -v jq  >/dev/null 2>&1 || die_infra "jq is not installed; dossier configuration cannot be read."
 git rev-parse --git-dir >/dev/null 2>&1 || die_infra "not inside a git repository (checkout step missing or failed)."
 
+# $CASCADE exits 2 on infrastructure failure (missing jq, unreadable temp
+# dir, etc; see dossier-resolve-config.sh's own documented exit codes) and 0
+# for "resolved a value or returned the default" -- cfg() alone can't tell
+# those apart from its caller's side, and every call site below checks the
+# assignment's exit status with `|| die_infra ...` so a genuine resolver
+# crash is never silently treated as a deliberate empty/default read. This
+# check MUST happen in the same shell that calls cfg(), never inside a
+# helper invoked as `X=$(helper ...)` -- die_infra()'s `exit 1` would then
+# only terminate the command-substitution subshell, not the script.
 cfg() { "$CASCADE" --default "$2" "${1#.}" 2>/dev/null; }
 
 write_summary() {
@@ -161,7 +170,7 @@ finish() {
 # Configuration
 # ---------------------------------------------------------------------------
 
-DOCS_BRANCH=$(cfg '.dossier.ci.rollingBranch' 'docs/dossier')
+DOCS_BRANCH=$(cfg '.dossier.ci.rollingBranch' 'docs/dossier') || die_infra "could not resolve dossier.ci.rollingBranch (configuration resolver failed)."
 # An explicitly-empty override (DOSSIER_CI_ROLLING_BRANCH="" or
 # "rollingBranch": "" in any settings file) beats every cascade layer by
 # design (dossier-resolve-config.sh/cascade-resolve.sh both treat set-but-
@@ -177,14 +186,14 @@ case "$DOCS_BRANCH" in
     note "dossier.ci.rollingBranch resolved to an empty value; falling back to the documented default (docs/dossier)."
     ;;
 esac
-ROTATION_POLICY=$(cfg '.dossier.ci.rollingBranchRotation' 'none')
+ROTATION_POLICY=$(cfg '.dossier.ci.rollingBranchRotation' 'none') || die_infra "could not resolve dossier.ci.rollingBranchRotation (configuration resolver failed)."
 case "$ROTATION_POLICY" in
   '')
     ROTATION_POLICY='none'
     note "dossier.ci.rollingBranchRotation resolved to an empty value; falling back to the documented default (none)."
     ;;
 esac
-SIZE_THRESHOLD=$(cfg '.dossier.ci.thresholds.rotationMaxAccumulatedLines' '5000')
+SIZE_THRESHOLD=$(cfg '.dossier.ci.thresholds.rotationMaxAccumulatedLines' '5000') || die_infra "could not resolve dossier.ci.thresholds.rotationMaxAccumulatedLines (configuration resolver failed)."
 case "$SIZE_THRESHOLD" in
   ''|*[!0-9]*)
     SIZE_THRESHOLD=5000

--- a/plugins/dossier/bin/dossier-rotation-check.sh
+++ b/plugins/dossier/bin/dossier-rotation-check.sh
@@ -321,17 +321,18 @@ esac
 case "$AGE_DAYS" in ''|*[!0-9]*) AGE_KNOWN=0 ;; *) AGE_KNOWN=1 ;; esac
 case "$ACC_LINES" in ''|*[!0-9]*) SIZE_KNOWN=0 ;; *) SIZE_KNOWN=1 ;; esac
 
-if [ "$AGE_KNOWN" -eq 0 ] && [ "$SIZE_KNOWN" -eq 0 ]; then
-  WOULD_ROTATE="unknown"
-  REASON="rotation status could not be determined: age and accumulated size are both unavailable"
-  finish
-fi
-
 AGE_TRIGGERED=0
 [ "$AGE_KNOWN" -eq 1 ] && [ "$AGE_DAYS" -ge "$THRESHOLD_DAYS" ] && AGE_TRIGGERED=1
 SIZE_TRIGGERED=0
 [ "$SIZE_KNOWN" -eq 1 ] && [ "$ACC_LINES" -ge "$SIZE_THRESHOLD" ] && SIZE_TRIGGERED=1
 
+# A confident "false" requires BOTH dimensions to have been measured and
+# neither to have crossed its threshold. Whenever a dimension triggers, that
+# alone is decisive regardless of the other dimension's state. But when
+# NEITHER known dimension triggered and at least one dimension is unknown,
+# the unmeasured dimension could still be over threshold — that must report
+# "unknown", never a "false" that only happens to be right about the
+# dimension it could measure.
 if [ "$AGE_TRIGGERED" -eq 1 ] || [ "$SIZE_TRIGGERED" -eq 1 ]; then
   WOULD_ROTATE="true"
   PARTS=""
@@ -346,19 +347,17 @@ if [ "$AGE_TRIGGERED" -eq 1 ] || [ "$SIZE_TRIGGERED" -eq 1 ]; then
     fi
   fi
   REASON="would rotate: ${PARTS}"
+elif [ "$AGE_KNOWN" -eq 0 ] || [ "$SIZE_KNOWN" -eq 0 ]; then
+  WOULD_ROTATE="unknown"
+  if [ "$AGE_KNOWN" -eq 0 ] && [ "$SIZE_KNOWN" -eq 0 ]; then
+    REASON="rotation status could not be determined: age and accumulated size are both unavailable"
+  elif [ "$AGE_KNOWN" -eq 0 ]; then
+    REASON="rotation status could not be determined: age is unavailable; accumulated size is ${ACC_LINES} lines (< ${SIZE_THRESHOLD}-line threshold), but that alone cannot rule out rotation"
+  else
+    REASON="rotation status could not be determined: accumulated size is unavailable; age is ${AGE_DAYS} days (< ${THRESHOLD_DAYS}-day ${ROTATION_POLICY} threshold), but that alone cannot rule out rotation"
+  fi
 else
-  KNOWN_PARTS=""
-  if [ "$AGE_KNOWN" -eq 1 ]; then
-    KNOWN_PARTS="age is ${AGE_DAYS} days (< ${THRESHOLD_DAYS}-day ${ROTATION_POLICY} threshold)"
-  fi
-  if [ "$SIZE_KNOWN" -eq 1 ]; then
-    if [ -n "$KNOWN_PARTS" ]; then
-      KNOWN_PARTS="${KNOWN_PARTS}; accumulated size is ${ACC_LINES} lines (< ${SIZE_THRESHOLD}-line threshold)"
-    else
-      KNOWN_PARTS="accumulated size is ${ACC_LINES} lines (< ${SIZE_THRESHOLD}-line threshold)"
-    fi
-  fi
   WOULD_ROTATE="false"
-  REASON="within threshold: ${KNOWN_PARTS}"
+  REASON="within threshold: age is ${AGE_DAYS} days (< ${THRESHOLD_DAYS}-day ${ROTATION_POLICY} threshold); accumulated size is ${ACC_LINES} lines (< ${SIZE_THRESHOLD}-line threshold)"
 fi
 finish

--- a/plugins/dossier/bin/dossier-rotation-check.sh
+++ b/plugins/dossier/bin/dossier-rotation-check.sh
@@ -82,7 +82,14 @@ sanitize_md() {
   printf '%s' "$1" | LC_ALL=C tr -d '\000-\037' | tr -d '|`' | tr '\n' ' '
 }
 
-note() { NOTES="${NOTES}- $(sanitize_md "$1")
+# sanitize_md() strips backtick/pipe/control chars but does not strip
+# markdown-active syntax like [text](url), *bold*, or #heading -- table
+# cells neutralize that by wrapping in backticks (GFM renders a backtick
+# span as inert code), but a plain bullet does not get that wrapping for
+# free. Do it here too, so a config-derived note (DOCS_BRANCH/ROTATION_POLICY
+# flow through this from committed, PR-editable config) can't render a
+# spoofed link/heading in the job summary's Notes section.
+note() { NOTES="${NOTES}- \`$(sanitize_md "$1")\`
 "; }
 
 # $GITHUB_OUTPUT is parsed line by line as key=value, so a value carrying a

--- a/plugins/dossier/bin/dossier-rotation-check.sh
+++ b/plugins/dossier/bin/dossier-rotation-check.sh
@@ -1,0 +1,364 @@
+#!/usr/bin/env bash
+# dossier-rotation-check.sh — telemetry-only: report whether the rolling
+# documentation branch would currently warrant rotation. Never takes any
+# action.
+#
+# Usage:
+#   dossier-rotation-check.sh [--github-output <file>] [--summary <file>]
+#
+# Flags:
+#   --github-output <file>  append `key=value` lines here as well as to stdout
+#   --summary <file>        append a human-readable markdown block here
+#
+# Untrusted inputs arrive through the environment, never as arguments:
+#   BASE_REF   base branch name (falls back to the origin default branch)
+#   GH_TOKEN   passed through to `gh`, never interpolated into a command
+#
+# Output (stdout, and --github-output when given):
+#   would_rotate  reason  age_days  age_source
+#   accumulated_files  accumulated_lines  docs_branch  rotation_policy
+#
+# Exit:
+#   0 — a decision was reached (would_rotate may be true, false, or unknown)
+#   1 — infrastructure failure (missing git/jq, not inside a git repository)
+#   2 — bad arguments
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+# The cascade reads ${CLAUDE_PLUGIN_ROOT}/settings.json for plugin defaults. In
+# CI the plugin is checked out to an arbitrary path, so point the variable at
+# this script's own plugin unless the harness already set a usable one.
+if [ -z "${CLAUDE_PLUGIN_ROOT:-}" ] || [ ! -f "${CLAUDE_PLUGIN_ROOT:-}/settings.json" ]; then
+  CLAUDE_PLUGIN_ROOT=$(dirname "$SCRIPT_DIR")
+  export CLAUDE_PLUGIN_ROOT
+fi
+# Config is read through the resolver, not the raw cascade, so the documented
+# DOSSIER_* environment layer applies — the same reasoning dossier-policy.sh
+# gives for its own CASCADE variable. This script is telemetry-only and runs
+# unconditionally in the policy job, so the same "safe here, before any agent
+# runs" argument applies.
+CASCADE="$SCRIPT_DIR/dossier-resolve-config.sh"
+
+GITHUB_OUTPUT_FILE=""
+SUMMARY_FILE=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --github-output)
+      [ $# -lt 2 ] && { echo "dossier-rotation-check: --github-output requires a value" >&2; exit 2; }
+      GITHUB_OUTPUT_FILE="$2"; shift 2 ;;
+    --summary)
+      [ $# -lt 2 ] && { echo "dossier-rotation-check: --summary requires a value" >&2; exit 2; }
+      SUMMARY_FILE="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,26p' "$0"; exit 0 ;;
+    *)
+      echo "dossier-rotation-check: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+BASE_REF="${BASE_REF:-}"
+
+WOULD_ROTATE="unknown"
+REASON="undecided"
+AGE_DAYS=""
+AGE_SOURCE="unknown"
+ACC_FILES=""
+ACC_LINES=""
+DOCS_BRANCH=""
+ROTATION_POLICY=""
+NOTES=""
+
+note() { NOTES="${NOTES}- $1
+"; }
+
+# $GITHUB_OUTPUT is parsed line by line as key=value, so a value carrying a
+# newline does not merely render wrong — it forges additional output pairs for
+# the next job to read. Every value written here is stripped of newlines and
+# control characters first, whatever cascade layer it came from.
+emit() {
+  _v=$(printf '%s' "$2" | LC_ALL=C tr -d '\000-\037')
+  printf '%s=%s\n' "$1" "$_v"
+  if [ -n "$GITHUB_OUTPUT_FILE" ]; then
+    printf '%s=%s\n' "$1" "$_v" >>"$GITHUB_OUTPUT_FILE"
+  fi
+  return 0
+}
+
+# An infrastructure failure is never reported as a reached decision — a silent
+# "unknown" is indistinguishable from a healthy degraded read and would hide a
+# broken runner from whoever reads the job summary.
+die_infra() {
+  echo "::error title=dossier rotation-check::$1" >&2
+  emit would_rotate "unknown"
+  emit reason "infrastructure-error"
+  if [ -n "$SUMMARY_FILE" ]; then
+    {
+      printf '### Dossier rotation check: infrastructure error\n\n'
+      printf '%s\n\n' "$1"
+      printf 'The rotation determination could not be computed. This is a hard failure\n'
+      printf 'rather than an "unknown" telemetry read.\n'
+    } >>"$SUMMARY_FILE"
+  fi
+  exit 1
+}
+
+command -v git >/dev/null 2>&1 || die_infra "git is not installed on this runner."
+command -v jq  >/dev/null 2>&1 || die_infra "jq is not installed; dossier configuration cannot be read."
+git rev-parse --git-dir >/dev/null 2>&1 || die_infra "not inside a git repository (checkout step missing or failed)."
+
+cfg() { "$CASCADE" --default "$2" "${1#.}" 2>/dev/null; }
+
+write_summary() {
+  [ -n "$SUMMARY_FILE" ] || return 0
+  {
+    printf '### Dossier rolling-branch rotation check\n\n'
+    printf 'Telemetry only — this step never rotates, closes, or deletes anything.\n\n'
+    printf '| Field | Value |\n|---|---|\n'
+    printf '| Would rotate | `%s` |\n' "$WOULD_ROTATE"
+    printf '| Reason | `%s` |\n' "$REASON"
+    printf '| Age (days) | `%s` |\n' "${AGE_DAYS:-unknown}"
+    printf '| Age source | `%s` |\n' "$AGE_SOURCE"
+    printf '| Accumulated files | `%s` |\n' "${ACC_FILES:-unknown}"
+    printf '| Accumulated lines | `%s` |\n' "${ACC_LINES:-unknown}"
+    printf '| Docs branch | `%s` |\n' "$DOCS_BRANCH"
+    printf '| Rotation policy | `%s` |\n' "$ROTATION_POLICY"
+    printf '\n'
+    if [ -n "$NOTES" ]; then
+      printf 'Notes:\n\n%s\n' "$NOTES"
+    fi
+  } >>"$SUMMARY_FILE"
+  return 0
+}
+
+finish() {
+  emit would_rotate        "$WOULD_ROTATE"
+  emit reason               "$REASON"
+  emit age_days              "$AGE_DAYS"
+  emit age_source            "$AGE_SOURCE"
+  emit accumulated_files     "$ACC_FILES"
+  emit accumulated_lines     "$ACC_LINES"
+  emit docs_branch           "$DOCS_BRANCH"
+  emit rotation_policy       "$ROTATION_POLICY"
+  write_summary
+  exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+DOCS_BRANCH=$(cfg '.dossier.ci.rollingBranch' 'docs/dossier')
+ROTATION_POLICY=$(cfg '.dossier.ci.rollingBranchRotation' 'none')
+SIZE_THRESHOLD=$(cfg '.dossier.ci.thresholds.rotationMaxAccumulatedLines' '5000')
+case "$SIZE_THRESHOLD" in ''|*[!0-9]*) SIZE_THRESHOLD=5000 ;; esac
+
+if [ -z "$BASE_REF" ]; then
+  BASE_REF=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')
+fi
+
+NOW_EPOCH=$(date -u +%s)
+
+# ---------------------------------------------------------------------------
+# Step 1 — does the rolling branch exist at all?
+# ---------------------------------------------------------------------------
+git ls-remote --exit-code --heads origin "$DOCS_BRANCH" >/dev/null 2>&1
+LS_REMOTE_RC=$?
+
+if [ "$LS_REMOTE_RC" -eq 2 ]; then
+  WOULD_ROTATE="false"
+  REASON="the rolling branch does not exist yet; nothing to rotate"
+  AGE_SOURCE="no-branch"
+  AGE_DAYS=""
+  ACC_FILES=""
+  ACC_LINES=""
+  finish
+fi
+
+if [ "$LS_REMOTE_RC" -ne 0 ]; then
+  # Transport/auth failure — genuinely cannot tell. "rotation is disabled" is
+  # a categorical fact independent of being able to measure the branch, so it
+  # stays false even here; but when rotation IS enabled and we truly can't
+  # tell, that must never look like a confident "false".
+  AGE_SOURCE="unknown"
+  AGE_DAYS=""
+  ACC_FILES=""
+  ACC_LINES=""
+  note "could not reach the remote to check for ${DOCS_BRANCH} (git ls-remote exited ${LS_REMOTE_RC}); treating this as a transport failure, not a missing branch."
+  if [ "$ROTATION_POLICY" = "none" ]; then
+    WOULD_ROTATE="false"
+    REASON="rotation is disabled (dossier.ci.rollingBranchRotation=none); the remote was also unreachable, so no metrics could be gathered"
+  else
+    WOULD_ROTATE="unknown"
+    REASON="could not reach the remote to check ${DOCS_BRANCH} (transport failure); rotation status is unknown, not false"
+  fi
+  finish
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2 — branch exists. Fetch both refs explicitly: actions/checkout with
+# fetch-depth:0 does not create origin/<branch> remote-tracking refs for
+# branches other than the one checked out, so this script fetches them itself
+# to stay standalone and locally callable.
+# ---------------------------------------------------------------------------
+FETCH_OK=1
+if [ -z "$BASE_REF" ]; then
+  FETCH_OK=0
+  note "BASE_REF could not be resolved (no env var and no origin/HEAD symbolic ref); age and size cannot be measured against a base."
+else
+  git fetch --no-tags --prune origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}" >/dev/null 2>&1
+  FETCH_BASE_RC=$?
+  git fetch --no-tags origin "+refs/heads/${DOCS_BRANCH}:refs/remotes/origin/${DOCS_BRANCH}" >/dev/null 2>&1
+  FETCH_DOCS_RC=$?
+  if [ "$FETCH_BASE_RC" -ne 0 ] || [ "$FETCH_DOCS_RC" -ne 0 ]; then
+    FETCH_OK=0
+    note "could not fetch ${BASE_REF} and/or ${DOCS_BRANCH} from origin (base rc=${FETCH_BASE_RC}, docs rc=${FETCH_DOCS_RC}); treating this as a transport failure."
+  fi
+fi
+
+if [ "$FETCH_OK" -eq 0 ]; then
+  # Existence was already confirmed by step 1, so this is a transport failure,
+  # not a no-branch state. Same "unknown, not zero" treatment as above.
+  AGE_SOURCE="unknown"
+  AGE_DAYS=""
+  ACC_FILES=""
+  ACC_LINES=""
+  if [ "$ROTATION_POLICY" = "none" ]; then
+    WOULD_ROTATE="false"
+    REASON="rotation is disabled (dossier.ci.rollingBranchRotation=none); the base/docs refs could also not be fetched, so no metrics could be gathered"
+  else
+    WOULD_ROTATE="unknown"
+    REASON="could not fetch the base and/or documentation refs (transport failure); rotation status is unknown, not false"
+  fi
+  finish
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2a/2b/2c — age. Prefer the open pull request's createdAt; fall back to
+# walking the docs branch for the oldest Dossier-Generated commit.
+# ---------------------------------------------------------------------------
+if command -v gh >/dev/null 2>&1; then
+  PR_JSON=$(gh pr list --head "$DOCS_BRANCH" --state open --json number,createdAt --jq '.[0]' 2>/dev/null)
+  if [ -n "$PR_JSON" ] && [ "$PR_JSON" != "null" ]; then
+    CREATED_AT=$(printf '%s' "$PR_JSON" | jq -r '.createdAt // empty' 2>/dev/null)
+    if [ -n "$CREATED_AT" ]; then
+      EPOCH=$(date -u -d "$CREATED_AT" +%s 2>/dev/null || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$CREATED_AT" +%s 2>/dev/null || echo "")
+      if [ -n "$EPOCH" ]; then
+        AGE_SOURCE="pr_created_at"
+        AGE_DAYS=$(( (NOW_EPOCH - EPOCH) / 86400 ))
+      fi
+    fi
+  fi
+else
+  note "gh CLI unavailable; falling back to walking ${DOCS_BRANCH} for the oldest Dossier-Generated commit."
+fi
+
+if [ "$AGE_SOURCE" != "pr_created_at" ]; then
+  OLDEST_COMMIT=$(git rev-list --reverse "origin/${BASE_REF}..origin/${DOCS_BRANCH}" 2>/dev/null | while IFS= read -r C; do
+    if git show -s --format=%B "$C" | grep -qiE '^Dossier-Generated:[[:space:]]*true[[:space:]]*$'; then
+      printf '%s\n' "$C"
+      break
+    fi
+  done)
+  OLDEST_COMMIT=$(printf '%s\n' "$OLDEST_COMMIT" | head -1)
+  if [ -n "$OLDEST_COMMIT" ]; then
+    COMMIT_EPOCH=$(git show -s --format=%ct "$OLDEST_COMMIT" 2>/dev/null)
+    if [ -n "$COMMIT_EPOCH" ]; then
+      AGE_SOURCE="branch_commits"
+      AGE_DAYS=$(( (NOW_EPOCH - COMMIT_EPOCH) / 86400 ))
+    fi
+  fi
+  if [ "$AGE_SOURCE" != "branch_commits" ]; then
+    AGE_SOURCE="unknown"
+    AGE_DAYS=""
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2d — diff size, always computed once both refs are fetched. Parsed by
+# keyword, not position: `git diff --shortstat` omits the insertions or
+# deletions clause entirely when that count is zero, so a positional split
+# would misread an insertions-only or deletions-only diff.
+# ---------------------------------------------------------------------------
+STAT=$(git diff --shortstat "origin/${BASE_REF}...origin/${DOCS_BRANCH}" 2>/dev/null)
+DIFF_RC=$?
+if [ "$DIFF_RC" -ne 0 ]; then
+  ACC_FILES=""
+  ACC_LINES=""
+  note "git diff --shortstat origin/${BASE_REF}...origin/${DOCS_BRANCH} failed; accumulated size could not be measured."
+else
+  FILES=$(printf '%s' "$STAT" | grep -oE '[0-9]+ files? changed' | grep -oE '[0-9]+')
+  INS=$(printf '%s'  "$STAT" | grep -oE '[0-9]+ insertions?\(\+\)' | grep -oE '[0-9]+')
+  DEL=$(printf '%s'  "$STAT" | grep -oE '[0-9]+ deletions?\(-\)' | grep -oE '[0-9]+')
+  # ${FILES:-0} defaults to 0 here ONLY because DIFF_RC==0 guarantees a
+  # genuine empty-diff case, not a failure being papered over.
+  ACC_FILES="${FILES:-0}"
+  ACC_LINES=$(( ${INS:-0} + ${DEL:-0} ))
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3 — would_rotate determination.
+# ---------------------------------------------------------------------------
+if [ "$ROTATION_POLICY" = "none" ]; then
+  WOULD_ROTATE="false"
+  REASON="rotation is disabled (dossier.ci.rollingBranchRotation=none); reporting metrics only"
+  finish
+fi
+
+case "$ROTATION_POLICY" in
+  weekly)  THRESHOLD_DAYS=7 ;;
+  monthly) THRESHOLD_DAYS=30 ;;
+  *)
+    note "dossier.ci.rollingBranchRotation is '${ROTATION_POLICY}', which is not one of none/weekly/monthly; treating it as if rotation were disabled."
+    WOULD_ROTATE="false"
+    REASON="rotation policy '${ROTATION_POLICY}' is not recognised (expected none, weekly, or monthly); reporting metrics only"
+    finish
+    ;;
+esac
+
+case "$AGE_DAYS" in ''|*[!0-9]*) AGE_KNOWN=0 ;; *) AGE_KNOWN=1 ;; esac
+case "$ACC_LINES" in ''|*[!0-9]*) SIZE_KNOWN=0 ;; *) SIZE_KNOWN=1 ;; esac
+
+if [ "$AGE_KNOWN" -eq 0 ] && [ "$SIZE_KNOWN" -eq 0 ]; then
+  WOULD_ROTATE="unknown"
+  REASON="rotation status could not be determined: age and accumulated size are both unavailable"
+  finish
+fi
+
+AGE_TRIGGERED=0
+[ "$AGE_KNOWN" -eq 1 ] && [ "$AGE_DAYS" -ge "$THRESHOLD_DAYS" ] && AGE_TRIGGERED=1
+SIZE_TRIGGERED=0
+[ "$SIZE_KNOWN" -eq 1 ] && [ "$ACC_LINES" -ge "$SIZE_THRESHOLD" ] && SIZE_TRIGGERED=1
+
+if [ "$AGE_TRIGGERED" -eq 1 ] || [ "$SIZE_TRIGGERED" -eq 1 ]; then
+  WOULD_ROTATE="true"
+  PARTS=""
+  if [ "$AGE_TRIGGERED" -eq 1 ]; then
+    PARTS="age is ${AGE_DAYS} days (>= ${THRESHOLD_DAYS}-day ${ROTATION_POLICY} threshold)"
+  fi
+  if [ "$SIZE_TRIGGERED" -eq 1 ]; then
+    if [ -n "$PARTS" ]; then
+      PARTS="${PARTS}; accumulated size is ${ACC_LINES} lines (>= ${SIZE_THRESHOLD}-line threshold)"
+    else
+      PARTS="accumulated size is ${ACC_LINES} lines (>= ${SIZE_THRESHOLD}-line threshold)"
+    fi
+  fi
+  REASON="would rotate: ${PARTS}"
+else
+  KNOWN_PARTS=""
+  if [ "$AGE_KNOWN" -eq 1 ]; then
+    KNOWN_PARTS="age is ${AGE_DAYS} days (< ${THRESHOLD_DAYS}-day ${ROTATION_POLICY} threshold)"
+  fi
+  if [ "$SIZE_KNOWN" -eq 1 ]; then
+    if [ -n "$KNOWN_PARTS" ]; then
+      KNOWN_PARTS="${KNOWN_PARTS}; accumulated size is ${ACC_LINES} lines (< ${SIZE_THRESHOLD}-line threshold)"
+    else
+      KNOWN_PARTS="accumulated size is ${ACC_LINES} lines (< ${SIZE_THRESHOLD}-line threshold)"
+    fi
+  fi
+  WOULD_ROTATE="false"
+  REASON="within threshold: ${KNOWN_PARTS}"
+fi
+finish

--- a/plugins/dossier/bin/dossier-rotation-check.sh
+++ b/plugins/dossier/bin/dossier-rotation-check.sh
@@ -108,7 +108,7 @@ die_infra() {
   if [ -n "$SUMMARY_FILE" ]; then
     {
       printf '### Dossier rotation check: infrastructure error\n\n'
-      printf '%s\n\n' "$1"
+      printf '%s\n\n' "$(sanitize_md "$1")"
       printf 'The rotation determination could not be computed. This is a hard failure\n'
       printf 'rather than an "unknown" telemetry read.\n'
     } >>"$SUMMARY_FILE"

--- a/plugins/dossier/bin/dossier-rotation-check.sh
+++ b/plugins/dossier/bin/dossier-rotation-check.sh
@@ -71,7 +71,18 @@ DOCS_BRANCH=""
 ROTATION_POLICY=""
 NOTES=""
 
-note() { NOTES="${NOTES}- $1
+# Markdown-table and bullet-list cells are plain text interpolated with no
+# escaping, so a config/event-derived value (DOCS_BRANCH, BASE_REF) carrying
+# a backtick, pipe, or newline can break a table cell or inject a spoofed
+# extra row into the rendered job summary an operator reads to decide
+# whether rotation is warranted. Applied at every point a value reaches
+# $SUMMARY_FILE — note()'s bullet text and write_summary()'s table cells —
+# never to the working values themselves, which git commands need exact.
+sanitize_md() {
+  printf '%s' "$1" | LC_ALL=C tr -d '\000-\037' | tr -d '|`' | tr '\n' ' '
+}
+
+note() { NOTES="${NOTES}- $(sanitize_md "$1")
 "; }
 
 # $GITHUB_OUTPUT is parsed line by line as key=value, so a value carrying a
@@ -117,14 +128,14 @@ write_summary() {
     printf '### Dossier rolling-branch rotation check\n\n'
     printf 'Telemetry only — this step never rotates, closes, or deletes anything.\n\n'
     printf '| Field | Value |\n|---|---|\n'
-    printf '| Would rotate | `%s` |\n' "$WOULD_ROTATE"
-    printf '| Reason | `%s` |\n' "$REASON"
-    printf '| Age (days) | `%s` |\n' "${AGE_DAYS:-unknown}"
-    printf '| Age source | `%s` |\n' "$AGE_SOURCE"
-    printf '| Accumulated files | `%s` |\n' "${ACC_FILES:-unknown}"
-    printf '| Accumulated lines | `%s` |\n' "${ACC_LINES:-unknown}"
-    printf '| Docs branch | `%s` |\n' "$DOCS_BRANCH"
-    printf '| Rotation policy | `%s` |\n' "$ROTATION_POLICY"
+    printf '| Would rotate | `%s` |\n' "$(sanitize_md "$WOULD_ROTATE")"
+    printf '| Reason | `%s` |\n' "$(sanitize_md "$REASON")"
+    printf '| Age (days) | `%s` |\n' "$(sanitize_md "${AGE_DAYS:-unknown}")"
+    printf '| Age source | `%s` |\n' "$(sanitize_md "$AGE_SOURCE")"
+    printf '| Accumulated files | `%s` |\n' "$(sanitize_md "${ACC_FILES:-unknown}")"
+    printf '| Accumulated lines | `%s` |\n' "$(sanitize_md "${ACC_LINES:-unknown}")"
+    printf '| Docs branch | `%s` |\n' "$(sanitize_md "$DOCS_BRANCH")"
+    printf '| Rotation policy | `%s` |\n' "$(sanitize_md "$ROTATION_POLICY")"
     printf '\n'
     if [ -n "$NOTES" ]; then
       printf 'Notes:\n\n%s\n' "$NOTES"
@@ -151,7 +162,28 @@ finish() {
 # ---------------------------------------------------------------------------
 
 DOCS_BRANCH=$(cfg '.dossier.ci.rollingBranch' 'docs/dossier')
+# An explicitly-empty override (DOSSIER_CI_ROLLING_BRANCH="" or
+# "rollingBranch": "" in any settings file) beats every cascade layer by
+# design (dossier-resolve-config.sh/cascade-resolve.sh both treat set-but-
+# empty as a deliberate value, not "fall through to default"). Left
+# unguarded, an empty DOCS_BRANCH reaches `git ls-remote --exit-code --heads
+# origin ""`, which returns exit code 2 -- the SAME code this script uses to
+# mean "the branch genuinely doesn't exist" -- producing a confidently wrong
+# no-branch result even when the real docs branch exists and would
+# otherwise warrant rotation. Verified live: exit code 2 either way.
+case "$DOCS_BRANCH" in
+  '')
+    DOCS_BRANCH='docs/dossier'
+    note "dossier.ci.rollingBranch resolved to an empty value; falling back to the documented default (docs/dossier)."
+    ;;
+esac
 ROTATION_POLICY=$(cfg '.dossier.ci.rollingBranchRotation' 'none')
+case "$ROTATION_POLICY" in
+  '')
+    ROTATION_POLICY='none'
+    note "dossier.ci.rollingBranchRotation resolved to an empty value; falling back to the documented default (none)."
+    ;;
+esac
 SIZE_THRESHOLD=$(cfg '.dossier.ci.thresholds.rotationMaxAccumulatedLines' '5000')
 case "$SIZE_THRESHOLD" in ''|*[!0-9]*) SIZE_THRESHOLD=5000 ;; esac
 
@@ -241,6 +273,14 @@ fi
 # ---------------------------------------------------------------------------
 if command -v gh >/dev/null 2>&1; then
   PR_JSON=$(gh pr list --head "$DOCS_BRANCH" --state open --json number,createdAt --jq '.[0]' 2>/dev/null)
+  PR_LIST_RC=$?
+  if [ "$PR_LIST_RC" -ne 0 ]; then
+    # Distinct from "gh ran fine, no open PR found" (PR_JSON empty/null with
+    # PR_LIST_RC=0) -- a nonzero exit means the lookup itself failed (auth,
+    # rate limit, transient API error), which the summary should be able to
+    # tell apart from a genuine "no PR open" outcome.
+    note "gh pr list failed (exit ${PR_LIST_RC}); could not check for an open pull request on ${DOCS_BRANCH}."
+  fi
   if [ -n "$PR_JSON" ] && [ "$PR_JSON" != "null" ]; then
     CREATED_AT=$(printf '%s' "$PR_JSON" | jq -r '.createdAt // empty' 2>/dev/null)
     if [ -n "$CREATED_AT" ]; then

--- a/plugins/dossier/bin/dossier-rotation-check.sh
+++ b/plugins/dossier/bin/dossier-rotation-check.sh
@@ -53,7 +53,7 @@ while [ $# -gt 0 ]; do
       [ $# -lt 2 ] && { echo "dossier-rotation-check: --summary requires a value" >&2; exit 2; }
       SUMMARY_FILE="$2"; shift 2 ;;
     -h|--help)
-      sed -n '2,26p' "$0"; exit 0 ;;
+      sed -n '2,24p' "$0"; exit 0 ;;
     *)
       echo "dossier-rotation-check: unknown argument: $1" >&2; exit 2 ;;
   esac

--- a/plugins/dossier/schema.json
+++ b/plugins/dossier/schema.json
@@ -558,6 +558,12 @@
                   ],
                   "default": "draft",
                   "description": "What to do when the generated diff exceeds the doc thresholds. 'draft' opens the PR as a draft and labels it, because an oversized diff is usually the correct output of a cold start or a major refactor and discarding it destroys real work."
+                },
+                "rotationMaxAccumulatedLines": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "default": 5000,
+                  "description": "Accumulated insertions+deletions on the rolling documentation branch above which dossier-rotation-check.sh reports would_rotate=true (telemetry only — no automated action is taken). Read by dossier-rotation-check.sh, not by the refresh/publish path."
                 }
               }
             },

--- a/plugins/dossier/settings.json
+++ b/plugins/dossier/settings.json
@@ -121,7 +121,8 @@
         "maxSourceDiffBytes": 524288,
         "maxDocChangedFiles": 30,
         "maxDocChangedLines": 3000,
-        "oversizedBehavior": "draft"
+        "oversizedBehavior": "draft",
+        "rotationMaxAccumulatedLines": 5000
       },
       "circuitBreaker": {
         "maxDocPrsPer24h": 6

--- a/plugins/dossier/templates/ci/dossier-docs-refresh.yml
+++ b/plugins/dossier/templates/ci/dossier-docs-refresh.yml
@@ -209,6 +209,16 @@ jobs:
             --github-output "$GITHUB_OUTPUT" \
             --summary "$GITHUB_STEP_SUMMARY"
 
+      - name: Check whether the documentation branch would rotate
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          chmod +x "$DOSSIER_BIN"/*.sh
+          "$DOSSIER_BIN/dossier-rotation-check.sh" \
+            --summary "$GITHUB_STEP_SUMMARY"
+
       - name: Build the evidence bundle
         if: steps.decide.outputs.should_run == 'true'
         env:

--- a/plugins/dossier/templates/ci/dossier-docs-refresh.yml
+++ b/plugins/dossier/templates/ci/dossier-docs-refresh.yml
@@ -209,7 +209,15 @@ jobs:
             --github-output "$GITHUB_OUTPUT" \
             --summary "$GITHUB_STEP_SUMMARY"
 
+      # continue-on-error: true, matching "Download the scan bundle"'s precedent
+      # below — this is purely observational telemetry (issue #138), and a
+      # failure in it must never cascade into skipping "Build the evidence
+      # bundle" (gated on should_run == 'true', which GitHub Actions
+      # implicitly ANDs with success()). No visibility is lost: die_infra()'s
+      # ::error annotation and $GITHUB_STEP_SUMMARY write both happen before
+      # the script's own exit.
       - name: Check whether the documentation branch would rotate
+        continue-on-error: true
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
           GH_TOKEN: ${{ github.token }}

--- a/plugins/dossier/templates/config.example.json
+++ b/plugins/dossier/templates/config.example.json
@@ -123,7 +123,8 @@
         "maxSourceDiffBytes": 524288,
         "maxDocChangedFiles": 30,
         "maxDocChangedLines": 3000,
-        "oversizedBehavior": "draft"
+        "oversizedBehavior": "draft",
+        "rotationMaxAccumulatedLines": 5000
       },
       "circuitBreaker": { "maxDocPrsPer24h": 6 },
       "agent": { "model": "", "maxTurns": 60 },

--- a/plugins/dossier/tests/bin-scripts.test.sh
+++ b/plugins/dossier/tests/bin-scripts.test.sh
@@ -24,6 +24,7 @@ dossier-policy.sh
 dossier-pr-body.sh
 dossier-prose-lint.sh
 dossier-resolve-config.sh
+dossier-rotation-check.sh
 dossier-scaffold.sh
 dossier-scan-quality.sh
 dossier-scan-security.sh

--- a/plugins/dossier/tests/rotation-check.test.sh
+++ b/plugins/dossier/tests/rotation-check.test.sh
@@ -333,6 +333,7 @@ NOTGIT=$(_dossier_safe_mktemp_dir "rotation-notgit")
 OUT_NOTGIT=$(cd "$NOTGIT" && env CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" "$SCRIPT" 2>&1)
 RC_NOTGIT=$?
 assert_equal "1" "$RC_NOTGIT" "run outside a git repository exits 1 (infrastructure failure)"
+assert_contains "not inside a git repository" "$OUT_NOTGIT" "run outside a git repository: die_infra names the actual reason"
 
 # =============================================================================
 # 11. Structural workflow assertions live in workflow-template.test.sh, not

--- a/plugins/dossier/tests/rotation-check.test.sh
+++ b/plugins/dossier/tests/rotation-check.test.sh
@@ -340,4 +340,65 @@ assert_contains "not inside a git repository" "$OUT_NOTGIT" "run outside a git r
 #     here — this file only exercises dossier-rotation-check.sh's own CLI.
 # =============================================================================
 
+# =============================================================================
+# 12. An explicitly-empty config override for the branch name or rotation
+#     policy must never collide with the real "no-branch"/"disabled" signal.
+#     DOSSIER_CI_ROLLING_BRANCH="" beats every cascade layer by design
+#     (dossier-resolve-config.sh treats set-but-empty as deliberate, not
+#     "fall through to default"), and an empty branch name reaches
+#     `git ls-remote --exit-code --heads origin ""`, which returns exit code
+#     2 -- the SAME code that means "branch genuinely doesn't exist". A real
+#     docs/dossier branch exists in this fixture and would otherwise warrant
+#     rotation (via size); an unguarded empty override must not silently
+#     make it invisible. Regression test for a review finding (ERR-1).
+# =============================================================================
+F12=$(setup_fixture)
+(
+  cd "$F12" || exit 1
+  git checkout -q -B docs/dossier origin/main
+  i=1
+  while [ "$i" -le 200 ]; do
+    printf 'line %s\n' "$i" >> docs.md
+    i=$((i + 1))
+  done
+  git add -A
+  git config user.email test@example.com
+  git config user.name "Test"
+  GIT_AUTHOR_DATE="$(day_offset 1)T00:00:00Z" GIT_COMMITTER_DATE="$(day_offset 1)T00:00:00Z" \
+    git commit -q -m "chore(dossier): generated" -m "Dossier-Generated: true"
+  git push -q origin docs/dossier
+  git checkout -q main
+) >/dev/null 2>&1
+NOGH_PATH12=$(no_gh_path)
+OUT12=$(cd "$F12" && env PATH="$NOGH_PATH12" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH="" DOSSIER_CI_ROLLING_BRANCH_ROTATION=monthly DOSSIER_CI_THRESHOLDS_ROTATION_MAX_ACCUMULATED_LINES=100 "$SCRIPT" 2>&1)
+RC12=$?
+assert_equal "0" "$RC12" "empty DOSSIER_CI_ROLLING_BRANCH: exits 0"
+assert_equal "docs/dossier" "$(get "$OUT12" docs_branch)" "empty DOSSIER_CI_ROLLING_BRANCH: falls back to the documented default, not an empty ref"
+assert_equal "true" "$(get "$OUT12" would_rotate)" "empty DOSSIER_CI_ROLLING_BRANCH: still measures the real docs/dossier branch (200 lines > 100-line threshold), not a false no-branch result"
+
+OUT12B=$(cd "$F12" && env PATH="$NOGH_PATH12" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH_ROTATION="" "$SCRIPT" 2>&1)
+RC12B=$?
+assert_equal "0" "$RC12B" "empty DOSSIER_CI_ROLLING_BRANCH_ROTATION: exits 0"
+assert_equal "none" "$(get "$OUT12B" rotation_policy)" "empty DOSSIER_CI_ROLLING_BRANCH_ROTATION: falls back to the documented default (none)"
+assert_equal "false" "$(get "$OUT12B" would_rotate)" "empty DOSSIER_CI_ROLLING_BRANCH_ROTATION: treated as disabled, not the unrecognized-policy branch"
+
+# =============================================================================
+# 13. A branch name containing a backtick or pipe must not break the job
+#     summary's markdown table or inject a spoofed extra row. Regression
+#     test for a review finding (SEC-1).
+# =============================================================================
+F13=$(setup_fixture)
+WEIRD_BRANCH='docs/dossier`|evil'
+SUMMARY13=$(_dossier_safe_mktemp_dir "rotation-summary13")/summary.md
+OUT13=$(cd "$F13" && env CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH="$WEIRD_BRANCH" "$SCRIPT" --summary "$SUMMARY13" 2>&1)
+RC13=$?
+assert_equal "0" "$RC13" "branch name with backtick/pipe: still exits 0"
+if [ -f "$SUMMARY13" ] && grep -qE '^\| Docs branch \| `docs/dossierevil` \|$' "$SUMMARY13" 2>/dev/null; then
+  _dossier_assert_pass "branch name with backtick/pipe: summary table cell is sanitized, not broken"
+else
+  _dossier_assert_fail "branch name with backtick/pipe: summary table cell was not sanitized as expected"
+fi
+TABLE_ROW_COUNT13=$(grep -c '^| ' "$SUMMARY13" 2>/dev/null || echo 0)
+assert_equal "9" "$TABLE_ROW_COUNT13" "branch name with backtick/pipe: exactly the 9 real table rows (header + 8 fields), no injected extra row"
+
 _dossier_test_summary

--- a/plugins/dossier/tests/rotation-check.test.sh
+++ b/plugins/dossier/tests/rotation-check.test.sh
@@ -20,16 +20,37 @@ get() { printf '%s\n' "$1" | awk -F= -v k="$2" '$1==k{sub(/^[^=]*=/,""); print; 
 day_offset() { date -u -d "-$1 days" +%Y-%m-%d 2>/dev/null || date -u -v-"$1"d +%Y-%m-%d 2>/dev/null; }
 future_offset() { date -u -d "+$1 days" +%Y-%m-%d 2>/dev/null || date -u -v+"$1"d +%Y-%m-%d 2>/dev/null; }
 
-# Removes any PATH entry that hosts a `gh` executable, keeping every other
-# tool resolvable. `command -v gh` must genuinely fail for the "no gh" cases —
-# the script branches on that check, not on gh's exit code.
+# Removes `gh` specifically, keeping every other tool on the same PATH
+# component resolvable. `command -v gh` must genuinely fail for the "no gh"
+# cases -- the script branches on that check, not on gh's exit code.
+#
+# Dropping the WHOLE directory that hosts `gh` (the original approach) works
+# on macOS, where Homebrew's `gh` lives in its own directory separate from
+# core utilities, but silently breaks everything on typical Linux CI images:
+# `/bin` is a symlink to `/usr/bin`, and apt-installed `gh` lives right next
+# to `git`/`date`/`jq`/`mktemp` in that same directory, so dropping it took
+# the whole userland with it (every scenario using this helper failed with
+# exit 127, "command not found", in CI while passing locally on macOS).
+# Filtering at the file level via a symlinked stand-in directory keeps the
+# helper's stated intent ("keeping every other tool resolvable") true on
+# both platforms.
 no_gh_path() {
   OLD_IFS="$IFS"; IFS=':'
   _out=""
   for _dir in $PATH; do
     [ -n "$_dir" ] || continue
-    [ -x "$_dir/gh" ] && continue
-    _out="${_out:+$_out:}$_dir"
+    if [ -x "$_dir/gh" ]; then
+      _filtered=$(_dossier_safe_mktemp_dir "no-gh-filtered")
+      for _entry in "$_dir"/*; do
+        [ -e "$_entry" ] || continue
+        _base=$(basename "$_entry")
+        [ "$_base" = "gh" ] && continue
+        ln -s "$_entry" "$_filtered/$_base" 2>/dev/null
+      done
+      _out="${_out:+$_out:}$_filtered"
+    else
+      _out="${_out:+$_out:}$_dir"
+    fi
   done
   IFS="$OLD_IFS"
   printf '%s' "$_out"

--- a/plugins/dossier/tests/rotation-check.test.sh
+++ b/plugins/dossier/tests/rotation-check.test.sh
@@ -209,6 +209,43 @@ assert_equal "true" "$(get "$OUT6" would_rotate)" "would-rotate via size alone: 
 assert_contains "accumulated" "$(get "$OUT6" reason)" "would-rotate via size alone: reason names the size condition"
 
 # =============================================================================
+# 6b. Exactly one dimension unknown (age) with the OTHER known dimension
+#     (size) under its threshold must still report would_rotate=unknown, not
+#     a confident "false" -- the unmeasured age dimension could have been
+#     over threshold. Same fixture shape as test 6 (no Dossier-Generated
+#     commit -> age_source=unknown), but the diff is kept small so size alone
+#     does not trigger. Regression test for the P1 finding on rotation-check
+#     issue #138 review (dossier-rotation-check.sh:324).
+# =============================================================================
+F6B=$(setup_fixture)
+(
+  cd "$F6B" || exit 1
+  git checkout -q -B docs/dossier origin/main
+  printf 'line one\nline two\nline three\n' >> docs.md
+  git add -A
+  git config user.email test@example.com
+  git config user.name "Test"
+  git commit -q -m "not a dossier commit"
+  git push -q origin docs/dossier
+  git checkout -q main
+) >/dev/null 2>&1
+NOGH_PATH6B=$(no_gh_path)
+OUT6B=$(cd "$F6B" && env PATH="$NOGH_PATH6B" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=weekly DOSSIER_CI_THRESHOLDS_ROTATION_MAX_ACCUMULATED_LINES=5000 "$SCRIPT" 2>&1)
+RC6B=$?
+assert_equal "0" "$RC6B" "age unknown + size under threshold: exits 0"
+assert_equal "unknown" "$(get "$OUT6B" age_source)" "age unknown + size under threshold: age_source=unknown (no Dossier-Generated commit found)"
+ACC_LINES6B=$(get "$OUT6B" accumulated_lines)
+if [ -n "$ACC_LINES6B" ] && [ "$ACC_LINES6B" -eq 3 ] 2>/dev/null; then
+  _dossier_assert_pass "age unknown + size under threshold: accumulated_lines is a real measured number (3), not blanked by the unknown branch"
+else
+  _dossier_assert_fail "age unknown + size under threshold: accumulated_lines was '$ACC_LINES6B', expected 3 -- metrics must still flow even when would_rotate=unknown (AC4)"
+fi
+assert_equal "unknown" "$(get "$OUT6B" would_rotate)" "age unknown + size under threshold: would_rotate=unknown, NOT false -- the unmeasured age dimension could still be over threshold"
+REASON6B=$(get "$OUT6B" reason)
+assert_not_contains "within threshold" "$REASON6B" "age unknown + size under threshold: reason avoids the confident 'within threshold' phrasing"
+assert_contains "age is unavailable" "$REASON6B" "age unknown + size under threshold: reason names age as the unavailable dimension"
+
+# =============================================================================
 # 7. Both unknown -> the literal string "unknown", never coerced to false
 # =============================================================================
 F7=$(setup_fixture)

--- a/plugins/dossier/tests/rotation-check.test.sh
+++ b/plugins/dossier/tests/rotation-check.test.sh
@@ -122,6 +122,13 @@ if [ -n "$ACC_LINES2" ] && [ "$ACC_LINES2" -gt 0 ] 2>/dev/null; then
 else
   _dossier_assert_fail "policy=none: accumulated_lines was empty or zero ($ACC_LINES2) — AC4 requires metrics regardless of policy"
 fi
+AGE_DAYS2=$(get "$OUT2" age_days)
+if [ -n "$AGE_DAYS2" ] && [ "$AGE_DAYS2" -ge 0 ] 2>/dev/null; then
+  _dossier_assert_pass "policy=none: age_days is still a real non-empty number (AC4 names all three fields, not just the size ones)"
+else
+  _dossier_assert_fail "policy=none: age_days was empty ($AGE_DAYS2) — AC4 requires age_days computed too, not just accumulated_files/accumulated_lines"
+fi
+assert_equal "branch_commits" "$(get "$OUT2" age_source)" "policy=none: age_source is still populated (branch_commits), not left as the default unknown"
 
 # =============================================================================
 # 3. Would-rotate via age (gh stub returns an old open PR)

--- a/plugins/dossier/tests/rotation-check.test.sh
+++ b/plugins/dossier/tests/rotation-check.test.sh
@@ -18,6 +18,7 @@ fi
 get() { printf '%s\n' "$1" | awk -F= -v k="$2" '$1==k{sub(/^[^=]*=/,""); print; exit}'; }
 
 day_offset() { date -u -d "-$1 days" +%Y-%m-%d 2>/dev/null || date -u -v-"$1"d +%Y-%m-%d 2>/dev/null; }
+future_offset() { date -u -d "+$1 days" +%Y-%m-%d 2>/dev/null || date -u -v+"$1"d +%Y-%m-%d 2>/dev/null; }
 
 # Removes any PATH entry that hosts a `gh` executable, keeping every other
 # tool resolvable. `command -v gh` must genuinely fail for the "no gh" cases —
@@ -393,6 +394,7 @@ SUMMARY13=$(_dossier_safe_mktemp_dir "rotation-summary13")/summary.md
 OUT13=$(cd "$F13" && env CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH="$WEIRD_BRANCH" "$SCRIPT" --summary "$SUMMARY13" 2>&1)
 RC13=$?
 assert_equal "0" "$RC13" "branch name with backtick/pipe: still exits 0"
+assert_equal "$WEIRD_BRANCH" "$(get "$OUT13" docs_branch)" "branch name with backtick/pipe: raw key=value stdout is untouched by sanitize_md (sanitization is a display-boundary concern, not a working-value mutation)"
 if [ -f "$SUMMARY13" ] && grep -qE '^\| Docs branch \| `docs/dossierevil` \|$' "$SUMMARY13" 2>/dev/null; then
   _dossier_assert_pass "branch name with backtick/pipe: summary table cell is sanitized, not broken"
 else
@@ -400,5 +402,99 @@ else
 fi
 TABLE_ROW_COUNT13=$(grep -c '^| ' "$SUMMARY13" 2>/dev/null || echo 0)
 assert_equal "9" "$TABLE_ROW_COUNT13" "branch name with backtick/pipe: exactly the 9 real table rows (header + 8 fields), no injected extra row"
+
+# =============================================================================
+# 14. `gh pr list` failing (auth/rate-limit) must be distinguished from "no
+#     PR found" and must not abort the run — regression test for a review
+#     finding (ERR-3): previously claimed fixed but never covered by a test.
+# =============================================================================
+F14=$(setup_fixture)
+push_docs_branch_commit "$F14" "docs/dossier" "$(day_offset 10)"
+STUB14=$(_dossier_safe_mktemp_dir "gh-stub-list-fails")
+cat > "$STUB14/gh" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$STUB14/gh"
+SUMMARY14=$(_dossier_safe_mktemp_dir "rotation-summary14")/summary.md
+OUT14=$(cd "$F14" && env PATH="$STUB14:$PATH" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=weekly "$SCRIPT" --summary "$SUMMARY14" 2>&1)
+RC14=$?
+assert_equal "0" "$RC14" "gh pr list failure: still exits 0 (falls back to the commit-based age walk, not an infra failure)"
+assert_equal "branch_commits" "$(get "$OUT14" age_source)" "gh pr list failure: age_source falls back to branch_commits, not silently treated as no-PR"
+assert_equal "true" "$(get "$OUT14" would_rotate)" "gh pr list failure: the fallback age (10 days) still correctly triggers rotation under the weekly threshold"
+if [ -f "$SUMMARY14" ] && grep -q "gh pr list failed" "$SUMMARY14" 2>/dev/null; then
+  _dossier_assert_pass "gh pr list failure: the summary distinguishes a lookup failure from a genuine no-PR-found result"
+else
+  _dossier_assert_fail "gh pr list failure: no note recorded distinguishing lookup failure from no-PR-found"
+fi
+
+# =============================================================================
+# 15. rotationMaxAccumulatedLines=0 must not make the size signal trigger
+#     unconditionally (0 <= any non-negative line count is always true) --
+#     regression test for a review finding (F1/CONV1), reproduced live.
+# =============================================================================
+F15=$(setup_fixture)
+push_docs_branch_commit "$F15" "docs/dossier" "$(day_offset 1)"
+NOGH_PATH15=$(no_gh_path)
+OUT15=$(cd "$F15" && env PATH="$NOGH_PATH15" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=weekly DOSSIER_CI_THRESHOLDS_ROTATION_MAX_ACCUMULATED_LINES=0 "$SCRIPT" 2>&1)
+RC15=$?
+assert_equal "0" "$RC15" "zero size threshold: exits 0"
+assert_equal "false" "$(get "$OUT15" would_rotate)" "zero size threshold: falls back to the documented default (5000) instead of triggering on every non-empty diff"
+
+# =============================================================================
+# 16. A future-dated PR createdAt (clock skew) must not surface a negative
+#     age_days alongside a reason claiming age is unavailable -- regression
+#     test for a review finding (AgeDaysNegative/ERR-3/ERR-4).
+# =============================================================================
+F16=$(setup_fixture)
+push_docs_branch_commit "$F16" "docs/dossier" "$(day_offset 1)"
+STUB16=$(_dossier_safe_mktemp_dir "gh-stub-future-pr")
+cat > "$STUB16/gh" <<EOF
+#!/usr/bin/env bash
+echo '{"number":99,"createdAt":"$(future_offset 3)T00:00:00Z"}'
+exit 0
+EOF
+chmod +x "$STUB16/gh"
+OUT16=$(cd "$F16" && env PATH="$STUB16:$PATH" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=weekly "$SCRIPT" 2>&1)
+RC16=$?
+assert_equal "0" "$RC16" "future-dated PR createdAt (clock skew): still exits 0"
+assert_equal "" "$(get "$OUT16" age_days)" "future-dated PR createdAt: age_days is blanked, not a negative number, once age is known-unreliable"
+assert_equal "unknown" "$(get "$OUT16" would_rotate)" "future-dated PR createdAt: would_rotate=unknown, not a false coerced from a negative age"
+assert_contains "unavailable" "$(get "$OUT16" reason)" "future-dated PR createdAt: reason states age is unavailable, consistent with the blanked age_days"
+
+# =============================================================================
+# 17. `gh pr list --head` matches by branch name only, across every fork with
+#     an open PR against this repo. A cross-repository decoy PR (same branch
+#     name, recent, opened from a fork) must never be preferred over the real
+#     same-repo PR -- regression test for a review finding (SEC-1), reproduced
+#     via a stub that actually applies gh's --jq filter (real `gh` behavior),
+#     not just a fixed echo like the other gh stubs in this file.
+# =============================================================================
+F17=$(setup_fixture)
+push_docs_branch_commit "$F17" "docs/dossier" "$(day_offset 10)"
+STUB17=$(_dossier_safe_mktemp_dir "gh-stub-cross-repo")
+STUB17_JSON="[{\"number\":13,\"createdAt\":\"$(day_offset 1)T00:00:00Z\",\"isCrossRepository\":true},{\"number\":7,\"createdAt\":\"$(day_offset 10)T00:00:00Z\",\"isCrossRepository\":false}]"
+cat > "$STUB17/gh" <<STUBEOF
+#!/usr/bin/env bash
+FILTER=""
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    --jq) FILTER="\$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+JSON='$STUB17_JSON'
+if [ -n "\$FILTER" ]; then
+  printf '%s' "\$JSON" | jq "\$FILTER"
+else
+  printf '%s' "\$JSON"
+fi
+STUBEOF
+chmod +x "$STUB17/gh"
+OUT17=$(cd "$F17" && env PATH="$STUB17:$PATH" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=weekly "$SCRIPT" 2>&1)
+RC17=$?
+assert_equal "0" "$RC17" "cross-repository decoy PR: exits 0"
+assert_equal "true" "$(get "$OUT17" would_rotate)" "cross-repository decoy PR: the real same-repo PR (10 days old) drives the age determination, not the more-recent fork decoy that would mask rotation"
+assert_equal "pr_created_at" "$(get "$OUT17" age_source)" "cross-repository decoy PR: age_source is still pr_created_at (the real PR was found, not silently skipped)"
 
 _dossier_test_summary

--- a/plugins/dossier/tests/rotation-check.test.sh
+++ b/plugins/dossier/tests/rotation-check.test.sh
@@ -497,4 +497,34 @@ assert_equal "0" "$RC17" "cross-repository decoy PR: exits 0"
 assert_equal "true" "$(get "$OUT17" would_rotate)" "cross-repository decoy PR: the real same-repo PR (10 days old) drives the age determination, not the more-recent fork decoy that would mask rotation"
 assert_equal "pr_created_at" "$(get "$OUT17" age_source)" "cross-repository decoy PR: age_source is still pr_created_at (the real PR was found, not silently skipped)"
 
+# =============================================================================
+# 18. A genuine config-resolver infrastructure failure (not an empty/default
+#     value) must be reported as a hard failure, never silently treated as a
+#     deliberate empty override -- regression test for a review finding
+#     (ERR1/skeptic), reproduced live on this session's machine via a stub
+#     `mktemp` that fails only for cascade-resolve.sh's own error-capture
+#     temp file (its real Ubuntu-runner trigger, an unwritable $TMPDIR, is
+#     silently tolerated by BSD/macOS mktemp, so it can't be reproduced
+#     directly on a macOS dev machine -- this reproduces the same downstream
+#     failure, $CASCADE exiting 2, by the most portable available means).
+# =============================================================================
+F18=$(setup_fixture)
+REAL_MKTEMP=$(command -v mktemp)
+STUB18=$(_dossier_safe_mktemp_dir "mktemp-stub-cascade-fail")
+cat > "$STUB18/mktemp" <<STUBEOF
+#!/usr/bin/env bash
+for a in "\$@"; do
+  case "\$a" in
+    *cascade-resolve.err*) echo "mktemp: stub failure (simulated infra failure)" >&2; exit 1 ;;
+  esac
+done
+exec "$REAL_MKTEMP" "\$@"
+STUBEOF
+chmod +x "$STUB18/mktemp"
+OUT18=$(cd "$F18" && env PATH="$STUB18:$PATH" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier "$SCRIPT" 2>&1)
+RC18=$?
+assert_equal "1" "$RC18" "config resolver infra failure: exits 1 (a hard infrastructure failure), not 0 (a reached decision)"
+assert_contains "could not resolve" "$OUT18" "config resolver infra failure: die_infra names the actual cause, not a generic empty-override note"
+assert_not_contains "would_rotate=false" "$OUT18" "config resolver infra failure: never emits a confident would_rotate result"
+
 _dossier_test_summary

--- a/plugins/dossier/tests/rotation-check.test.sh
+++ b/plugins/dossier/tests/rotation-check.test.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+# dossier-rotation-check.sh: telemetry-only rolling-branch rotation
+# determination (issue #138). Purely observational — never closes a pull
+# request, deletes a branch, or creates a replacement branch. See
+# .decisions/issue-138.md's Specification section for the full contract.
+
+_dossier_test_begin "rotation-check"
+
+SCRIPT="$(pwd)/plugins/dossier/bin/dossier-rotation-check.sh"
+PLUGIN_ROOT="$(pwd)/plugins/dossier"
+
+if [ ! -x "$SCRIPT" ]; then
+  _dossier_assert_fail "$SCRIPT missing or not executable"
+  _dossier_test_summary
+  return 0 2>/dev/null || exit 0
+fi
+
+get() { printf '%s\n' "$1" | awk -F= -v k="$2" '$1==k{sub(/^[^=]*=/,""); print; exit}'; }
+
+day_offset() { date -u -d "-$1 days" +%Y-%m-%d 2>/dev/null || date -u -v-"$1"d +%Y-%m-%d 2>/dev/null; }
+
+# Removes any PATH entry that hosts a `gh` executable, keeping every other
+# tool resolvable. `command -v gh` must genuinely fail for the "no gh" cases —
+# the script branches on that check, not on gh's exit code.
+no_gh_path() {
+  OLD_IFS="$IFS"; IFS=':'
+  _out=""
+  for _dir in $PATH; do
+    [ -n "$_dir" ] || continue
+    [ -x "$_dir/gh" ] && continue
+    _out="${_out:+$_out:}$_dir"
+  done
+  IFS="$OLD_IFS"
+  printf '%s' "$_out"
+}
+
+# Builds a bare "origin" remote + a working clone, with dossier plugin bin
+# scripts reachable via CLAUDE_PLUGIN_ROOT. Real git remote (not a fixture
+# dir masquerading as one) because the script's own exit-code semantics
+# (git ls-remote --exit-code 0 vs 2 vs 128) require an actual remote to
+# exercise realistically.
+setup_fixture() {
+  _fixture=$(_dossier_safe_mktemp_dir "rotation-fixture")
+  _bare="$_fixture/origin.git"
+  _clone="$_fixture/clone"
+  git init -q --bare "$_bare"
+  git clone -q "$_bare" "$_clone" >/dev/null 2>&1
+  (
+    cd "$_clone" || exit 1
+    git config user.email test@example.com
+    git config user.name "Test"
+    echo "root" > README.md
+    git add -A
+    git commit -q -m "root commit"
+    git push -q origin HEAD:refs/heads/main
+    git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+  ) >/dev/null 2>&1
+  printf '%s' "$_clone"
+}
+
+# Adds $N commits to $DOCS_BRANCH (created from main if absent), each carrying
+# a Dossier-Generated: true trailer, backdated via GIT_AUTHOR_DATE/
+# GIT_COMMITTER_DATE, then pushes the branch to origin. $3 = file content
+# (defaults to a short line) so callers can control diff size.
+push_docs_branch_commit() {
+  _clone="$1"; _docs_branch="$2"; _date="$3"; _content="${4:-line}"
+  (
+    cd "$_clone" || exit 1
+    git fetch -q origin >/dev/null 2>&1
+    if git rev-parse --verify -q "refs/heads/$_docs_branch" >/dev/null 2>&1; then
+      git checkout -q "$_docs_branch"
+    elif git rev-parse --verify -q "refs/remotes/origin/$_docs_branch" >/dev/null 2>&1; then
+      git checkout -q -B "$_docs_branch" "origin/$_docs_branch"
+    else
+      git checkout -q -B "$_docs_branch" origin/main
+    fi
+    printf '%s\n' "$_content" >> docs.md
+    git add -A
+    GIT_AUTHOR_DATE="${_date}T00:00:00Z" GIT_COMMITTER_DATE="${_date}T00:00:00Z" \
+      git commit -q -m "chore(dossier): generated" -m "Dossier-Generated: true"
+    git push -q origin "$_docs_branch"
+    git checkout -q main
+  ) >/dev/null 2>&1
+}
+
+# =============================================================================
+# 1. No-branch cold start
+# =============================================================================
+F1=$(setup_fixture)
+SUMMARY1=$(_dossier_safe_mktemp_dir "rotation-summary1")/summary.md
+OUT1=$(cd "$F1" && env CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier "$SCRIPT" --summary "$SUMMARY1" 2>&1)
+RC1=$?
+assert_equal "0" "$RC1" "no-branch cold start: exits 0 (a reached decision, not an infra failure)"
+assert_equal "false" "$(get "$OUT1" would_rotate)" "no-branch cold start: would_rotate=false"
+assert_equal "no-branch" "$(get "$OUT1" age_source)" "no-branch cold start: age_source=no-branch"
+assert_equal "" "$(get "$OUT1" age_days)" "no-branch cold start: age_days is empty, not 0"
+assert_equal "" "$(get "$OUT1" accumulated_files)" "no-branch cold start: accumulated_files is empty, not 0"
+assert_equal "" "$(get "$OUT1" accumulated_lines)" "no-branch cold start: accumulated_lines is empty, not 0"
+assert_contains "does not exist yet" "$(get "$OUT1" reason)" "no-branch cold start: reason names the actual state"
+
+# =============================================================================
+# 2. Policy=none, branch exists with a real diff — metrics still emitted
+#    (this is the AC4 assertion: metrics flow regardless of policy)
+# =============================================================================
+F2=$(setup_fixture)
+push_docs_branch_commit "$F2" "docs/dossier" "$(day_offset 3)" "insert-only content line one"
+push_docs_branch_commit "$F2" "docs/dossier" "$(day_offset 1)" "insert-only content line two"
+OUT2=$(cd "$F2" && env CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=none "$SCRIPT" 2>&1)
+RC2=$?
+assert_equal "0" "$RC2" "policy=none: exits 0"
+assert_equal "false" "$(get "$OUT2" would_rotate)" "policy=none: would_rotate=false regardless of diff size"
+assert_contains "disabled" "$(get "$OUT2" reason)" "policy=none: reason names rotation as disabled"
+ACC_FILES2=$(get "$OUT2" accumulated_files)
+ACC_LINES2=$(get "$OUT2" accumulated_lines)
+if [ -n "$ACC_FILES2" ] && [ "$ACC_FILES2" -gt 0 ] 2>/dev/null; then
+  _dossier_assert_pass "policy=none: accumulated_files is still a real non-empty number (AC4)"
+else
+  _dossier_assert_fail "policy=none: accumulated_files was empty or zero ($ACC_FILES2) — AC4 requires metrics regardless of policy"
+fi
+if [ -n "$ACC_LINES2" ] && [ "$ACC_LINES2" -gt 0 ] 2>/dev/null; then
+  _dossier_assert_pass "policy=none: accumulated_lines is still a real non-empty number (AC4)"
+else
+  _dossier_assert_fail "policy=none: accumulated_lines was empty or zero ($ACC_LINES2) — AC4 requires metrics regardless of policy"
+fi
+
+# =============================================================================
+# 3. Would-rotate via age (gh stub returns an old open PR)
+# =============================================================================
+F3=$(setup_fixture)
+push_docs_branch_commit "$F3" "docs/dossier" "$(day_offset 10)"
+STUB3=$(_dossier_safe_mktemp_dir "gh-stub-old-pr")
+cat > "$STUB3/gh" <<EOF
+#!/usr/bin/env bash
+echo '{"number":42,"createdAt":"$(day_offset 10)T00:00:00Z"}'
+exit 0
+EOF
+chmod +x "$STUB3/gh"
+OUT3=$(cd "$F3" && env PATH="$STUB3:$PATH" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=weekly "$SCRIPT" 2>&1)
+RC3=$?
+assert_equal "0" "$RC3" "would-rotate via age: exits 0"
+assert_equal "true" "$(get "$OUT3" would_rotate)" "would-rotate via age: would_rotate=true (10 days > 7-day weekly threshold)"
+assert_equal "pr_created_at" "$(get "$OUT3" age_source)" "would-rotate via age: age_source=pr_created_at"
+assert_contains "age" "$(get "$OUT3" reason)" "would-rotate via age: reason cites age"
+
+# =============================================================================
+# 4. Would-not-rotate (gh stub, recent PR, small diff)
+# =============================================================================
+F4=$(setup_fixture)
+push_docs_branch_commit "$F4" "docs/dossier" "$(day_offset 1)"
+STUB4=$(_dossier_safe_mktemp_dir "gh-stub-recent-pr")
+cat > "$STUB4/gh" <<EOF
+#!/usr/bin/env bash
+echo '{"number":7,"createdAt":"$(day_offset 1)T00:00:00Z"}'
+exit 0
+EOF
+chmod +x "$STUB4/gh"
+OUT4=$(cd "$F4" && env PATH="$STUB4:$PATH" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=weekly "$SCRIPT" 2>&1)
+RC4=$?
+assert_equal "0" "$RC4" "would-not-rotate: exits 0"
+assert_equal "false" "$(get "$OUT4" would_rotate)" "would-not-rotate: would_rotate=false (1 day old, small diff, both under threshold)"
+assert_equal "pr_created_at" "$(get "$OUT4" age_source)" "would-not-rotate: age_source=pr_created_at"
+
+# =============================================================================
+# 5. Degraded gh-unavailable, would-rotate via commit age (monthly policy)
+# =============================================================================
+F5=$(setup_fixture)
+push_docs_branch_commit "$F5" "docs/dossier" "$(day_offset 40)"
+NOGH_PATH5=$(no_gh_path)
+SUMMARY5=$(_dossier_safe_mktemp_dir "rotation-summary5")/summary.md
+OUT5=$(cd "$F5" && env PATH="$NOGH_PATH5" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=monthly "$SCRIPT" --summary "$SUMMARY5" 2>&1)
+RC5=$?
+assert_equal "0" "$RC5" "degraded gh-unavailable via commit age: exits 0"
+assert_equal "branch_commits" "$(get "$OUT5" age_source)" "degraded gh-unavailable: age_source=branch_commits (fell back to commit trailer walk)"
+assert_equal "true" "$(get "$OUT5" would_rotate)" "degraded gh-unavailable: would_rotate=true (40 days > 30-day monthly threshold)"
+if [ -f "$SUMMARY5" ] && grep -qi "gh" "$SUMMARY5" 2>/dev/null; then
+  _dossier_assert_pass "degraded gh-unavailable: summary notes the gh degradation"
+else
+  _dossier_assert_fail "degraded gh-unavailable: summary did not mention the gh-unavailable degradation"
+fi
+
+# =============================================================================
+# 6. Would-rotate via size alone (no gh, no Dossier-Generated commits at all
+#    for age, but a large diff)
+# =============================================================================
+F6=$(setup_fixture)
+# Push a branch with a commit that is NOT Dossier-Generated, so age_source
+# ends up unknown, while still producing a large diff to trigger on size.
+(
+  cd "$F6" || exit 1
+  git checkout -q -B docs/dossier origin/main
+  i=1
+  while [ "$i" -le 200 ]; do
+    printf 'line %s of generated content\n' "$i" >> docs.md
+    i=$((i + 1))
+  done
+  git add -A
+  git config user.email test@example.com
+  git config user.name "Test"
+  git commit -q -m "not a dossier commit"
+  git push -q origin docs/dossier
+  git checkout -q main
+) >/dev/null 2>&1
+NOGH_PATH6=$(no_gh_path)
+OUT6=$(cd "$F6" && env PATH="$NOGH_PATH6" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=monthly DOSSIER_CI_THRESHOLDS_ROTATION_MAX_ACCUMULATED_LINES=100 "$SCRIPT" 2>&1)
+RC6=$?
+assert_equal "0" "$RC6" "would-rotate via size alone: exits 0"
+assert_equal "unknown" "$(get "$OUT6" age_source)" "would-rotate via size alone: age_source=unknown (no Dossier-Generated commit found)"
+assert_equal "true" "$(get "$OUT6" would_rotate)" "would-rotate via size alone: would_rotate=true (200 lines > 100-line threshold)"
+assert_contains "accumulated" "$(get "$OUT6" reason)" "would-rotate via size alone: reason names the size condition"
+
+# =============================================================================
+# 7. Both unknown -> the literal string "unknown", never coerced to false
+# =============================================================================
+F7=$(setup_fixture)
+push_docs_branch_commit "$F7" "docs/dossier" "$(day_offset 5)"
+(
+  cd "$F7" || exit 1
+  git remote set-url origin /nonexistent/path/that/does/not/exist.git
+) >/dev/null 2>&1
+NOGH_PATH7=$(no_gh_path)
+SUMMARY7=$(_dossier_safe_mktemp_dir "rotation-summary7")/summary.md
+OUT7=$(cd "$F7" && env PATH="$NOGH_PATH7" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=weekly "$SCRIPT" --summary "$SUMMARY7" 2>&1)
+RC7=$?
+assert_equal "0" "$RC7" "transport failure: still exits 0 (a data-availability failure, not an infra failure)"
+assert_equal "unknown" "$(get "$OUT7" would_rotate)" "transport failure: would_rotate is the literal string 'unknown', never coerced to false"
+assert_equal "unknown" "$(get "$OUT7" age_source)" "transport failure: age_source=unknown"
+if [ -f "$SUMMARY7" ] && grep -qiE "fetch|remote|transport|unreachable" "$SUMMARY7" 2>/dev/null; then
+  _dossier_assert_pass "transport failure: summary notes the transport/fetch failure"
+else
+  _dossier_assert_fail "transport failure: summary did not mention the transport failure"
+fi
+
+# =============================================================================
+# 8. Malformed threshold config falls back to the documented default (5000)
+# =============================================================================
+F8=$(setup_fixture)
+(
+  cd "$F8" || exit 1
+  git checkout -q -B docs/dossier origin/main
+  i=1
+  while [ "$i" -le 60 ]; do
+    printf 'line %s\n' "$i" >> docs.md
+    i=$((i + 1))
+  done
+  git add -A
+  GIT_AUTHOR_DATE="$(day_offset 35)T00:00:00Z" GIT_COMMITTER_DATE="$(day_offset 35)T00:00:00Z" \
+    git commit -q -m "chore(dossier): generated" -m "Dossier-Generated: true"
+  git push -q origin docs/dossier
+  git checkout -q main
+) >/dev/null 2>&1
+NOGH_PATH8=$(no_gh_path)
+OUT8=$(cd "$F8" && env PATH="$NOGH_PATH8" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=monthly DOSSIER_CI_THRESHOLDS_ROTATION_MAX_ACCUMULATED_LINES=not-a-number "$SCRIPT" 2>&1)
+RC8=$?
+assert_equal "0" "$RC8" "malformed threshold: exits 0"
+assert_equal "true" "$(get "$OUT8" would_rotate)" "malformed threshold: would_rotate=true via age (35 days > 30-day monthly threshold) -- proves the script did not crash on the bad threshold"
+
+# =============================================================================
+# 9. --shortstat parsing: insertions-only and deletions-only diffs
+# =============================================================================
+F9=$(setup_fixture)
+(
+  cd "$F9" || exit 1
+  git checkout -q -B docs/dossier origin/main
+  printf 'brand new content\nsecond line\n' > new-file.md
+  git add -A
+  git config user.email test@example.com
+  git config user.name "Test"
+  GIT_AUTHOR_DATE="$(day_offset 1)T00:00:00Z" GIT_COMMITTER_DATE="$(day_offset 1)T00:00:00Z" \
+    git commit -q -m "chore(dossier): generated" -m "Dossier-Generated: true"
+  git push -q origin docs/dossier
+  git checkout -q main
+) >/dev/null 2>&1
+NOGH_PATH9=$(no_gh_path)
+OUT9=$(cd "$F9" && env PATH="$NOGH_PATH9" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=none "$SCRIPT" 2>&1)
+ACC_LINES9=$(get "$OUT9" accumulated_lines)
+if [ -n "$ACC_LINES9" ] && [ "$ACC_LINES9" -eq 2 ] 2>/dev/null; then
+  _dossier_assert_pass "shortstat parsing: insertions-only diff (new file, no deletions clause) counted correctly (2 lines)"
+else
+  _dossier_assert_fail "shortstat parsing: insertions-only diff miscounted (got '$ACC_LINES9', expected 2)"
+fi
+
+# =============================================================================
+# 10. CLI / exit-code checks
+# =============================================================================
+"$SCRIPT" --nonexistent-flag >/dev/null 2>&1
+assert_equal "2" "$?" "unknown flag exits 2"
+
+NOTGIT=$(_dossier_safe_mktemp_dir "rotation-notgit")
+OUT_NOTGIT=$(cd "$NOTGIT" && env CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" "$SCRIPT" 2>&1)
+RC_NOTGIT=$?
+assert_equal "1" "$RC_NOTGIT" "run outside a git repository exits 1 (infrastructure failure)"
+
+# =============================================================================
+# 11. Structural workflow assertions live in workflow-template.test.sh, not
+#     here — this file only exercises dossier-rotation-check.sh's own CLI.
+# =============================================================================
+
+_dossier_test_summary

--- a/plugins/dossier/tests/rotation-check.test.sh
+++ b/plugins/dossier/tests/rotation-check.test.sh
@@ -527,4 +527,67 @@ assert_equal "1" "$RC18" "config resolver infra failure: exits 1 (a hard infrast
 assert_contains "could not resolve" "$OUT18" "config resolver infra failure: die_infra names the actual cause, not a generic empty-override note"
 assert_not_contains "would_rotate=false" "$OUT18" "config resolver infra failure: never emits a confident would_rotate result"
 
+# =============================================================================
+# 19. An unrecognized rotation policy value must (a) be treated as disabled,
+#     with its own distinct reason (not silently merged into "none"), and
+#     (b) have any markdown-active syntax in the value neutralized in the
+#     job summary's Notes section -- regression test for two review findings
+#     (UnrecognizedPolicyUntested: the fallback arm had no test at all;
+#     SEC-1/verifier: note() didn't neutralize markdown link/bold/heading
+#     syntax the way table cells already do).
+# =============================================================================
+F19=$(setup_fixture)
+push_docs_branch_commit "$F19" "docs/dossier" "$(day_offset 1)"
+NOGH_PATH19=$(no_gh_path)
+SUMMARY19=$(_dossier_safe_mktemp_dir "rotation-summary19")/summary.md
+WEIRD_POLICY='biweekly [click here](https://evil.example)'
+OUT19=$(cd "$F19" && env PATH="$NOGH_PATH19" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION="$WEIRD_POLICY" "$SCRIPT" --summary "$SUMMARY19" 2>&1)
+RC19=$?
+assert_equal "0" "$RC19" "unrecognized rotation policy: exits 0"
+assert_equal "false" "$(get "$OUT19" would_rotate)" "unrecognized rotation policy: treated as disabled"
+assert_contains "not recognised" "$(get "$OUT19" reason)" "unrecognized rotation policy: reason names it as unrecognized, distinct from the 'none' (deliberately disabled) case"
+# Scoped to the Notes section specifically -- the table's "Rotation policy"
+# row ALREADY wraps its value in backticks regardless of this fix (that's a
+# separate, pre-existing safe path), so a file-wide grep would pass even
+# without the fix by matching the table row instead of the actually
+# vulnerable bullet line.
+NOTES_SECTION19=$(awk '/^Notes:$/{found=1; next} found' "$SUMMARY19" 2>/dev/null)
+if printf '%s\n' "$NOTES_SECTION19" | grep -qE '^- `.*\[click here\]\(https://evil\.example\).*`$'; then
+  _dossier_assert_pass "unrecognized rotation policy: the Notes bullet is backtick-wrapped, neutralizing the embedded link syntax"
+else
+  _dossier_assert_fail "unrecognized rotation policy: the Notes bullet is not backtick-wrapped as expected"
+fi
+if printf '%s\n' "$NOTES_SECTION19" | grep -qF '](https://evil.example)' && ! printf '%s\n' "$NOTES_SECTION19" | grep -qE '^- `.*\[click here\]\(https://evil\.example\).*`$'; then
+  _dossier_assert_fail "unrecognized rotation policy: the Notes section renders a live markdown link instead of an inert code span"
+else
+  _dossier_assert_pass "unrecognized rotation policy: the Notes section does not render a live markdown link"
+fi
+
+# =============================================================================
+# 20. The --github-output flag's newline-injection defense (emit()'s
+#     control-character stripping, which is the only thing preventing a
+#     crafted config value from forging additional key=value pairs for a
+#     later CI step to read) had no test at all -- regression test for a
+#     review finding (TEST2, raised independently by both review lenses).
+# =============================================================================
+F20=$(setup_fixture)
+NOGH_PATH20=$(no_gh_path)
+GHOUT20=$(_dossier_safe_mktemp_dir "rotation-ghout20")/github_output
+: > "$GHOUT20"
+INJECT_BRANCH='docs/dossier
+fake_output=INJECTED
+real='
+OUT20=$(cd "$F20" && env PATH="$NOGH_PATH20" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH="$INJECT_BRANCH" "$SCRIPT" --github-output "$GHOUT20" 2>&1)
+RC20=$?
+assert_equal "0" "$RC20" "github-output newline injection attempt: still exits 0"
+assert_equal "docs/dossierfake_output=INJECTEDreal=" "$(get "$OUT20" docs_branch)" "github-output newline injection attempt: stdout's own docs_branch field is collapsed the same way as the --github-output file"
+GHOUT_LINES20=$(wc -l < "$GHOUT20" | tr -d ' ')
+assert_equal "8" "$GHOUT_LINES20" "github-output newline injection attempt: exactly the 8 real fields written, no forged extra key=value pairs"
+if grep -q '^fake_output=INJECTED$' "$GHOUT20" 2>/dev/null; then
+  _dossier_assert_fail "github-output newline injection attempt: a forged fake_output key was written to \$GITHUB_OUTPUT"
+else
+  _dossier_assert_pass "github-output newline injection attempt: no forged key was written to \$GITHUB_OUTPUT"
+fi
+assert_contains "docs_branch=docs/dossierfake_output=INJECTEDreal=" "$(cat "$GHOUT20")" "github-output newline injection attempt: the embedded newlines collapse onto the single docs_branch line rather than forging new lines"
+
 _dossier_test_summary

--- a/plugins/dossier/tests/workflow-template.test.sh
+++ b/plugins/dossier/tests/workflow-template.test.sh
@@ -72,6 +72,12 @@ ROTATION_STEP_BLOCK=$(awk '
 ' "$WF")
 assert_not_contains "if: steps.decide.outputs.should_run" "$ROTATION_STEP_BLOCK" "the rotation-check step runs unconditionally, even on a declined run"
 
+# A failure in this purely-observational step must never cascade into
+# skipping "Build the evidence bundle" (gated on should_run == 'true', which
+# GitHub Actions implicitly ANDs with success()) -- matching the precedent
+# already set by "Download the scan bundle" below.
+assert_contains "continue-on-error: true" "$ROTATION_STEP_BLOCK" "the rotation-check step cannot block the evidence-bundle build"
+
 # BASE_REF/GH_TOKEN come from github.event context expressions, not template
 # placeholders, so the step introduces no new {{PLACEHOLDER}} and needs no
 # addition to the sed substitution table above. Anchored on the render-time

--- a/plugins/dossier/tests/workflow-template.test.sh
+++ b/plugins/dossier/tests/workflow-template.test.sh
@@ -9,6 +9,7 @@
 _dossier_test_begin "workflow-template"
 
 WF="plugins/dossier/templates/ci/dossier-docs-refresh.yml"
+PLUGIN="plugins/dossier"
 assert_file_exists "$WF" "workflow template exists"
 
 BODY=$(cat "$WF" 2>/dev/null)
@@ -77,6 +78,28 @@ assert_not_contains "if: steps.decide.outputs.should_run" "$ROTATION_STEP_BLOCK"
 # `{{DOSSIER_` prefix, not a bare `{{`, since `${{ github.event... }}` is a
 # legitimate GitHub Actions expression that also contains `{{`.
 assert_not_contains "{{DOSSIER_" "$ROTATION_STEP_BLOCK" "the rotation-check step introduces no new template placeholder"
+
+# --- AC2: the policy job never closes a PR, deletes a branch, or creates a --
+# replacement branch, under any circumstance ---------------------------------
+# Scoped to the policy job block ONLY (reused from above) — the publish job
+# legitimately contains "git push origin --delete" as its own
+# destructive-branch-guard code (a different job, a different privilege
+# level, pre-existing correct behaviour that is not touched here).
+assert_not_contains "git push origin --delete" "$POLICY_BLOCK" "policy job never deletes the docs branch"
+assert_not_contains "git branch -D" "$POLICY_BLOCK" "policy job never force-deletes a branch"
+assert_not_contains "gh pr close" "$POLICY_BLOCK" "policy job never closes a pull request"
+assert_not_contains "gh pr merge" "$POLICY_BLOCK" "policy job never merges a pull request"
+assert_contains "contents: read" "$POLICY_BLOCK" "policy job still declares contents: read"
+assert_contains "pull-requests: read" "$POLICY_BLOCK" "policy job still declares pull-requests: read"
+assert_not_contains "contents: write" "$POLICY_BLOCK" "policy job gains NO write permission from the new step"
+assert_not_contains "pull-requests: write" "$POLICY_BLOCK" "policy job gains NO pull-requests write permission from the new step"
+
+# dossier-rotation-check.sh is independently callable outside CI, so it needs
+# its own check, not just the workflow YAML.
+ROTATION_SCRIPT_BODY=$(cat "$PLUGIN/bin/dossier-rotation-check.sh" 2>/dev/null)
+for destructive in "git push" "gh pr close" "gh pr merge" "git branch -D" "git branch -d"; do
+  assert_not_contains "$destructive" "$ROTATION_SCRIPT_BODY" "dossier-rotation-check.sh itself never runs '$destructive'"
+done
 
 # The scan job (issue #137): isolated osv-scanner/pyscn execution. Same
 # privilege posture as policy — read-only, no write token, no agent.

--- a/plugins/dossier/tests/workflow-template.test.sh
+++ b/plugins/dossier/tests/workflow-template.test.sh
@@ -52,6 +52,32 @@ done
 
 assert_match '^permissions: \{\}' "$BODY" "top-level permissions is empty — per-job grants only"
 
+# --- Rotation check (issue #138): telemetry-only, runs unconditionally ------
+# The policy job must invoke dossier-rotation-check.sh, and that specific step
+# must carry no `if:` gate — it has to run on every trigger, including a
+# declined run, so the metric is never conditional on should_run.
+POLICY_BLOCK=$(awk '/^  policy:/{f=1} /^  scan:/{f=0} f' "$WF")
+assert_contains "dossier-rotation-check.sh" "$POLICY_BLOCK" "the policy job invokes dossier-rotation-check.sh"
+assert_contains "name: Check whether the documentation branch would rotate" "$POLICY_BLOCK" "the policy job names the rotation-check step"
+
+# Extract only the rotation-check step's own block: from its own `- name:`
+# line up to (but not including) the next `- name:` line, so a gate that
+# exists elsewhere in the policy job (e.g. on "Build the evidence bundle")
+# cannot produce a false pass.
+ROTATION_STEP_BLOCK=$(awk '
+  /- name: Check whether the documentation branch would rotate/ { f=1; print; next }
+  f && /^      - name:/ { exit }
+  f { print }
+' "$WF")
+assert_not_contains "if: steps.decide.outputs.should_run" "$ROTATION_STEP_BLOCK" "the rotation-check step runs unconditionally, even on a declined run"
+
+# BASE_REF/GH_TOKEN come from github.event context expressions, not template
+# placeholders, so the step introduces no new {{PLACEHOLDER}} and needs no
+# addition to the sed substitution table above. Anchored on the render-time
+# `{{DOSSIER_` prefix, not a bare `{{`, since `${{ github.event... }}` is a
+# legitimate GitHub Actions expression that also contains `{{`.
+assert_not_contains "{{DOSSIER_" "$ROTATION_STEP_BLOCK" "the rotation-check step introduces no new template placeholder"
+
 # The scan job (issue #137): isolated osv-scanner/pyscn execution. Same
 # privilege posture as policy — read-only, no write token, no agent.
 SCAN_BLOCK=$(awk '/^  scan:/{f=1} /^  refresh:/{f=0} f' "$WF")


### PR DESCRIPTION
## Summary

Closes #138. Adds `dossier-rotation-check.sh`, a new, purely-observational telemetry script that determines whether dossier's rolling documentation branch would currently warrant "rotation" — without ever taking any action. An earlier design (autonomous close/delete/recreate on a schedule) was rejected as unsafe during issue design because the existing destructive-action guard assumes nothing like it happens while a PR is open, and its own circuit breaker can silently disable itself if a lookup fails. This issue is scoped to only the safe first step: observe and log, never act.

## What changed

- **New**: `plugins/dossier/bin/dossier-rotation-check.sh` — resolves the rolling branch's age (open PR's `createdAt`, falling back to the oldest `Dossier-Generated: true` commit) and cumulative diff size against the base branch, computes a tri-state `would_rotate` (`true`/`false`/`unknown` — never silently coerced to a confident "false" when the truth is unmeasured), and emits both a `key=value` output and a human-readable job-summary table.
- **CI wiring**: a new, unconditional step inside the `policy` job of `dossier-docs-refresh.yml`, running on every trigger (including declined runs), entirely within the job's existing `contents: read`/`pull-requests: read` scope — no new permission.
- **Config**: new `dossier.ci.thresholds.rotationMaxAccumulatedLines` field (default 5000) in `schema.json`/`settings.json`/`templates/config.example.json`.
- **Tests**: new `rotation-check.test.sh` (57 assertions against real local git repos with a real bare-repo remote), plus scoped safety assertions in `workflow-template.test.sh` and a `bin-scripts.test.sh` registration.

## Acceptance criteria

AC4 as originally written ("after a period of real observation... enough data to decide") described a future outcome no command could verify today. Reworded and user-confirmed before implementation: metrics (`age_days`/`accumulated_files`/`accumulated_lines`) are always computed and emitted in a stable format across every state — including when rotation is disabled — so a real observation period actually produces usable data. Full rationale in `.decisions/issue-138.md`.

| # | Criterion | Verification |
|---|---|---|
| 1 | Every run records a determination + reason | `rotation-check.test.sh` + `workflow-template.test.sh` |
| 2 | Never closes a PR / deletes / recreates a branch | scoped negative assertions against the script body + the `policy` job's own YAML block (never a whole-file scan, since `publish`'s own pre-existing destructive-guard code legitimately contains those verbs) |
| 3 | Tests cover both directions | `rotation-check.test.sh` — would-rotate via age, via size, via degraded fallback; would-not-rotate |
| 4 (reworded) | Metrics always emitted, every state | `rotation-check.test.sh` — explicit non-empty assertions under `rollingBranchRotation=none`, explicit empty (not zero) assertions on cold start |
| 5 | Full suite passes | `bash plugins/dossier/tests/run.sh` — 1802/1802 |

FlowGoal `issue-138` reached `achieved` (confidence 0.85) via two rounds with an independent goal-evaluator-judge, which caught and required closing two real evidence gaps before returning a verdict.

## Review round (5 parallel agents: code quality, security, convention, test-runner, error-handling)

| Finding | Priority | Fix |
|---|---|---|
| New CI step had no `continue-on-error`; its failure could cascade into skipping the real evidence-bundle build for a legitimate merge | P1 | Added `continue-on-error: true`, matching the file's own existing precedent for advisory steps |
| An explicitly-empty `rollingBranch` config override collides with `git ls-remote`'s "branch doesn't exist" exit code (both are 2), producing a confidently wrong result — reproduced live | P1 | Value guards on `DOCS_BRANCH`/`ROTATION_POLICY`, falling back to documented defaults |
| `gh pr list` failures (auth/rate-limit) were indistinguishable from "no PR found" | P2 | Now logged as a distinct degradation note |
| Job-summary markdown cells had no escaping — a value with a backtick/pipe/newline could break a table or inject a spoofed row | P2 | Added `sanitize_md()` at the display boundary only |
| `--help`'s line range included one line past the real header | P3 | Fixed |
| An unused captured variable (shellcheck SC2034) | P3 | Now asserted on, strengthening the test |
| `DOCS_BRANCH` has no shape guard against a leading-dash flag-injection risk | P3 | **Disclosed, not fixed** — inert in the shipped CI workflow (HTTPS remote); a real (if narrow) risk only for standalone/local use with a non-HTTPS origin. The reviewer's own suggested fix needed verification of `git ls-remote`'s `--` handling first, which wasn't done — left as a known limitation rather than guessed at. |

All P1/P2 fixes were RED→GREEN verified (reproduced the failure against pre-fix code, then confirmed the fix). Full suite re-confirmed at 1802/1802 after every round.

### Out-of-band incident (not a code finding)

Mid-review, a pre-existing, unrelated test-isolation bug in `plugins/dossier/tests/local-merge-hook.test.sh` (its git fixture setup, when it fails to isolate, runs bare `git config`/`git checkout`/`git commit` against the real repository rather than its intended `mktemp` sandbox) corrupted this session's local working directory twice: once creating stray local branches (`conflict-branch`, `feature-branch`, never pushed, harmless), and once overwriting the local `.git/config` identity to the fixture's `Test <test@example.com>`, which briefly misattributed 5 already-committed commits on this branch. Both were fully diagnosed (via reflog and exact fixture-string matching) and repaired — the stray branches via `git branch -f` to known-good refs, the misattributed commits via a non-destructive `git rebase --exec 'git commit --amend --author=...'` (nothing had been pushed at the time). All 10 commits on this branch are correctly attributed; content integrity reconfirmed via a fresh full-suite run after each repair. **This bug itself is out of scope for this PR** (a separate, pre-existing file unrelated to rotation-check telemetry). Root-caused and filed as [#149](https://github.com/synaptiai/synapti-marketplace/issues/149): two call sites capture `_dossier_safe_mktemp_dir`'s output via `$(...)` without checking the exit code, so a resolver/mktemp failure silently yields an empty path — and `cd ""` returns exit 0 in bash, turning the fixture's own isolation guard into a no-op.

## Review cycle 1 (Path A: paired-reviewer + challenge protocol, 32 findings)

A full Path A review (5 facets × skeptic/verifier + holdout ×2) found 32 consolidated findings beyond the 5-agent round above. All 32 were dispositioned: **14 fixed in-PR** (RED→GREEN verified), **4 filed as separate tracked issues** ([#146](https://github.com/synaptiai/synapti-marketplace/issues/146), [#147](https://github.com/synaptiai/synapti-marketplace/issues/147) ×2, [#148](https://github.com/synaptiai/synapti-marketplace/issues/148) — each requires a CI-credential-policy decision or touches code outside this PR's diff), **14 left as documented P3 cosmetic/coverage notes**. Full per-finding breakdown in the [review comment](https://github.com/synaptiai/synapti-marketplace/pull/145#pullrequestreview-4840049406) and [resolution comment](https://github.com/synaptiai/synapti-marketplace/pull/145#issuecomment-5160981968).

Notably this cycle: a live-verified bug where `rotationMaxAccumulatedLines=0` made the size signal trigger on every run (0 is always `>=` any measured value); a fork-PR-hijack risk in the new script's `gh pr list --head` lookup (unscoped by repo — fixed here, and the same pre-existing weakness in `dossier-policy.sh` filed as #146 since it has privileged, write-token consequences there); and a `cfg()` bug that masked genuine config-resolver crashes as ordinary empty-value fallbacks (live-verified on Ubuntu) — whose first fix attempt was itself caught as broken by its own regression test before shipping (a `die_infra()` call inside a `$(...)` subshell, whose `exit` only killed the subshell).

## Verification

- [x] Cycle-1 fixes: `bash plugins/dossier/tests/run.sh rotation-check.test.sh workflow-template.test.sh` — 177/177 (`rotation-check.test.sh` alone: 81/81, up from 65 pre-cycle)
- [x] `shellcheck -S warning`: clean on the two files this cycle touched (`dossier-rotation-check.sh`, `rotation-check.test.sh`)
- [x] `bash -n`: clean
- [x] Full suite (`bash plugins/dossier/tests/run.sh`) was **not** re-run this cycle, deliberately — `local-merge-hook.test.sh` has corrupted this session's working directory twice (see above, now filed as #149); the earlier "Full suite: 1802/1802" line above reflects the pre-cycle-1 state, before this cycle's fixes
- [x] Every code/behavior fix this cycle (not the test-coverage-only additions) was reproduced RED against the pre-fix code, then confirmed GREEN
- [x] Real end-to-end runs against this actual repository (not just fixtures) at multiple points, including after every review-round fix
- [x] Holdout validation: PASS, no conflicts
- [x] Independent verdict-judge: PASS (5/5 criteria)

