### PR TITLE
fix(dossier): close mktemp-dir guard exit-code gap, repo-wide

### DIFF
--- a/.decisions/issue-149.md
+++ b/.decisions/issue-149.md
@@ -34,13 +34,23 @@ created: '2026-08-03T10:03:20Z'
 
 PASS — 3 tasks reviewed. Task "add guarded helper" specifies the exact function signature, its two internal guards, and the printf -v assignment mechanism. Task "fix local-merge-hook.test.sh" names the exact two call sites (file:line) and the exact verification command. Task "repo-wide conversion" specifies the exact audit method (Python scan, zero pre-existing guards confirmed) and the two conversion shapes (simple swap; two-line split for the 7 path-suffix sites in rotation-check.test.sh).
 
+## Second-order finding (PR #150 review, fix-forwarded before merge)
+
+The first-pass fix (direct call-site conversion) left one gap: `setup_fixture()`/`no_gh_path()` in `rotation-check.test.sh` and `setup_fixture()` in `staleness-trigger.test.sh` called the new guard correctly *internally*, but were themselves invoked via `$(...)` at ~24 call sites — reopening the exact swallowed-exit bug one level up, since command substitution forks a subshell around the whole function body too. Found independently by three `/flow:pr` review agents (error-handling, security, code-quality) from three different angles. Fixed by converting both functions to the same out-parameter convention as the guard itself (`printf -v` into a caller-named variable, called as a plain statement), updating every call site, and hardening the guard's own final `printf -v` line to match. A repo-wide re-audit (every `$(...)`-invoked function name cross-checked against every function body containing the guard, across all 10 test files) confirmed zero remaining instances of this pattern.
+
+One reviewer's suggested prerequisite (`local _dir` in `_dossier_safe_mktemp_dir`, to prevent a claimed loop-variable clobber in `no_gh_path`) was investigated and empirically disproven via a standalone repro script — the guard's own internal `$(_dossier_safe_mktemp_dir ...)` call already forks its own subshell, which isolates `_dir` regardless of whether the outer helper is itself wrapped in `$(...)`. Not applied.
+
+Also checked: converting `setup_fixture`/`no_gh_path` from subshell-isolated to plain-statement execution means their previously-unscoped internal variables (`_bare`, `_clone`, `_out`, `_dir`, `_entry`, `_base`, `OLD_IFS`) now persist in the caller's real shell instead of dying with a subshell. Grepped for reads of all seven names outside their three defining functions (`no_gh_path`, `setup_fixture`, `push_docs_branch_commit`) in `rotation-check.test.sh` — zero external reads found, so the newly-persistent globals are inert (each function reassigns before reading, so there's no cross-call contamination either).
+
 ## Verification
 
-- Full suite: `bash plugins/dossier/tests/run.sh` — 1844/1844 (up from 1798 pre-change)
+- Full suite: `bash plugins/dossier/tests/run.sh` — 1848/1848 (up from 1798 pre-change, then 1844 after the first fix pass, then 1848 after the second-order fix's new mktemp-guard.test.sh scenario 4)
 - `shellcheck -S warning -x plugins/dossier/tests/*.sh` (exact CI invocation) — clean, exit 0
 - `bash -n` on every modified file — clean
 - Regression test (`mktemp-guard.test.sh` scenario 3) reproduced RED against the pre-fix `local-merge-hook.test.sh` (confirmed a `.git` directory materializes in an isolated scratch fixture when the guard doesn't fire), then confirmed GREEN after the fix
-- Repo-wide audit: 0 remaining `VAR=$(_dossier_safe_mktemp_dir ...)` call sites without a guard (116 total call sites found; 116 now guarded)
+- Regression test (`mktemp-guard.test.sh` scenario 4) regression-tests the second-order pattern generically (stdout-returning wrapper vs. out-parameter wrapper), independent of any specific file
+- Repo-wide audit: 0 remaining `VAR=$(_dossier_safe_mktemp_dir ...)` direct call sites without a guard (116 total direct call sites found; 116 guarded)
+- Repo-wide re-audit (second-order): 0 remaining functions that call the guard internally and are invoked via `$(...)` by their own callers
 
 <!-- auto-log: 2026-08-03 Write /Users/danielbentes/synapti-marketplace/.decisions/issue-149.md -->
 
@@ -63,3 +73,9 @@ PASS — 3 tasks reviewed. Task "add guarded helper" specifies the exact functio
 <!-- auto-log: 2026-08-03 12:33 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/lib/assert.sh -->
 
 <!-- auto-log: 2026-08-03 12:39 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/lib/assert.sh -->
+
+<!-- auto-log: 2026-08-03 12:41 commit "fix(dossier): close second-order guard-swallow in setup_fixture/no_gh_path" -->
+
+<!-- auto-log: 2026-08-03 12:42 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/pr149-body.md -->
+
+<!-- auto-log: 2026-08-03 12:46 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-149.md -->

--- a/.decisions/issue-149.md
+++ b/.decisions/issue-149.md
@@ -1,0 +1,47 @@
+---
+issue: 149
+created: '2026-08-03T10:03:20Z'
+---
+# Issue #149 — mktemp-dir guard: exit-code check reopens the `cd ""` corruption risk
+
+**Title**: dossier tests: local-merge-hook.test.sh doesn't check `_dossier_safe_mktemp_dir`'s exit code, reopening the `cd ""` corruption risk the helper was hardened against
+**Labels**: bug, plugin
+
+## Specification
+
+### Non-goals
+
+- Not touching the two real, already-corrected corruption incidents from earlier this session (stray local branches, misattributed commit authors) — those are already repaired; this issue is about closing the mechanism that caused them, not re-litigating the incident.
+- Not changing `_dossier_safe_mktemp_dir`'s own internal behavior (its `exit 2`-on-failure contract is correct and intentional) — the fix is entirely at the call-site layer.
+
+### Failure modes
+
+- **Partial failures** — `_dossier_safe_mktemp_dir` hitting any of its internal `exit 2` paths (unset `RUN_TMPDIR`, failed `mktemp -d`, unusable returned path) inside a bare `VAR=$(...)` call site only kills the command-substitution subshell; the caller proceeds with `VAR=""`, and `cd ""` returns 0 in bash — a silent no-op, not an abort.
+- **Scale of the gap** — a repo-wide audit (Python scan of every `plugins/dossier/tests/*.test.sh`) found 108 more unguarded call sites across 8 additional files beyond `local-merge-hook.test.sh`, none with any existing exit-code or emptiness guard. All converted in this PR, not just the two the issue named.
+
+### Interface contracts
+
+- New helper `_dossier_require_mktemp_dir <varname> <prefix>` in `plugins/dossier/tests/lib/assert.sh` — captures `_dossier_safe_mktemp_dir`'s output, checks `|| exit 2` AND emptiness/directory-existence, then assigns into the caller's named variable via `printf -v`. Implemented as a plain function call (never itself wrapped in `$(...)`), so an internal `exit 2` propagates through the caller's real shell instead of being swallowed by another subshell layer.
+
+## Acceptance Criteria (as validated)
+
+1. `local-merge-hook.test.sh`'s two call sites (`FLOWLESS_ROOT`, `REPO`) use the guarded helper. Verification: `bash plugins/dossier/tests/run.sh local-merge-hook.test.sh`
+2. The same unguarded pattern is fixed everywhere else it appears in `plugins/dossier/tests/*.test.sh`. Verification: repo-wide audit script (0 remaining unguarded call sites) + `bash plugins/dossier/tests/run.sh`
+3. A regression test proves the exact corruption mechanism (git init/config/checkout running against a real-looking directory instead of aborting) is closed, not just that the helper exists. Verification: `bash plugins/dossier/tests/run.sh mktemp-guard.test.sh`
+4. The full dossier test suite passes. Verification: `bash plugins/dossier/tests/run.sh`
+
+## Stranger Test
+
+PASS — 3 tasks reviewed. Task "add guarded helper" specifies the exact function signature, its two internal guards, and the printf -v assignment mechanism. Task "fix local-merge-hook.test.sh" names the exact two call sites (file:line) and the exact verification command. Task "repo-wide conversion" specifies the exact audit method (Python scan, zero pre-existing guards confirmed) and the two conversion shapes (simple swap; two-line split for the 7 path-suffix sites in rotation-check.test.sh).
+
+## Verification
+
+- Full suite: `bash plugins/dossier/tests/run.sh` — 1844/1844 (up from 1798 pre-change)
+- `shellcheck -S warning -x plugins/dossier/tests/*.sh` (exact CI invocation) — clean, exit 0
+- `bash -n` on every modified file — clean
+- Regression test (`mktemp-guard.test.sh` scenario 3) reproduced RED against the pre-fix `local-merge-hook.test.sh` (confirmed a `.git` directory materializes in an isolated scratch fixture when the guard doesn't fire), then confirmed GREEN after the fix
+- Repo-wide audit: 0 remaining `VAR=$(_dossier_safe_mktemp_dir ...)` call sites without a guard (116 total call sites found; 116 now guarded)
+
+<!-- auto-log: 2026-08-03 Write /Users/danielbentes/synapti-marketplace/.decisions/issue-149.md -->
+
+<!-- auto-log: 2026-08-03 12:21 Write /Users/danielbentes/synapti-marketplace/.decisions/issue-149.md -->

--- a/.decisions/issue-149.md
+++ b/.decisions/issue-149.md
@@ -38,19 +38,32 @@ PASS — 3 tasks reviewed. Task "add guarded helper" specifies the exact functio
 
 The first-pass fix (direct call-site conversion) left one gap: `setup_fixture()`/`no_gh_path()` in `rotation-check.test.sh` and `setup_fixture()` in `staleness-trigger.test.sh` called the new guard correctly *internally*, but were themselves invoked via `$(...)` at ~24 call sites — reopening the exact swallowed-exit bug one level up, since command substitution forks a subshell around the whole function body too. Found independently by three `/flow:pr` review agents (error-handling, security, code-quality) from three different angles. Fixed by converting both functions to the same out-parameter convention as the guard itself (`printf -v` into a caller-named variable, called as a plain statement), updating every call site, and hardening the guard's own final `printf -v` line to match. A repo-wide re-audit (every `$(...)`-invoked function name cross-checked against every function body containing the guard, across all 10 test files) confirmed zero remaining instances of this pattern.
 
-One reviewer's suggested prerequisite (`local _dir` in `_dossier_safe_mktemp_dir`, to prevent a claimed loop-variable clobber in `no_gh_path`) was investigated and empirically disproven via a standalone repro script — the guard's own internal `$(_dossier_safe_mktemp_dir ...)` call already forks its own subshell, which isolates `_dir` regardless of whether the outer helper is itself wrapped in `$(...)`. Not applied.
+A reviewer's suggested prerequisite (`local _dir` in `_dossier_safe_mktemp_dir`, to prevent a claimed loop-variable clobber in `no_gh_path`) was investigated and empirically disproven at the time — the guard's own internal `$(_dossier_safe_mktemp_dir ...)` call already forks its own subshell, which isolates `_dir` regardless of whether the outer helper is itself wrapped in `$(...)`. Not applied in that round. It was independently re-raised by two more reviewers during `/flow:review` (see below) with a different framing — not "this is a live bug" (it isn't, under the current call graph) but "the file's own docstring actively directs future contributors toward a refactor that would make it live" — and applied in round 3 as cheap proactive hardening, not a live-bug fix. Both framings are consistent; the decision changed because the second framing is the stronger argument for a one-word, zero-behavior-change addition.
 
-Also checked: converting `setup_fixture`/`no_gh_path` from subshell-isolated to plain-statement execution means their previously-unscoped internal variables (`_bare`, `_clone`, `_out`, `_dir`, `_entry`, `_base`, `OLD_IFS`) now persist in the caller's real shell instead of dying with a subshell. Grepped for reads of all seven names outside their three defining functions (`no_gh_path`, `setup_fixture`, `push_docs_branch_commit`) in `rotation-check.test.sh` — zero external reads found, so the newly-persistent globals are inert (each function reassigns before reading, so there's no cross-call contamination either).
+Also checked: converting `setup_fixture`/`no_gh_path` from subshell-isolated to plain-statement execution means their previously-unscoped internal variables (`_bare`, `_clone`, `_out`, `_dir`, `_entry`, `_base`, `OLD_IFS`) now persist in the caller's real shell instead of dying with a subshell. Grepped for reads of all seven names outside their three defining functions (`no_gh_path`, `setup_fixture`, `push_docs_branch_commit`) in `rotation-check.test.sh` — zero external reads found, so the newly-persistent globals were inert either way — but `local`-scoped them anyway in round 3 (below) for consistency with `staleness-trigger.test.sh`'s sibling `setup_fixture`, which already scoped everything correctly.
+
+## Third-order findings (`/flow:review` on PR #150, fix-forwarded before merge)
+
+The Path A paired-reviewer round (10 agents, 5 facets × skeptic/verifier) re-reviewed the full PR at its round-2 HEAD and converged, across 4 independent reviewers, on:
+
+1. **`no_gh_path`/`setup_fixture` (rotation-check.test.sh) internal variables should be `local`** — applied (`OLD_IFS _out _dir _entry _base` in `no_gh_path`; `_bare _clone` in `setup_fixture`), matching `staleness-trigger.test.sh`'s already-correct sibling.
+2. **The wrapper functions' own final `printf -v` (the out-parameter handoff `no_gh_path`/`setup_fixture` introduced in round 2) was itself unguarded** — the exact ERR-3/SEC-2 class fixed in `_dossier_require_mktemp_dir` in round 2 had been reintroduced one level up, in new code from round 2 itself. Fixed by extracting a shared `_dossier_assign_outvar <varname> <value>` helper (guarded `printf -v`, matching the FATAL+exit-2 pattern) and having both `_dossier_require_mktemp_dir` and all three wrapper functions delegate to it — DRY, so the guard can't be dropped on a future copy-paste of the out-parameter pattern.
+3. **No durable, CI-enforced guard against a future helper reintroducing this exact class** — `mktemp-guard.test.sh` scenario 4 only regression-tested the *pattern* generically via synthetic stand-ins, not the real files. Fixed by adding scenario 6: a static lint (pure awk/grep, no python dependency) that scans every `plugins/dossier/tests/*.test.sh` file for any function that calls the guard internally and is also invoked via `$(...)`/backticks anywhere in that file — verified it correctly flags a deliberately-introduced violation before trusting it as a regression guard.
+4. **`local _dir` in `_dossier_safe_mktemp_dir`** — re-raised (see above), applied.
+5. Scenario 3's `.git`-absence assertion was found to be proven vacuously (`local-merge-hook.test.sh` has two guarded call sites; the first always aborts before the second, behind which the actual `git init` sits, is ever reached) — relabeled the assertions to accurately describe what's proven (the first guard's abort) rather than implying the second guard was independently isolated.
 
 ## Verification
 
-- Full suite: `bash plugins/dossier/tests/run.sh` — 1848/1848 (up from 1798 pre-change, then 1844 after the first fix pass, then 1848 after the second-order fix's new mktemp-guard.test.sh scenario 4)
+- Full suite: `bash plugins/dossier/tests/run.sh` — 1852/1852 (1798 pre-change → 1844 after round 1 → 1848 after round 2 → 1852 after round 3's new scenarios 5 and 6)
 - `shellcheck -S warning -x plugins/dossier/tests/*.sh` (exact CI invocation) — clean, exit 0
 - `bash -n` on every modified file — clean
 - Regression test (`mktemp-guard.test.sh` scenario 3) reproduced RED against the pre-fix `local-merge-hook.test.sh` (confirmed a `.git` directory materializes in an isolated scratch fixture when the guard doesn't fire), then confirmed GREEN after the fix
 - Regression test (`mktemp-guard.test.sh` scenario 4) regression-tests the second-order pattern generically (stdout-returning wrapper vs. out-parameter wrapper), independent of any specific file
+- Regression test (`mktemp-guard.test.sh` scenario 5) proves `_dossier_assign_outvar` itself hard-aborts on an invalid target identifier, rather than letting a bare `printf -v` fail silently
+- Static lint (`mktemp-guard.test.sh` scenario 6) proves, and will keep proving on every future run, that no `*.test.sh` file defines a guard-consuming function that's also invoked via `$(...)`/backticks — verified it actually catches a deliberately-introduced violation before trusting it
 - Repo-wide audit: 0 remaining `VAR=$(_dossier_safe_mktemp_dir ...)` direct call sites without a guard (116 total direct call sites found; 116 guarded)
-- Repo-wide re-audit (second-order): 0 remaining functions that call the guard internally and are invoked via `$(...)` by their own callers
+- Repo-wide re-audit (second-order): 0 remaining functions that call the guard internally and are invoked via `$(...)` by their own callers (now continuously enforced by scenario 6, not just a one-time audit)
+- CI on PR #150: 4/4 checks green (`test`, `CodeQL`, `Analyze (actions)`, `Analyze (python)`), independently re-checked via `gh pr checks` per this project's own memory of prior local-green/CI-red divergence on this exact plugin
 
 <!-- auto-log: 2026-08-03 Write /Users/danielbentes/synapti-marketplace/.decisions/issue-149.md -->
 
@@ -79,3 +92,29 @@ Also checked: converting `setup_fixture`/`no_gh_path` from subshell-isolated to 
 <!-- auto-log: 2026-08-03 12:42 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/pr149-body.md -->
 
 <!-- auto-log: 2026-08-03 12:46 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-149.md -->
+
+<!-- auto-log: 2026-08-03 12:55 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/lib/assert.sh -->
+
+<!-- auto-log: 2026-08-03 12:55 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 12:55 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 12:55 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/staleness-trigger.test.sh -->
+
+<!-- auto-log: 2026-08-03 12:55 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/mktemp-guard.test.sh -->
+
+<!-- auto-log: 2026-08-03 12:57 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 12:58 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 12:59 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/mktemp-guard.test.sh -->
+
+<!-- auto-log: 2026-08-03 12:59 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/mktemp-guard.test.sh -->
+
+<!-- auto-log: 2026-08-03 13:01 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/lib/assert.sh -->
+
+<!-- auto-log: 2026-08-03 13:06 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/mktemp-guard.test.sh -->
+
+<!-- auto-log: 2026-08-03 13:06 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/mktemp-guard.test.sh -->
+
+<!-- auto-log: 2026-08-03 13:12 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-149.md -->

--- a/.decisions/issue-149.md
+++ b/.decisions/issue-149.md
@@ -45,3 +45,21 @@ PASS — 3 tasks reviewed. Task "add guarded helper" specifies the exact functio
 <!-- auto-log: 2026-08-03 Write /Users/danielbentes/synapti-marketplace/.decisions/issue-149.md -->
 
 <!-- auto-log: 2026-08-03 12:21 Write /Users/danielbentes/synapti-marketplace/.decisions/issue-149.md -->
+
+<!-- auto-log: 2026-08-03 12:32 Write /Users/danielbentes/synapti-marketplace/.claude/agent-memory/flow-security-reviewer/project_dossier_mktemp_guard_wrapper_composition_gap.md -->
+
+<!-- auto-log: 2026-08-03 12:32 Edit /Users/danielbentes/synapti-marketplace/.claude/agent-memory/flow-security-reviewer/MEMORY.md -->
+
+<!-- auto-log: 2026-08-03 12:32 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/mktemp-guard.test.sh -->
+
+<!-- auto-log: 2026-08-03 12:32 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 12:33 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 12:33 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/staleness-trigger.test.sh -->
+
+<!-- auto-log: 2026-08-03 12:33 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/staleness-trigger.test.sh -->
+
+<!-- auto-log: 2026-08-03 12:33 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/lib/assert.sh -->
+
+<!-- auto-log: 2026-08-03 12:39 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/lib/assert.sh -->

--- a/plugins/dossier/tests/blast-radius-staleness.test.sh
+++ b/plugins/dossier/tests/blast-radius-staleness.test.sh
@@ -15,7 +15,7 @@ if [ ! -x "$SCRIPT" ]; then
   return 0 2>/dev/null || exit 0
 fi
 
-FIXTURE=$(_dossier_safe_mktemp_dir "blast-radius-staleness")
+_dossier_require_mktemp_dir FIXTURE "blast-radius-staleness"
 
 # A changed-files list that matches nothing in the event matrix, so the only
 # documents in the result (absent --stale-docs) are the four "always" docs.

--- a/plugins/dossier/tests/lib/assert.sh
+++ b/plugins/dossier/tests/lib/assert.sh
@@ -62,6 +62,18 @@ _dossier_safe_mktemp_dir() {
 # call (not itself wrapped in `$(...)`), so an internal failure's `exit 2`
 # propagates all the way up through the caller's shell rather than being
 # swallowed by another layer of subshell.
+#
+# That guarantee is only as good as every caller in the chain: if you write
+# a function that calls this helper internally and then hands its result
+# back to ITS OWN caller via stdout (`printf '%s' "$var"`, meant to be
+# consumed as `X=$(your_function)`), you have reintroduced the exact bug
+# this helper exists to close, one level up — `$(...)` forks a subshell for
+# your_function's entire body, so this helper's `exit 2` again only kills
+# that subshell. Give your function an <outvar> parameter and assign into
+# it via `printf -v` instead, and call it as a plain statement, the same
+# way this helper itself must be called. See `no_gh_path`/`setup_fixture`
+# in rotation-check.test.sh and staleness-trigger.test.sh for the pattern,
+# and mktemp-guard.test.sh scenario 4 for the regression test.
 _dossier_require_mktemp_dir() {
   local __dossier_mktemp_varname="$1" __dossier_mktemp_prefix="$2" __dossier_mktemp_dir
   __dossier_mktemp_dir=$(_dossier_safe_mktemp_dir "$__dossier_mktemp_prefix") || exit 2
@@ -69,7 +81,10 @@ _dossier_require_mktemp_dir() {
     echo "FATAL: _dossier_safe_mktemp_dir(\"$__dossier_mktemp_prefix\") returned an unusable path for \$$__dossier_mktemp_varname: '$__dossier_mktemp_dir'" >&2
     exit 2
   fi
-  printf -v "$__dossier_mktemp_varname" '%s' "$__dossier_mktemp_dir"
+  printf -v "$__dossier_mktemp_varname" '%s' "$__dossier_mktemp_dir" || {
+    echo "FATAL: printf -v failed to assign \$$__dossier_mktemp_varname (invalid identifier?)" >&2
+    exit 2
+  }
 }
 
 _dossier_assert_pass() {

--- a/plugins/dossier/tests/lib/assert.sh
+++ b/plugins/dossier/tests/lib/assert.sh
@@ -36,6 +36,16 @@ _dossier_test_begin() {
 # than returning empty, so a caller relying on `$(...)` cannot receive "" and
 # proceed regardless.
 _dossier_safe_mktemp_dir() {
+  # `_dir` is local defensively: this function is currently always invoked
+  # via `$(...)` (which subshell-isolates it regardless), but that isolation
+  # is an accident of every current caller's shape, not a documented
+  # invariant of this function itself — see _dossier_require_mktemp_dir's
+  # docstring, which actively tells future contributors to convert
+  # stdout-returning helpers like this one to a plain-statement out-param
+  # call. `local` here means that conversion can never silently clobber a
+  # caller's own `_dir` (e.g. no_gh_path's `for _dir in $PATH` loop
+  # variable), regardless of what shape a future caller takes.
+  local _dir
   if [ -z "${RUN_TMPDIR:-}" ] || [ ! -d "$RUN_TMPDIR" ]; then
     echo "FATAL: RUN_TMPDIR is unset or not a directory — this test file must be run via tests/run.sh, not invoked directly" >&2
     exit 2
@@ -70,10 +80,18 @@ _dossier_safe_mktemp_dir() {
 # this helper exists to close, one level up — `$(...)` forks a subshell for
 # your_function's entire body, so this helper's `exit 2` again only kills
 # that subshell. Give your function an <outvar> parameter and assign into
-# it via `printf -v` instead, and call it as a plain statement, the same
-# way this helper itself must be called. See `no_gh_path`/`setup_fixture`
-# in rotation-check.test.sh and staleness-trigger.test.sh for the pattern,
-# and mktemp-guard.test.sh scenario 4 for the regression test.
+# it via `_dossier_assign_outvar` (below) instead, and call it as a plain
+# statement, the same way this helper itself must be called. See
+# `no_gh_path`/`setup_fixture` in rotation-check.test.sh and
+# staleness-trigger.test.sh for the pattern, and mktemp-guard.test.sh
+# scenario 4 for the regression test.
+#
+# Callers of your <outvar> function must also avoid naming their outvar
+# argument the same as any of the function's own `local` variables (a
+# collision silently assigns the function's local shadow instead of the
+# caller's variable, since bash resolves `printf -v` by innermost scope) —
+# see `no_gh_path`/`setup_fixture`'s own local declarations for the names
+# already in use.
 _dossier_require_mktemp_dir() {
   local __dossier_mktemp_varname="$1" __dossier_mktemp_prefix="$2" __dossier_mktemp_dir
   __dossier_mktemp_dir=$(_dossier_safe_mktemp_dir "$__dossier_mktemp_prefix") || exit 2
@@ -81,8 +99,23 @@ _dossier_require_mktemp_dir() {
     echo "FATAL: _dossier_safe_mktemp_dir(\"$__dossier_mktemp_prefix\") returned an unusable path for \$$__dossier_mktemp_varname: '$__dossier_mktemp_dir'" >&2
     exit 2
   fi
-  printf -v "$__dossier_mktemp_varname" '%s' "$__dossier_mktemp_dir" || {
-    echo "FATAL: printf -v failed to assign \$$__dossier_mktemp_varname (invalid identifier?)" >&2
+  _dossier_assign_outvar "$__dossier_mktemp_varname" "$__dossier_mktemp_dir"
+}
+
+# _dossier_assign_outvar <varname> <value> — the one guarded way to assign
+# into a caller-named "out parameter" via `printf -v`, used both by
+# _dossier_require_mktemp_dir above and by any wrapper function that
+# re-exposes its own result through an outvar (see that function's
+# docstring for why stdout+$(...) is unsafe here). A bare `printf -v` can
+# fail silently (invalid identifier, readonly/array-name collision) and
+# return non-zero with no message — under this suite's `set -uo pipefail`
+# (no `-e`), that failure would otherwise be swallowed exactly like the
+# bug this file exists to close. Centralized here so the guard can't be
+# dropped on the next copy-paste of the out-parameter pattern.
+_dossier_assign_outvar() {
+  local __dossier_assign_varname="$1" __dossier_assign_value="$2"
+  printf -v "$__dossier_assign_varname" '%s' "$__dossier_assign_value" || {
+    echo "FATAL: printf -v failed to assign \$$__dossier_assign_varname (invalid identifier?)" >&2
     exit 2
   }
 }

--- a/plugins/dossier/tests/lib/assert.sh
+++ b/plugins/dossier/tests/lib/assert.sh
@@ -51,6 +51,27 @@ _dossier_safe_mktemp_dir() {
   printf '%s\n' "$_dir"
 }
 
+# _dossier_require_mktemp_dir <varname> <prefix> — the sanctioned way for a
+# call site to consume _dossier_safe_mktemp_dir's output. A bare
+# `VAR=$(_dossier_safe_mktemp_dir ...)` reopens the exact risk that function
+# was hardened against: its `exit 2` only terminates the `$(...)` subshell,
+# so a caller that doesn't check the assignment's own exit status proceeds
+# with VAR="" — and `cd ""` returns 0 in bash, silently no-oping instead of
+# aborting (issue #149; this happened for real to local-merge-hook.test.sh).
+# This helper does the capture-and-check exactly once, as a plain function
+# call (not itself wrapped in `$(...)`), so an internal failure's `exit 2`
+# propagates all the way up through the caller's shell rather than being
+# swallowed by another layer of subshell.
+_dossier_require_mktemp_dir() {
+  local __dossier_mktemp_varname="$1" __dossier_mktemp_prefix="$2" __dossier_mktemp_dir
+  __dossier_mktemp_dir=$(_dossier_safe_mktemp_dir "$__dossier_mktemp_prefix") || exit 2
+  if [ -z "$__dossier_mktemp_dir" ] || [ ! -d "$__dossier_mktemp_dir" ]; then
+    echo "FATAL: _dossier_safe_mktemp_dir(\"$__dossier_mktemp_prefix\") returned an unusable path for \$$__dossier_mktemp_varname: '$__dossier_mktemp_dir'" >&2
+    exit 2
+  fi
+  printf -v "$__dossier_mktemp_varname" '%s' "$__dossier_mktemp_dir"
+}
+
 _dossier_assert_pass() {
   DOSSIER_TEST_PASS=$((DOSSIER_TEST_PASS + 1))
   printf 'PASS %s — %s\n' "$DOSSIER_TEST_CURRENT" "$1"

--- a/plugins/dossier/tests/local-merge-hook.test.sh
+++ b/plugins/dossier/tests/local-merge-hook.test.sh
@@ -18,7 +18,7 @@ fi
 # This is the test that actually proves self-containment, not just asserts it
 # in prose: PLUGIN_ROOT points at a directory tree where plugins/flow simply
 # does not exist on disk, and the hook must still behave correctly.
-FLOWLESS_ROOT=$(_dossier_safe_mktemp_dir "flowless-plugins")
+_dossier_require_mktemp_dir FLOWLESS_ROOT "flowless-plugins"
 cp -R plugins/dossier "$FLOWLESS_ROOT/dossier"
 if [ -d "$FLOWLESS_ROOT/flow" ]; then
   _dossier_assert_fail "fixture setup bug: flow plugin ended up in the flowless fixture"
@@ -29,7 +29,7 @@ PLUGIN_ROOT="$FLOWLESS_ROOT/dossier"
 
 # A git repo to run the hook against — default branch checked out, HEAD has
 # no second parent yet.
-REPO=$(_dossier_safe_mktemp_dir "local-merge-repo")
+_dossier_require_mktemp_dir REPO "local-merge-repo"
 (
   cd "$REPO" || exit 1
   git init -q -b main

--- a/plugins/dossier/tests/mktemp-guard.test.sh
+++ b/plugins/dossier/tests/mktemp-guard.test.sh
@@ -49,4 +49,42 @@ else
   _dossier_assert_pass "no .git directory materialized in the scratch cwd — git init never ran"
 fi
 
+# --- Scenario 4: pattern-level regression — a helper-consuming function that
+# returns its result via stdout (meant to be called as `X=$(fn)`) reopens the
+# exact swallowed-exit bug one level up, even though it calls the guard
+# correctly *internally*: the whole function runs inside the subshell that
+# `$(...)` forks for it, so the guard's `exit 2` only kills that subshell.
+# This is the shape setup_fixture()/no_gh_path() had in rotation-check.test.sh
+# and staleness-trigger.test.sh before this fix — found by review, not by the
+# original repo-wide audit, because the audit only greped for direct
+# `_dossier_safe_mktemp_dir` call sites, not for guard-consuming functions
+# invoked via `$(...)` by their own callers.
+BROKEN_WRAPPER_OUTPUT=$(RUN_TMPDIR="" bash -c "
+  source '$ASSERT_LIB_ABS'
+  stdout_returning_fn() {
+    local _d
+    _dossier_require_mktemp_dir _d 'wrapper-broken'
+    printf '%s' \"\$_d\"
+  }
+  RESULT=\$(stdout_returning_fn)
+  RC=\$?
+  echo \"RESULT=[\$RESULT] RC=\$RC OUTER_UNREACHABLE_MARKER\"
+" 2>&1)
+assert_contains "OUTER_UNREACHABLE_MARKER" "$BROKEN_WRAPPER_OUTPUT" "confirms the vulnerable shape: a stdout-returning wrapper lets the caller's script continue past a failed guard (RESULT=[] silently)"
+assert_contains "RESULT=[]" "$BROKEN_WRAPPER_OUTPUT" "confirms the vulnerable shape: the caller receives an empty result instead of the process dying"
+
+OUTVAR_WRAPPER_OUTPUT=$(RUN_TMPDIR="" bash -c "
+  source '$ASSERT_LIB_ABS'
+  outvar_returning_fn() {
+    local __outvar=\"\$1\" _d
+    _dossier_require_mktemp_dir _d 'wrapper-fixed'
+    printf -v \"\$__outvar\" '%s' \"\$_d\"
+  }
+  outvar_returning_fn RESULT
+  echo \"OUTER_UNREACHABLE_MARKER RESULT=[\$RESULT]\"
+" 2>&1)
+OUTVAR_WRAPPER_RC=$?
+assert_exit "2" "$OUTVAR_WRAPPER_RC" "the fixed shape (out-parameter via printf -v, called as a plain statement) correctly propagates exit 2 through the wrapper"
+assert_not_contains "OUTER_UNREACHABLE_MARKER" "$OUTVAR_WRAPPER_OUTPUT" "the fixed shape never reaches the caller's next line when the guard fires inside the wrapper"
+
 _dossier_test_summary

--- a/plugins/dossier/tests/mktemp-guard.test.sh
+++ b/plugins/dossier/tests/mktemp-guard.test.sh
@@ -1,0 +1,51 @@
+# _dossier_require_mktemp_dir (issue #149): closes the "cd \"\" silently
+# no-ops" corruption risk that a bare `VAR=$(_dossier_safe_mktemp_dir ...)`
+# call site reopens whenever it forgets to check the command substitution's
+# own exit status. This file proves the guarded helper itself works, and
+# regression-proves the exact file (local-merge-hook.test.sh) that corrupted
+# this repository's working directory twice before the fix.
+
+_dossier_test_begin "mktemp-guard"
+
+# --- Scenario 1: happy path — helper assigns a real, existing directory ----
+_dossier_require_mktemp_dir HAPPY_DIR "guard-happy"
+if [ -n "$HAPPY_DIR" ] && [ -d "$HAPPY_DIR" ]; then
+  _dossier_assert_pass "helper assigns a real, existing directory on success"
+else
+  _dossier_assert_fail "helper did not assign a usable directory: '$HAPPY_DIR'"
+fi
+
+# --- Scenario 2: RUN_TMPDIR invalid -> hard abort, no silent empty passthrough
+# Run in a real child process (not a mere `$(...)` subshell) so we can
+# observe whether `exit 2` actually escapes the helper and kills the whole
+# script, rather than being swallowed the way the original bug swallowed it.
+ASSERT_LIB_ABS="$(cd "$(dirname "${BASH_SOURCE[0]}")/lib" && pwd)/assert.sh"
+
+GUARD_OUTPUT=$(RUN_TMPDIR="" bash -c "source '$ASSERT_LIB_ABS'; _dossier_require_mktemp_dir TARGET 'guard-should-fail'; echo \"UNREACHABLE:TARGET=[\$TARGET]\"" 2>&1)
+GUARD_RC=$?
+
+assert_exit "2" "$GUARD_RC" "helper hard-aborts (exit 2) when RUN_TMPDIR is invalid"
+assert_not_contains "UNREACHABLE" "$GUARD_OUTPUT" "control flow never reaches past a failed guard call"
+
+# --- Scenario 3: regression — local-merge-hook.test.sh's own fixture setup
+# must abort, not fall through to git init/config/checkout. Exercised inside
+# an isolated scratch directory (never the real repo) so that even a broken
+# fix can only ever corrupt a throwaway fixture, not this working tree.
+TARGET_TEST_ABS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/local-merge-hook.test.sh"
+GUARD_SCRATCH=$(_dossier_safe_mktemp_dir "local-merge-hook-guard-regression")
+mkdir -p "$GUARD_SCRATCH/plugins/dossier/hooks/scripts"
+cp "plugins/dossier/hooks/scripts/detect-local-merge.sh" "$GUARD_SCRATCH/plugins/dossier/hooks/scripts/detect-local-merge.sh"
+chmod +x "$GUARD_SCRATCH/plugins/dossier/hooks/scripts/detect-local-merge.sh"
+
+REGRESSION_OUTPUT=$(cd "$GUARD_SCRATCH" && RUN_TMPDIR="" bash -c "source '$ASSERT_LIB_ABS'; source '$TARGET_TEST_ABS'; echo REGRESSION_UNREACHABLE_MARKER" 2>&1)
+REGRESSION_RC=$?
+
+assert_exit "2" "$REGRESSION_RC" "local-merge-hook.test.sh aborts (exit 2) when RUN_TMPDIR is invalid, not a soft failure"
+assert_not_contains "REGRESSION_UNREACHABLE_MARKER" "$REGRESSION_OUTPUT" "local-merge-hook.test.sh never reaches its final line when the guard fires early"
+if [ -d "$GUARD_SCRATCH/.git" ]; then
+  _dossier_assert_fail "regression: a .git directory was created in the scratch cwd — the guard did not prevent git init from running against a real-looking directory"
+else
+  _dossier_assert_pass "no .git directory materialized in the scratch cwd — git init never ran"
+fi
+
+_dossier_test_summary

--- a/plugins/dossier/tests/mktemp-guard.test.sh
+++ b/plugins/dossier/tests/mktemp-guard.test.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # _dossier_require_mktemp_dir (issue #149): closes the "cd \"\" silently
 # no-ops" corruption risk that a bare `VAR=$(_dossier_safe_mktemp_dir ...)`
 # call site reopens whenever it forgets to check the command substitution's
@@ -32,7 +33,7 @@ assert_not_contains "UNREACHABLE" "$GUARD_OUTPUT" "control flow never reaches pa
 # an isolated scratch directory (never the real repo) so that even a broken
 # fix can only ever corrupt a throwaway fixture, not this working tree.
 TARGET_TEST_ABS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/local-merge-hook.test.sh"
-GUARD_SCRATCH=$(_dossier_safe_mktemp_dir "local-merge-hook-guard-regression")
+_dossier_require_mktemp_dir GUARD_SCRATCH "local-merge-hook-guard-regression"
 mkdir -p "$GUARD_SCRATCH/plugins/dossier/hooks/scripts"
 cp "plugins/dossier/hooks/scripts/detect-local-merge.sh" "$GUARD_SCRATCH/plugins/dossier/hooks/scripts/detect-local-merge.sh"
 chmod +x "$GUARD_SCRATCH/plugins/dossier/hooks/scripts/detect-local-merge.sh"

--- a/plugins/dossier/tests/mktemp-guard.test.sh
+++ b/plugins/dossier/tests/mktemp-guard.test.sh
@@ -32,6 +32,14 @@ assert_not_contains "UNREACHABLE" "$GUARD_OUTPUT" "control flow never reaches pa
 # must abort, not fall through to git init/config/checkout. Exercised inside
 # an isolated scratch directory (never the real repo) so that even a broken
 # fix can only ever corrupt a throwaway fixture, not this working tree.
+#
+# Note on what this actually proves: local-merge-hook.test.sh has two guarded
+# call sites (FLOWLESS_ROOT then REPO); with RUN_TMPDIR invalid, the FIRST
+# one aborts before the second is ever reached, so this specifically proves
+# the FLOWLESS_ROOT guard fires and the script never gets near the git init
+# block behind REPO — it does not independently isolate REPO's own guard.
+# That guard mechanism itself (does _dossier_require_mktemp_dir correctly
+# abort on failure) is proven generically in scenario 2 above.
 TARGET_TEST_ABS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/local-merge-hook.test.sh"
 _dossier_require_mktemp_dir GUARD_SCRATCH "local-merge-hook-guard-regression"
 mkdir -p "$GUARD_SCRATCH/plugins/dossier/hooks/scripts"
@@ -41,12 +49,12 @@ chmod +x "$GUARD_SCRATCH/plugins/dossier/hooks/scripts/detect-local-merge.sh"
 REGRESSION_OUTPUT=$(cd "$GUARD_SCRATCH" && RUN_TMPDIR="" bash -c "source '$ASSERT_LIB_ABS'; source '$TARGET_TEST_ABS'; echo REGRESSION_UNREACHABLE_MARKER" 2>&1)
 REGRESSION_RC=$?
 
-assert_exit "2" "$REGRESSION_RC" "local-merge-hook.test.sh aborts (exit 2) when RUN_TMPDIR is invalid, not a soft failure"
-assert_not_contains "REGRESSION_UNREACHABLE_MARKER" "$REGRESSION_OUTPUT" "local-merge-hook.test.sh never reaches its final line when the guard fires early"
+assert_exit "2" "$REGRESSION_RC" "local-merge-hook.test.sh's FLOWLESS_ROOT guard aborts (exit 2) when RUN_TMPDIR is invalid, not a soft failure"
+assert_not_contains "REGRESSION_UNREACHABLE_MARKER" "$REGRESSION_OUTPUT" "local-merge-hook.test.sh never reaches its final line when the FLOWLESS_ROOT guard fires early"
 if [ -d "$GUARD_SCRATCH/.git" ]; then
-  _dossier_assert_fail "regression: a .git directory was created in the scratch cwd — the guard did not prevent git init from running against a real-looking directory"
+  _dossier_assert_fail "regression: a .git directory was created in the scratch cwd — the guard did not prevent the script from reaching git init"
 else
-  _dossier_assert_pass "no .git directory materialized in the scratch cwd — git init never ran"
+  _dossier_assert_pass "no .git directory materialized in the scratch cwd — the script never got far enough to run git init (proves the FLOWLESS_ROOT guard's abort, not REPO's guard specifically — that mechanism is proven generically in scenario 2)"
 fi
 
 # --- Scenario 4: pattern-level regression — a helper-consuming function that
@@ -68,23 +76,80 @@ BROKEN_WRAPPER_OUTPUT=$(RUN_TMPDIR="" bash -c "
   }
   RESULT=\$(stdout_returning_fn)
   RC=\$?
-  echo \"RESULT=[\$RESULT] RC=\$RC OUTER_UNREACHABLE_MARKER\"
+  echo \"RC_WAS=[\$RC] RESULT=[\$RESULT] RC=\$RC OUTER_UNREACHABLE_MARKER\"
 " 2>&1)
 assert_contains "OUTER_UNREACHABLE_MARKER" "$BROKEN_WRAPPER_OUTPUT" "confirms the vulnerable shape: a stdout-returning wrapper lets the caller's script continue past a failed guard (RESULT=[] silently)"
 assert_contains "RESULT=[]" "$BROKEN_WRAPPER_OUTPUT" "confirms the vulnerable shape: the caller receives an empty result instead of the process dying"
+assert_contains "RC_WAS=[2]" "$BROKEN_WRAPPER_OUTPUT" "confirms the failure info WAS available via \$? (the guard's exit 2 propagated to the assignment) — the danger is that nothing checked it, not that it was lost"
 
 OUTVAR_WRAPPER_OUTPUT=$(RUN_TMPDIR="" bash -c "
   source '$ASSERT_LIB_ABS'
   outvar_returning_fn() {
     local __outvar=\"\$1\" _d
     _dossier_require_mktemp_dir _d 'wrapper-fixed'
-    printf -v \"\$__outvar\" '%s' \"\$_d\"
+    _dossier_assign_outvar \"\$__outvar\" \"\$_d\"
   }
   outvar_returning_fn RESULT
   echo \"OUTER_UNREACHABLE_MARKER RESULT=[\$RESULT]\"
 " 2>&1)
 OUTVAR_WRAPPER_RC=$?
-assert_exit "2" "$OUTVAR_WRAPPER_RC" "the fixed shape (out-parameter via printf -v, called as a plain statement) correctly propagates exit 2 through the wrapper"
+assert_exit "2" "$OUTVAR_WRAPPER_RC" "the fixed shape (out-parameter via _dossier_assign_outvar, called as a plain statement) correctly propagates exit 2 through the wrapper"
 assert_not_contains "OUTER_UNREACHABLE_MARKER" "$OUTVAR_WRAPPER_OUTPUT" "the fixed shape never reaches the caller's next line when the guard fires inside the wrapper"
+
+# --- Scenario 5: regression — a wrapper's own final assignment must be
+# guarded too, not just the mktemp-dir lookup it wraps. A bare `printf -v`
+# (bypassing _dossier_assign_outvar) can itself fail silently on a bad
+# identifier and, under this suite's `set -uo pipefail` (no `-e`), the
+# caller would continue past it with the target var never set — the same
+# swallowed-failure shape this whole file exists to close, one line lower.
+BAD_OUTVAR_OUTPUT=$(bash -c "
+  source '$ASSERT_LIB_ABS'
+  wrapper_with_guarded_assign() {
+    local __outvar=\"\$1\"
+    _dossier_assign_outvar \"\$__outvar\" 'some-value'
+  }
+  wrapper_with_guarded_assign '1bad-identifier'
+  echo OUTER_UNREACHABLE_MARKER
+" 2>&1)
+BAD_OUTVAR_RC=$?
+assert_exit "2" "$BAD_OUTVAR_RC" "_dossier_assign_outvar hard-aborts (exit 2) on an invalid target identifier, rather than letting printf -v fail silently"
+assert_not_contains "OUTER_UNREACHABLE_MARKER" "$BAD_OUTVAR_OUTPUT" "control flow never reaches past a failed outvar assignment"
+
+# --- Scenario 6: static lint — no *.test.sh file may define a function that
+# calls the guard internally and is ALSO invoked via `$(...)`/backticks
+# anywhere in that file. Scenario 4 regression-tests the pattern generically
+# but is bound to two synthetic stand-ins, not the real functions — this
+# scenario is what actually stops a FUTURE helper (or a reversion of
+# no_gh_path/setup_fixture) from silently reopening issue #149's bug class.
+# Pure awk/grep, no python dependency (matches this suite's own toolset).
+TESTS_DIR_ABS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LINT_VIOLATIONS=""
+for LINT_FILE in "$TESTS_DIR_ABS"/*.test.sh; do
+  GUARD_FUNCS=$(awk '
+    /^[A-Za-z_][A-Za-z0-9_]*\(\)[[:space:]]*\{[[:space:]]*$/ {
+      match($0, /^[A-Za-z_][A-Za-z0-9_]*/)
+      fname = substr($0, RSTART, RLENGTH)
+      in_func = 1
+      has_guard = 0
+      next
+    }
+    in_func && /_dossier_require_mktemp_dir|_dossier_assign_outvar/ { has_guard = 1 }
+    in_func && /^\}[[:space:]]*$/ {
+      if (has_guard) print fname
+      in_func = 0
+      next
+    }
+  ' "$LINT_FILE")
+  [ -n "$GUARD_FUNCS" ] || continue
+  while IFS= read -r LINT_FNAME; do
+    [ -n "$LINT_FNAME" ] || continue
+    if grep -vE '^\s*#' "$LINT_FILE" | grep -qE "(^|[^A-Za-z0-9_])\\\$\\(\\s*${LINT_FNAME}([[:space:]]|\\))|\`\\s*${LINT_FNAME}([[:space:]]|\`)"; then
+      LINT_VIOLATIONS="${LINT_VIOLATIONS}${LINT_FILE##*/}:${LINT_FNAME} "
+    fi
+  done <<EOF
+$GUARD_FUNCS
+EOF
+done
+assert_equal "" "$LINT_VIOLATIONS" "static lint: no guard-consuming function anywhere in plugins/dossier/tests/*.test.sh is invoked via \$(...)/backticks (violations: ${LINT_VIOLATIONS:-none})"
 
 _dossier_test_summary

--- a/plugins/dossier/tests/quality-scan-execution.test.sh
+++ b/plugins/dossier/tests/quality-scan-execution.test.sh
@@ -21,7 +21,7 @@ fi
 # is off, proven with a tripwire binary: a fake `pyscn` on PATH that writes
 # a marker file if ever executed.
 # =============================================================================
-DIR_DISABLED=$(_dossier_safe_mktemp_dir "disabled")
+_dossier_require_mktemp_dir DIR_DISABLED "disabled"
 mkdir -p "$DIR_DISABLED/target" "$DIR_DISABLED/tripwire-bin"
 printf 'def f():\n    pass\n' >"$DIR_DISABLED/target/mod.py"
 TRIPWIRE_MARKER="$DIR_DISABLED/pyscn-was-invoked"
@@ -71,7 +71,7 @@ assert_equal "unavailable" "$STATUS_NOTOOL" "tool-unavailable: distinct status, 
 # created), so this must never read as a clean zero-issues result.
 # =============================================================================
 if command -v pyscn >/dev/null 2>&1; then
-  DIR_NOPY=$(_dossier_safe_mktemp_dir "no-python-files")
+  _dossier_require_mktemp_dir DIR_NOPY "no-python-files"
   mkdir -p "$DIR_NOPY/target"
   printf 'hello\n' >"$DIR_NOPY/target/readme.txt"
   OUT_NOPY=$(DOSSIER_ENGAGEMENT_ALLOWED_ACTIONS_RUN_CODE_QUALITY_SCAN=true CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
@@ -89,7 +89,7 @@ fi
 # verify the tool process is ACTUALLY killed, not merely that the wrapper
 # reports "timeout" while the real process leaks on, orphaned.
 # =============================================================================
-DIR_TIMEOUT=$(_dossier_safe_mktemp_dir "timeout")
+_dossier_require_mktemp_dir DIR_TIMEOUT "timeout"
 mkdir -p "$DIR_TIMEOUT/fakebin" "$DIR_TIMEOUT/target"
 printf 'def f():\n    pass\n' >"$DIR_TIMEOUT/target/mod.py"
 TIMEOUT_PID_MARKER="$DIR_TIMEOUT/pyscn.pid"
@@ -135,7 +135,7 @@ fi
 # honest, NAMED skip locally when the tool is absent; CI installs it.
 # =============================================================================
 if command -v pyscn >/dev/null 2>&1; then
-  DIR_E2E=$(_dossier_safe_mktemp_dir "ac2-e2e")
+  _dossier_require_mktemp_dir DIR_E2E "ac2-e2e"
   mkdir -p "$DIR_E2E/target" "$DIR_E2E/out"
   cat >"$DIR_E2E/target/bad.py" <<'EOF'
 def unreachable_after_return(x):
@@ -193,7 +193,7 @@ fi
 # never return a stale (first-run) artifact on the second run.
 # =============================================================================
 if command -v pyscn >/dev/null 2>&1; then
-  DIR_RERUN=$(_dossier_safe_mktemp_dir "rerun")
+  _dossier_require_mktemp_dir DIR_RERUN "rerun"
   mkdir -p "$DIR_RERUN/target" "$DIR_RERUN/out"
   printf 'def f():\n    pass\n' >"$DIR_RERUN/target/mod.py"
   DOSSIER_ENGAGEMENT_ALLOWED_ACTIONS_RUN_CODE_QUALITY_SCAN=true CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
@@ -236,7 +236,7 @@ assert_equal "disabled" "$STATUS_CROSSFLAG" "AC3: runSecurityScan=true alone nev
 # =============================================================================
 SECURITY_SCRIPT="$(pwd)/plugins/dossier/bin/dossier-scan-security.sh"
 if [ -x "$SECURITY_SCRIPT" ]; then
-  DIR_JOINT=$(_dossier_safe_mktemp_dir "ac3-joint")
+  _dossier_require_mktemp_dir DIR_JOINT "ac3-joint"
   mkdir -p "$DIR_JOINT/sec-target" "$DIR_JOINT/qual-target"
   printf 'def f():\n    pass\n' >"$DIR_JOINT/qual-target/mod.py"
 
@@ -270,7 +270,7 @@ assert_equal "2" "$?" "exits 2 on an unrecognized flag"
 # can't be written. --out is a path nested UNDER A PLAIN FILE, guaranteeing
 # mkdir -p fails structurally.
 # =============================================================================
-DIR_OUTFAIL=$(_dossier_safe_mktemp_dir "out-write-failure")
+_dossier_require_mktemp_dir DIR_OUTFAIL "out-write-failure"
 mkdir -p "$DIR_OUTFAIL/target"
 printf 'not a directory\n' >"$DIR_OUTFAIL/blocker"
 OUT_OUTFAIL=$(CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" "$SCRIPT" --target "$DIR_OUTFAIL/target" --out "$DIR_OUTFAIL/blocker/nested" 2>/dev/null)
@@ -288,7 +288,7 @@ assert_contains "could not create --out directory" "$STDERR_OUTFAIL" "--out unde
 # disabling the poll loop's own timeout enforcement. A stub that runs for
 # ~2 real seconds forces the loop to iterate at least once.
 # =============================================================================
-DIR_BADTIMEOUT=$(_dossier_safe_mktemp_dir "bad-timeout-env")
+_dossier_require_mktemp_dir DIR_BADTIMEOUT "bad-timeout-env"
 mkdir -p "$DIR_BADTIMEOUT/fakebin" "$DIR_BADTIMEOUT/target"
 printf 'def f():\n    pass\n' >"$DIR_BADTIMEOUT/target/mod.py"
 cat >"$DIR_BADTIMEOUT/fakebin/pyscn" <<'EOF'
@@ -307,7 +307,7 @@ assert_not_contains "integer expression expected" "$STDERR_BADTIMEOUT" "a non-nu
 # closed branches that were already correct but untested.
 # =============================================================================
 # A plain FILE as --target is an explicit error, never a clean result.
-DIR_FILETARGET=$(_dossier_safe_mktemp_dir "file-as-target")
+_dossier_require_mktemp_dir DIR_FILETARGET "file-as-target"
 printf 'not a directory\n' >"$DIR_FILETARGET/plainfile"
 OUT_FILETARGET=$(DOSSIER_ENGAGEMENT_ALLOWED_ACTIONS_RUN_CODE_QUALITY_SCAN=true CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
   "$SCRIPT" --target "$DIR_FILETARGET/plainfile" 2>&1)
@@ -317,7 +317,7 @@ assert_equal "error" "$STATUS_FILETARGET" "a plain file as --target (not a direc
 # A readable-but-not-enterable directory (r--, no x). Skipped when the test
 # runner itself is root, which bypasses directory permission checks.
 if [ "$(id -u)" != "0" ]; then
-  DIR_NOEXEC_PARENT=$(_dossier_safe_mktemp_dir "noexec-target")
+  _dossier_require_mktemp_dir DIR_NOEXEC_PARENT "noexec-target"
   mkdir -p "$DIR_NOEXEC_PARENT/locked"
   chmod 644 "$DIR_NOEXEC_PARENT/locked"
   OUT_NOEXEC=$(DOSSIER_ENGAGEMENT_ALLOWED_ACTIONS_RUN_CODE_QUALITY_SCAN=true CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
@@ -331,7 +331,7 @@ fi
 
 # pyscn producing a report file that isn't valid JSON (distinct from
 # "produced no report file at all", which is already covered elsewhere).
-DIR_MALFORMED=$(_dossier_safe_mktemp_dir "malformed-report")
+_dossier_require_mktemp_dir DIR_MALFORMED "malformed-report"
 mkdir -p "$DIR_MALFORMED/fakebin" "$DIR_MALFORMED/target"
 printf 'def f():\n    pass\n' >"$DIR_MALFORMED/target/mod.py"
 cat >"$DIR_MALFORMED/fakebin/pyscn" <<'EOF'

--- a/plugins/dossier/tests/refresh-staleness.test.sh
+++ b/plugins/dossier/tests/refresh-staleness.test.sh
@@ -24,7 +24,7 @@ if [ ! -x "$EVIDENCE_SCRIPT" ]; then
 fi
 
 # --- dossier-evidence.sh --stale-docs -> manifest.json stale_docs ----------
-FIXTURE=$(_dossier_safe_mktemp_dir "refresh-staleness")
+_dossier_require_mktemp_dir FIXTURE "refresh-staleness"
 (
   cd "$FIXTURE" || exit 1
   git init -q
@@ -80,7 +80,7 @@ EOF
 # Same technique as staleness-trigger.test.sh's ERR-3 case: a real sibling-
 # script copy with only dossier-staleness-check.sh swapped for a script that
 # always fails, entirely inside an isolated fixture.
-ERR_ROOT=$(_dossier_safe_mktemp_dir "evidence-staleness-failure")
+_dossier_require_mktemp_dir ERR_ROOT "evidence-staleness-failure"
 mkdir -p "$ERR_ROOT/bin"
 cp "$(pwd)/plugins/dossier/bin/"*.sh "$ERR_ROOT/bin/"
 cat >"$ERR_ROOT/bin/dossier-staleness-check.sh" <<'FAKE'

--- a/plugins/dossier/tests/rotation-check.test.sh
+++ b/plugins/dossier/tests/rotation-check.test.sh
@@ -34,7 +34,17 @@ future_offset() { date -u -d "+$1 days" +%Y-%m-%d 2>/dev/null || date -u -v+"$1"
 # Filtering at the file level via a symlinked stand-in directory keeps the
 # helper's stated intent ("keeping every other tool resolvable") true on
 # both platforms.
+# no_gh_path <outvar> — assigns into $outvar via printf -v and must be
+# called as a plain statement (`no_gh_path OUT`, never `OUT=$(no_gh_path)`).
+# It calls _dossier_require_mktemp_dir internally, whose exit-2-on-failure
+# only propagates through the caller's real shell when no `$(...)` boundary
+# sits between this function and the script that invokes it — a stdout-
+# returning version (`printf '%s' "$_out"`, meant for `$(no_gh_path)`) would
+# run the ENTIRE function inside the subshell that command substitution
+# forks, silently swallowing the guard's abort one level up (see issue #149
+# review; mktemp-guard.test.sh scenario 4 regression-tests this pattern).
 no_gh_path() {
+  local __outvar="$1"
   OLD_IFS="$IFS"; IFS=':'
   _out=""
   for _dir in $PATH; do
@@ -54,7 +64,7 @@ no_gh_path() {
     fi
   done
   IFS="$OLD_IFS"
-  printf '%s' "$_out"
+  printf -v "$__outvar" '%s' "$_out"
 }
 
 # Builds a bare "origin" remote + a working clone, with dossier plugin bin
@@ -62,8 +72,13 @@ no_gh_path() {
 # dir masquerading as one) because the script's own exit-code semantics
 # (git ls-remote --exit-code 0 vs 2 vs 128) require an actual remote to
 # exercise realistically.
+#
+# setup_fixture <outvar> — assigns the clone path into $outvar via printf -v
+# and must be called as a plain statement (`setup_fixture OUT`, never
+# `OUT=$(setup_fixture)`) — see no_gh_path's comment above for why a
+# stdout-returning version would swallow _dossier_require_mktemp_dir's guard.
 setup_fixture() {
-  local _fixture
+  local __outvar="$1" _fixture
   _dossier_require_mktemp_dir _fixture "rotation-fixture"
   _bare="$_fixture/origin.git"
   _clone="$_fixture/clone"
@@ -79,7 +94,7 @@ setup_fixture() {
     git push -q origin HEAD:refs/heads/main
     git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
   ) >/dev/null 2>&1
-  printf '%s' "$_clone"
+  printf -v "$__outvar" '%s' "$_clone"
 }
 
 # Adds $N commits to $DOCS_BRANCH (created from main if absent), each carrying
@@ -110,7 +125,7 @@ push_docs_branch_commit() {
 # =============================================================================
 # 1. No-branch cold start
 # =============================================================================
-F1=$(setup_fixture)
+setup_fixture F1
 _dossier_require_mktemp_dir SUMMARY1_DIR "rotation-summary1"
 SUMMARY1="$SUMMARY1_DIR/summary.md"
 OUT1=$(cd "$F1" && env CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier "$SCRIPT" --summary "$SUMMARY1" 2>&1)
@@ -127,7 +142,7 @@ assert_contains "does not exist yet" "$(get "$OUT1" reason)" "no-branch cold sta
 # 2. Policy=none, branch exists with a real diff — metrics still emitted
 #    (this is the AC4 assertion: metrics flow regardless of policy)
 # =============================================================================
-F2=$(setup_fixture)
+setup_fixture F2
 push_docs_branch_commit "$F2" "docs/dossier" "$(day_offset 3)" "insert-only content line one"
 push_docs_branch_commit "$F2" "docs/dossier" "$(day_offset 1)" "insert-only content line two"
 OUT2=$(cd "$F2" && env CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=none "$SCRIPT" 2>&1)
@@ -158,7 +173,7 @@ assert_equal "branch_commits" "$(get "$OUT2" age_source)" "policy=none: age_sour
 # =============================================================================
 # 3. Would-rotate via age (gh stub returns an old open PR)
 # =============================================================================
-F3=$(setup_fixture)
+setup_fixture F3
 push_docs_branch_commit "$F3" "docs/dossier" "$(day_offset 10)"
 _dossier_require_mktemp_dir STUB3 "gh-stub-old-pr"
 cat > "$STUB3/gh" <<EOF
@@ -177,7 +192,7 @@ assert_contains "age" "$(get "$OUT3" reason)" "would-rotate via age: reason cite
 # =============================================================================
 # 4. Would-not-rotate (gh stub, recent PR, small diff)
 # =============================================================================
-F4=$(setup_fixture)
+setup_fixture F4
 push_docs_branch_commit "$F4" "docs/dossier" "$(day_offset 1)"
 _dossier_require_mktemp_dir STUB4 "gh-stub-recent-pr"
 cat > "$STUB4/gh" <<EOF
@@ -195,9 +210,9 @@ assert_equal "pr_created_at" "$(get "$OUT4" age_source)" "would-not-rotate: age_
 # =============================================================================
 # 5. Degraded gh-unavailable, would-rotate via commit age (monthly policy)
 # =============================================================================
-F5=$(setup_fixture)
+setup_fixture F5
 push_docs_branch_commit "$F5" "docs/dossier" "$(day_offset 40)"
-NOGH_PATH5=$(no_gh_path)
+no_gh_path NOGH_PATH5
 _dossier_require_mktemp_dir SUMMARY5_DIR "rotation-summary5"
 SUMMARY5="$SUMMARY5_DIR/summary.md"
 OUT5=$(cd "$F5" && env PATH="$NOGH_PATH5" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=monthly "$SCRIPT" --summary "$SUMMARY5" 2>&1)
@@ -215,7 +230,7 @@ fi
 # 6. Would-rotate via size alone (no gh, no Dossier-Generated commits at all
 #    for age, but a large diff)
 # =============================================================================
-F6=$(setup_fixture)
+setup_fixture F6
 # Push a branch with a commit that is NOT Dossier-Generated, so age_source
 # ends up unknown, while still producing a large diff to trigger on size.
 (
@@ -233,7 +248,7 @@ F6=$(setup_fixture)
   git push -q origin docs/dossier
   git checkout -q main
 ) >/dev/null 2>&1
-NOGH_PATH6=$(no_gh_path)
+no_gh_path NOGH_PATH6
 OUT6=$(cd "$F6" && env PATH="$NOGH_PATH6" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=monthly DOSSIER_CI_THRESHOLDS_ROTATION_MAX_ACCUMULATED_LINES=100 "$SCRIPT" 2>&1)
 RC6=$?
 assert_equal "0" "$RC6" "would-rotate via size alone: exits 0"
@@ -250,7 +265,7 @@ assert_contains "accumulated" "$(get "$OUT6" reason)" "would-rotate via size alo
 #     does not trigger. Regression test for the P1 finding on rotation-check
 #     issue #138 review (dossier-rotation-check.sh:324).
 # =============================================================================
-F6B=$(setup_fixture)
+setup_fixture F6B
 (
   cd "$F6B" || exit 1
   git checkout -q -B docs/dossier origin/main
@@ -262,7 +277,7 @@ F6B=$(setup_fixture)
   git push -q origin docs/dossier
   git checkout -q main
 ) >/dev/null 2>&1
-NOGH_PATH6B=$(no_gh_path)
+no_gh_path NOGH_PATH6B
 OUT6B=$(cd "$F6B" && env PATH="$NOGH_PATH6B" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=weekly DOSSIER_CI_THRESHOLDS_ROTATION_MAX_ACCUMULATED_LINES=5000 "$SCRIPT" 2>&1)
 RC6B=$?
 assert_equal "0" "$RC6B" "age unknown + size under threshold: exits 0"
@@ -281,13 +296,13 @@ assert_contains "age is unavailable" "$REASON6B" "age unknown + size under thres
 # =============================================================================
 # 7. Both unknown -> the literal string "unknown", never coerced to false
 # =============================================================================
-F7=$(setup_fixture)
+setup_fixture F7
 push_docs_branch_commit "$F7" "docs/dossier" "$(day_offset 5)"
 (
   cd "$F7" || exit 1
   git remote set-url origin /nonexistent/path/that/does/not/exist.git
 ) >/dev/null 2>&1
-NOGH_PATH7=$(no_gh_path)
+no_gh_path NOGH_PATH7
 _dossier_require_mktemp_dir SUMMARY7_DIR "rotation-summary7"
 SUMMARY7="$SUMMARY7_DIR/summary.md"
 OUT7=$(cd "$F7" && env PATH="$NOGH_PATH7" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=weekly "$SCRIPT" --summary "$SUMMARY7" 2>&1)
@@ -304,7 +319,7 @@ fi
 # =============================================================================
 # 8. Malformed threshold config falls back to the documented default (5000)
 # =============================================================================
-F8=$(setup_fixture)
+setup_fixture F8
 (
   cd "$F8" || exit 1
   git checkout -q -B docs/dossier origin/main
@@ -319,7 +334,7 @@ F8=$(setup_fixture)
   git push -q origin docs/dossier
   git checkout -q main
 ) >/dev/null 2>&1
-NOGH_PATH8=$(no_gh_path)
+no_gh_path NOGH_PATH8
 OUT8=$(cd "$F8" && env PATH="$NOGH_PATH8" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=monthly DOSSIER_CI_THRESHOLDS_ROTATION_MAX_ACCUMULATED_LINES=not-a-number "$SCRIPT" 2>&1)
 RC8=$?
 assert_equal "0" "$RC8" "malformed threshold: exits 0"
@@ -328,7 +343,7 @@ assert_equal "true" "$(get "$OUT8" would_rotate)" "malformed threshold: would_ro
 # =============================================================================
 # 9. --shortstat parsing: insertions-only and deletions-only diffs
 # =============================================================================
-F9=$(setup_fixture)
+setup_fixture F9
 (
   cd "$F9" || exit 1
   git checkout -q -B docs/dossier origin/main
@@ -341,7 +356,7 @@ F9=$(setup_fixture)
   git push -q origin docs/dossier
   git checkout -q main
 ) >/dev/null 2>&1
-NOGH_PATH9=$(no_gh_path)
+no_gh_path NOGH_PATH9
 OUT9=$(cd "$F9" && env PATH="$NOGH_PATH9" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=none "$SCRIPT" 2>&1)
 ACC_LINES9=$(get "$OUT9" accumulated_lines)
 if [ -n "$ACC_LINES9" ] && [ "$ACC_LINES9" -eq 2 ] 2>/dev/null; then
@@ -379,7 +394,7 @@ assert_contains "not inside a git repository" "$OUT_NOTGIT" "run outside a git r
 #     rotation (via size); an unguarded empty override must not silently
 #     make it invisible. Regression test for a review finding (ERR-1).
 # =============================================================================
-F12=$(setup_fixture)
+setup_fixture F12
 (
   cd "$F12" || exit 1
   git checkout -q -B docs/dossier origin/main
@@ -396,7 +411,7 @@ F12=$(setup_fixture)
   git push -q origin docs/dossier
   git checkout -q main
 ) >/dev/null 2>&1
-NOGH_PATH12=$(no_gh_path)
+no_gh_path NOGH_PATH12
 OUT12=$(cd "$F12" && env PATH="$NOGH_PATH12" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH="" DOSSIER_CI_ROLLING_BRANCH_ROTATION=monthly DOSSIER_CI_THRESHOLDS_ROTATION_MAX_ACCUMULATED_LINES=100 "$SCRIPT" 2>&1)
 RC12=$?
 assert_equal "0" "$RC12" "empty DOSSIER_CI_ROLLING_BRANCH: exits 0"
@@ -414,7 +429,7 @@ assert_equal "false" "$(get "$OUT12B" would_rotate)" "empty DOSSIER_CI_ROLLING_B
 #     summary's markdown table or inject a spoofed extra row. Regression
 #     test for a review finding (SEC-1).
 # =============================================================================
-F13=$(setup_fixture)
+setup_fixture F13
 WEIRD_BRANCH='docs/dossier`|evil'
 _dossier_require_mktemp_dir SUMMARY13_DIR "rotation-summary13"
 SUMMARY13="$SUMMARY13_DIR/summary.md"
@@ -435,7 +450,7 @@ assert_equal "9" "$TABLE_ROW_COUNT13" "branch name with backtick/pipe: exactly t
 #     PR found" and must not abort the run — regression test for a review
 #     finding (ERR-3): previously claimed fixed but never covered by a test.
 # =============================================================================
-F14=$(setup_fixture)
+setup_fixture F14
 push_docs_branch_commit "$F14" "docs/dossier" "$(day_offset 10)"
 _dossier_require_mktemp_dir STUB14 "gh-stub-list-fails"
 cat > "$STUB14/gh" <<'EOF'
@@ -461,9 +476,9 @@ fi
 #     unconditionally (0 <= any non-negative line count is always true) --
 #     regression test for a review finding (F1/CONV1), reproduced live.
 # =============================================================================
-F15=$(setup_fixture)
+setup_fixture F15
 push_docs_branch_commit "$F15" "docs/dossier" "$(day_offset 1)"
-NOGH_PATH15=$(no_gh_path)
+no_gh_path NOGH_PATH15
 OUT15=$(cd "$F15" && env PATH="$NOGH_PATH15" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=weekly DOSSIER_CI_THRESHOLDS_ROTATION_MAX_ACCUMULATED_LINES=0 "$SCRIPT" 2>&1)
 RC15=$?
 assert_equal "0" "$RC15" "zero size threshold: exits 0"
@@ -474,7 +489,7 @@ assert_equal "false" "$(get "$OUT15" would_rotate)" "zero size threshold: falls 
 #     age_days alongside a reason claiming age is unavailable -- regression
 #     test for a review finding (AgeDaysNegative/ERR-3/ERR-4).
 # =============================================================================
-F16=$(setup_fixture)
+setup_fixture F16
 push_docs_branch_commit "$F16" "docs/dossier" "$(day_offset 1)"
 _dossier_require_mktemp_dir STUB16 "gh-stub-future-pr"
 cat > "$STUB16/gh" <<EOF
@@ -498,7 +513,7 @@ assert_contains "unavailable" "$(get "$OUT16" reason)" "future-dated PR createdA
 #     via a stub that actually applies gh's --jq filter (real `gh` behavior),
 #     not just a fixed echo like the other gh stubs in this file.
 # =============================================================================
-F17=$(setup_fixture)
+setup_fixture F17
 push_docs_branch_commit "$F17" "docs/dossier" "$(day_offset 10)"
 _dossier_require_mktemp_dir STUB17 "gh-stub-cross-repo"
 STUB17_JSON="[{\"number\":13,\"createdAt\":\"$(day_offset 1)T00:00:00Z\",\"isCrossRepository\":true},{\"number\":7,\"createdAt\":\"$(day_offset 10)T00:00:00Z\",\"isCrossRepository\":false}]"
@@ -536,7 +551,7 @@ assert_equal "pr_created_at" "$(get "$OUT17" age_source)" "cross-repository deco
 #     directly on a macOS dev machine -- this reproduces the same downstream
 #     failure, $CASCADE exiting 2, by the most portable available means).
 # =============================================================================
-F18=$(setup_fixture)
+setup_fixture F18
 REAL_MKTEMP=$(command -v mktemp)
 _dossier_require_mktemp_dir STUB18 "mktemp-stub-cascade-fail"
 cat > "$STUB18/mktemp" <<STUBEOF
@@ -564,9 +579,9 @@ assert_not_contains "would_rotate=false" "$OUT18" "config resolver infra failure
 #     SEC-1/verifier: note() didn't neutralize markdown link/bold/heading
 #     syntax the way table cells already do).
 # =============================================================================
-F19=$(setup_fixture)
+setup_fixture F19
 push_docs_branch_commit "$F19" "docs/dossier" "$(day_offset 1)"
-NOGH_PATH19=$(no_gh_path)
+no_gh_path NOGH_PATH19
 _dossier_require_mktemp_dir SUMMARY19_DIR "rotation-summary19"
 SUMMARY19="$SUMMARY19_DIR/summary.md"
 WEIRD_POLICY='biweekly [click here](https://evil.example)'
@@ -599,8 +614,8 @@ fi
 #     later CI step to read) had no test at all -- regression test for a
 #     review finding (TEST2, raised independently by both review lenses).
 # =============================================================================
-F20=$(setup_fixture)
-NOGH_PATH20=$(no_gh_path)
+setup_fixture F20
+no_gh_path NOGH_PATH20
 _dossier_require_mktemp_dir GHOUT20_DIR "rotation-ghout20"
 GHOUT20="$GHOUT20_DIR/github_output"
 : > "$GHOUT20"

--- a/plugins/dossier/tests/rotation-check.test.sh
+++ b/plugins/dossier/tests/rotation-check.test.sh
@@ -40,7 +40,8 @@ no_gh_path() {
   for _dir in $PATH; do
     [ -n "$_dir" ] || continue
     if [ -x "$_dir/gh" ]; then
-      _filtered=$(_dossier_safe_mktemp_dir "no-gh-filtered")
+      local _filtered
+      _dossier_require_mktemp_dir _filtered "no-gh-filtered"
       for _entry in "$_dir"/*; do
         [ -e "$_entry" ] || continue
         _base=$(basename "$_entry")
@@ -62,7 +63,8 @@ no_gh_path() {
 # (git ls-remote --exit-code 0 vs 2 vs 128) require an actual remote to
 # exercise realistically.
 setup_fixture() {
-  _fixture=$(_dossier_safe_mktemp_dir "rotation-fixture")
+  local _fixture
+  _dossier_require_mktemp_dir _fixture "rotation-fixture"
   _bare="$_fixture/origin.git"
   _clone="$_fixture/clone"
   git init -q --bare "$_bare"
@@ -109,7 +111,8 @@ push_docs_branch_commit() {
 # 1. No-branch cold start
 # =============================================================================
 F1=$(setup_fixture)
-SUMMARY1=$(_dossier_safe_mktemp_dir "rotation-summary1")/summary.md
+_dossier_require_mktemp_dir SUMMARY1_DIR "rotation-summary1"
+SUMMARY1="$SUMMARY1_DIR/summary.md"
 OUT1=$(cd "$F1" && env CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier "$SCRIPT" --summary "$SUMMARY1" 2>&1)
 RC1=$?
 assert_equal "0" "$RC1" "no-branch cold start: exits 0 (a reached decision, not an infra failure)"
@@ -157,7 +160,7 @@ assert_equal "branch_commits" "$(get "$OUT2" age_source)" "policy=none: age_sour
 # =============================================================================
 F3=$(setup_fixture)
 push_docs_branch_commit "$F3" "docs/dossier" "$(day_offset 10)"
-STUB3=$(_dossier_safe_mktemp_dir "gh-stub-old-pr")
+_dossier_require_mktemp_dir STUB3 "gh-stub-old-pr"
 cat > "$STUB3/gh" <<EOF
 #!/usr/bin/env bash
 echo '{"number":42,"createdAt":"$(day_offset 10)T00:00:00Z"}'
@@ -176,7 +179,7 @@ assert_contains "age" "$(get "$OUT3" reason)" "would-rotate via age: reason cite
 # =============================================================================
 F4=$(setup_fixture)
 push_docs_branch_commit "$F4" "docs/dossier" "$(day_offset 1)"
-STUB4=$(_dossier_safe_mktemp_dir "gh-stub-recent-pr")
+_dossier_require_mktemp_dir STUB4 "gh-stub-recent-pr"
 cat > "$STUB4/gh" <<EOF
 #!/usr/bin/env bash
 echo '{"number":7,"createdAt":"$(day_offset 1)T00:00:00Z"}'
@@ -195,7 +198,8 @@ assert_equal "pr_created_at" "$(get "$OUT4" age_source)" "would-not-rotate: age_
 F5=$(setup_fixture)
 push_docs_branch_commit "$F5" "docs/dossier" "$(day_offset 40)"
 NOGH_PATH5=$(no_gh_path)
-SUMMARY5=$(_dossier_safe_mktemp_dir "rotation-summary5")/summary.md
+_dossier_require_mktemp_dir SUMMARY5_DIR "rotation-summary5"
+SUMMARY5="$SUMMARY5_DIR/summary.md"
 OUT5=$(cd "$F5" && env PATH="$NOGH_PATH5" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=monthly "$SCRIPT" --summary "$SUMMARY5" 2>&1)
 RC5=$?
 assert_equal "0" "$RC5" "degraded gh-unavailable via commit age: exits 0"
@@ -284,7 +288,8 @@ push_docs_branch_commit "$F7" "docs/dossier" "$(day_offset 5)"
   git remote set-url origin /nonexistent/path/that/does/not/exist.git
 ) >/dev/null 2>&1
 NOGH_PATH7=$(no_gh_path)
-SUMMARY7=$(_dossier_safe_mktemp_dir "rotation-summary7")/summary.md
+_dossier_require_mktemp_dir SUMMARY7_DIR "rotation-summary7"
+SUMMARY7="$SUMMARY7_DIR/summary.md"
 OUT7=$(cd "$F7" && env PATH="$NOGH_PATH7" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=weekly "$SCRIPT" --summary "$SUMMARY7" 2>&1)
 RC7=$?
 assert_equal "0" "$RC7" "transport failure: still exits 0 (a data-availability failure, not an infra failure)"
@@ -351,7 +356,7 @@ fi
 "$SCRIPT" --nonexistent-flag >/dev/null 2>&1
 assert_equal "2" "$?" "unknown flag exits 2"
 
-NOTGIT=$(_dossier_safe_mktemp_dir "rotation-notgit")
+_dossier_require_mktemp_dir NOTGIT "rotation-notgit"
 OUT_NOTGIT=$(cd "$NOTGIT" && env CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" "$SCRIPT" 2>&1)
 RC_NOTGIT=$?
 assert_equal "1" "$RC_NOTGIT" "run outside a git repository exits 1 (infrastructure failure)"
@@ -411,7 +416,8 @@ assert_equal "false" "$(get "$OUT12B" would_rotate)" "empty DOSSIER_CI_ROLLING_B
 # =============================================================================
 F13=$(setup_fixture)
 WEIRD_BRANCH='docs/dossier`|evil'
-SUMMARY13=$(_dossier_safe_mktemp_dir "rotation-summary13")/summary.md
+_dossier_require_mktemp_dir SUMMARY13_DIR "rotation-summary13"
+SUMMARY13="$SUMMARY13_DIR/summary.md"
 OUT13=$(cd "$F13" && env CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH="$WEIRD_BRANCH" "$SCRIPT" --summary "$SUMMARY13" 2>&1)
 RC13=$?
 assert_equal "0" "$RC13" "branch name with backtick/pipe: still exits 0"
@@ -431,13 +437,14 @@ assert_equal "9" "$TABLE_ROW_COUNT13" "branch name with backtick/pipe: exactly t
 # =============================================================================
 F14=$(setup_fixture)
 push_docs_branch_commit "$F14" "docs/dossier" "$(day_offset 10)"
-STUB14=$(_dossier_safe_mktemp_dir "gh-stub-list-fails")
+_dossier_require_mktemp_dir STUB14 "gh-stub-list-fails"
 cat > "$STUB14/gh" <<'EOF'
 #!/usr/bin/env bash
 exit 1
 EOF
 chmod +x "$STUB14/gh"
-SUMMARY14=$(_dossier_safe_mktemp_dir "rotation-summary14")/summary.md
+_dossier_require_mktemp_dir SUMMARY14_DIR "rotation-summary14"
+SUMMARY14="$SUMMARY14_DIR/summary.md"
 OUT14=$(cd "$F14" && env PATH="$STUB14:$PATH" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION=weekly "$SCRIPT" --summary "$SUMMARY14" 2>&1)
 RC14=$?
 assert_equal "0" "$RC14" "gh pr list failure: still exits 0 (falls back to the commit-based age walk, not an infra failure)"
@@ -469,7 +476,7 @@ assert_equal "false" "$(get "$OUT15" would_rotate)" "zero size threshold: falls 
 # =============================================================================
 F16=$(setup_fixture)
 push_docs_branch_commit "$F16" "docs/dossier" "$(day_offset 1)"
-STUB16=$(_dossier_safe_mktemp_dir "gh-stub-future-pr")
+_dossier_require_mktemp_dir STUB16 "gh-stub-future-pr"
 cat > "$STUB16/gh" <<EOF
 #!/usr/bin/env bash
 echo '{"number":99,"createdAt":"$(future_offset 3)T00:00:00Z"}'
@@ -493,7 +500,7 @@ assert_contains "unavailable" "$(get "$OUT16" reason)" "future-dated PR createdA
 # =============================================================================
 F17=$(setup_fixture)
 push_docs_branch_commit "$F17" "docs/dossier" "$(day_offset 10)"
-STUB17=$(_dossier_safe_mktemp_dir "gh-stub-cross-repo")
+_dossier_require_mktemp_dir STUB17 "gh-stub-cross-repo"
 STUB17_JSON="[{\"number\":13,\"createdAt\":\"$(day_offset 1)T00:00:00Z\",\"isCrossRepository\":true},{\"number\":7,\"createdAt\":\"$(day_offset 10)T00:00:00Z\",\"isCrossRepository\":false}]"
 cat > "$STUB17/gh" <<STUBEOF
 #!/usr/bin/env bash
@@ -531,7 +538,7 @@ assert_equal "pr_created_at" "$(get "$OUT17" age_source)" "cross-repository deco
 # =============================================================================
 F18=$(setup_fixture)
 REAL_MKTEMP=$(command -v mktemp)
-STUB18=$(_dossier_safe_mktemp_dir "mktemp-stub-cascade-fail")
+_dossier_require_mktemp_dir STUB18 "mktemp-stub-cascade-fail"
 cat > "$STUB18/mktemp" <<STUBEOF
 #!/usr/bin/env bash
 for a in "\$@"; do
@@ -560,7 +567,8 @@ assert_not_contains "would_rotate=false" "$OUT18" "config resolver infra failure
 F19=$(setup_fixture)
 push_docs_branch_commit "$F19" "docs/dossier" "$(day_offset 1)"
 NOGH_PATH19=$(no_gh_path)
-SUMMARY19=$(_dossier_safe_mktemp_dir "rotation-summary19")/summary.md
+_dossier_require_mktemp_dir SUMMARY19_DIR "rotation-summary19"
+SUMMARY19="$SUMMARY19_DIR/summary.md"
 WEIRD_POLICY='biweekly [click here](https://evil.example)'
 OUT19=$(cd "$F19" && env PATH="$NOGH_PATH19" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier DOSSIER_CI_ROLLING_BRANCH_ROTATION="$WEIRD_POLICY" "$SCRIPT" --summary "$SUMMARY19" 2>&1)
 RC19=$?
@@ -593,7 +601,8 @@ fi
 # =============================================================================
 F20=$(setup_fixture)
 NOGH_PATH20=$(no_gh_path)
-GHOUT20=$(_dossier_safe_mktemp_dir "rotation-ghout20")/github_output
+_dossier_require_mktemp_dir GHOUT20_DIR "rotation-ghout20"
+GHOUT20="$GHOUT20_DIR/github_output"
 : > "$GHOUT20"
 INJECT_BRANCH='docs/dossier
 fake_output=INJECTED

--- a/plugins/dossier/tests/rotation-check.test.sh
+++ b/plugins/dossier/tests/rotation-check.test.sh
@@ -44,7 +44,7 @@ future_offset() { date -u -d "+$1 days" +%Y-%m-%d 2>/dev/null || date -u -v+"$1"
 # forks, silently swallowing the guard's abort one level up (see issue #149
 # review; mktemp-guard.test.sh scenario 4 regression-tests this pattern).
 no_gh_path() {
-  local __outvar="$1"
+  local __outvar="$1" OLD_IFS _out _dir _entry _base
   OLD_IFS="$IFS"; IFS=':'
   _out=""
   for _dir in $PATH; do
@@ -64,7 +64,7 @@ no_gh_path() {
     fi
   done
   IFS="$OLD_IFS"
-  printf -v "$__outvar" '%s' "$_out"
+  _dossier_assign_outvar "$__outvar" "$_out"
 }
 
 # Builds a bare "origin" remote + a working clone, with dossier plugin bin
@@ -78,7 +78,7 @@ no_gh_path() {
 # `OUT=$(setup_fixture)`) — see no_gh_path's comment above for why a
 # stdout-returning version would swallow _dossier_require_mktemp_dir's guard.
 setup_fixture() {
-  local __outvar="$1" _fixture
+  local __outvar="$1" _fixture _bare _clone
   _dossier_require_mktemp_dir _fixture "rotation-fixture"
   _bare="$_fixture/origin.git"
   _clone="$_fixture/clone"
@@ -94,7 +94,7 @@ setup_fixture() {
     git push -q origin HEAD:refs/heads/main
     git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
   ) >/dev/null 2>&1
-  printf -v "$__outvar" '%s' "$_clone"
+  _dossier_assign_outvar "$__outvar" "$_clone"
 }
 
 # Adds $N commits to $DOCS_BRANCH (created from main if absent), each carrying

--- a/plugins/dossier/tests/staleness-check.test.sh
+++ b/plugins/dossier/tests/staleness-check.test.sh
@@ -14,7 +14,7 @@ if [ ! -x "$SCRIPT" ]; then
   return 0 2>/dev/null || exit 0
 fi
 
-FIXTURE=$(_dossier_safe_mktemp_dir "staleness-check")
+_dossier_require_mktemp_dir FIXTURE "staleness-check"
 ARCH="$FIXTURE/docs/dossier/02-architecture"
 CONTROL="$FIXTURE/docs/dossier/00-control"
 mkdir -p "$ARCH" "$CONTROL"
@@ -177,7 +177,7 @@ assert_equal "true" "$(printf '%s\n' "$SF_ROLLOVER_FEB" | awk -F= '$1=="IS_UNDAT
 # Sweep mode must catch the same rollover — a document with only a rollover
 # date and nothing else planted in this fixture must count toward
 # DOCUMENTS_UNDATED, not silently vanish from every count.
-ROLLOVER_FIXTURE=$(_dossier_safe_mktemp_dir "staleness-rollover")
+_dossier_require_mktemp_dir ROLLOVER_FIXTURE "staleness-rollover"
 mkdir -p "$ROLLOVER_FIXTURE/docs/dossier/02-architecture"
 cat >"$ROLLOVER_FIXTURE/docs/dossier/02-architecture/system-architecture.md" <<EOF
 dossier-header: v1

--- a/plugins/dossier/tests/staleness-trigger.test.sh
+++ b/plugins/dossier/tests/staleness-trigger.test.sh
@@ -67,7 +67,7 @@ EOF
     git add -A
     git commit -q -m "watermark"
   ) >/dev/null 2>&1
-  printf -v "$__outvar" '%s' "$fixture"
+  _dossier_assign_outvar "$__outvar" "$fixture"
 }
 
 run_policy() {

--- a/plugins/dossier/tests/staleness-trigger.test.sh
+++ b/plugins/dossier/tests/staleness-trigger.test.sh
@@ -38,10 +38,16 @@ CANON_FIXTURE_DOCS='00-control/documentation-index.md
 02-architecture/interfaces-and-integrations.md
 02-architecture/infrastructure-and-deployment.md'
 
+# setup_fixture <outvar> <n> — assigns the fixture dir into $outvar via
+# printf -v and must be called as a plain statement (`setup_fixture OUT 1`,
+# never `OUT=$(setup_fixture 1)`) — a stdout-returning version would run
+# entirely inside the subshell $(...) forks for it, silently swallowing
+# _dossier_require_mktemp_dir's exit-2 guard one level up (issue #149
+# review; mktemp-guard.test.sh scenario 4 regression-tests this pattern).
 setup_fixture() {
-  # $1 = number of stale documents to plant (each independently past 90 days),
-  # drawn from CANON_FIXTURE_DOCS in order.
-  local n="$1" fixture rel i=1
+  # $1 = outvar, $2 = number of stale documents to plant (each independently
+  # past 90 days), drawn from CANON_FIXTURE_DOCS in order.
+  local __outvar="$1" n="$2" fixture rel i=1
   _dossier_require_mktemp_dir fixture "policy-stale"
   mkdir -p "$fixture/docs/dossier/00-control" "$fixture/docs/dossier/02-architecture"
   printf '%s\n' "$CANON_FIXTURE_DOCS" | head -n "$n" | while IFS= read -r rel; do
@@ -61,7 +67,7 @@ EOF
     git add -A
     git commit -q -m "watermark"
   ) >/dev/null 2>&1
-  printf '%s' "$fixture"
+  printf -v "$__outvar" '%s' "$fixture"
 }
 
 run_policy() {
@@ -75,7 +81,7 @@ run_policy() {
 get() { printf '%s\n' "$1" | awk -F= -v k="$2" '$1==k{sub(/^[^=]*=/,""); print; exit}'; }
 
 # --- One stale document, no other trigger, EVT=schedule ---------------------
-F1=$(setup_fixture 1)
+setup_fixture F1 1
 WM1=$(git -C "$F1" rev-parse HEAD)
 ( cd "$F1" && echo noise > random-file.txt && git add -A && git commit -q -m "irrelevant change" ) >/dev/null 2>&1
 
@@ -100,7 +106,7 @@ assert_equal "false" "$(get "$OUT_PR" should_run)" "staleness never overrides on
 assert_equal "no-relevant-paths" "$(get "$OUT_PR" reason)" "a non-schedule event keeps the original no-relevant-paths reason"
 
 # --- Many stale documents: the sweep is bounded, not unbounded (AC3) -------
-F2=$(setup_fixture 8)
+setup_fixture F2 8
 WM2=$(git -C "$F2" rev-parse HEAD)
 ( cd "$F2" && echo noise > random-file.txt && git add -A && git commit -q -m "irrelevant change" ) >/dev/null 2>&1
 
@@ -143,7 +149,7 @@ exit 2
 FAKE
 chmod +x "$ERR3_ROOT/bin"/*.sh
 
-F4=$(setup_fixture 1)
+setup_fixture F4 1
 WM4=$(git -C "$F4" rev-parse HEAD)
 ( cd "$F4" && echo noise > random-file.txt && git add -A && git commit -q -m "irrelevant change" ) >/dev/null 2>&1
 

--- a/plugins/dossier/tests/staleness-trigger.test.sh
+++ b/plugins/dossier/tests/staleness-trigger.test.sh
@@ -42,7 +42,7 @@ setup_fixture() {
   # $1 = number of stale documents to plant (each independently past 90 days),
   # drawn from CANON_FIXTURE_DOCS in order.
   local n="$1" fixture rel i=1
-  fixture=$(_dossier_safe_mktemp_dir "policy-stale")
+  _dossier_require_mktemp_dir fixture "policy-stale"
   mkdir -p "$fixture/docs/dossier/00-control" "$fixture/docs/dossier/02-architecture"
   printf '%s\n' "$CANON_FIXTURE_DOCS" | head -n "$n" | while IFS= read -r rel; do
     cat >"$fixture/docs/dossier/$rel" <<EOF
@@ -111,7 +111,7 @@ STALE_DOCS_COUNT=$(printf '%s' "$STALE_DOCS_FIELD" | tr ',' '\n' | grep -c .)
 assert_equal "3" "$STALE_DOCS_COUNT" "AC3: the stale_docs list is capped at maxStaleDocsPerSweep (3), not all 8"
 
 # --- No stale documents at all: schedule sweep behaves exactly as before ---
-F3=$(_dossier_safe_mktemp_dir "policy-fresh")
+_dossier_require_mktemp_dir F3 "policy-fresh"
 mkdir -p "$F3/docs/dossier/00-control" "$F3/docs/dossier/02-architecture"
 cat >"$F3/docs/dossier/02-architecture/system-architecture.md" <<EOF
 dossier-header: v1
@@ -133,7 +133,7 @@ assert_equal "no-relevant-paths" "$(get "$OUT_NOSTALE" reason)" "no stale docume
 # alongside it) with only dossier-staleness-check.sh swapped for a script that
 # always fails — entirely inside an isolated fixture, the real repo scripts
 # are never touched.
-ERR3_ROOT=$(_dossier_safe_mktemp_dir "policy-staleness-failure")
+_dossier_require_mktemp_dir ERR3_ROOT "policy-staleness-failure"
 mkdir -p "$ERR3_ROOT/bin"
 cp "$(pwd)/plugins/dossier/bin/"*.sh "$ERR3_ROOT/bin/"
 cat >"$ERR3_ROOT/bin/dossier-staleness-check.sh" <<'FAKE'

--- a/plugins/dossier/tests/vuln-evidence-gate.test.sh
+++ b/plugins/dossier/tests/vuln-evidence-gate.test.sh
@@ -27,7 +27,7 @@ fi
 # evidence citation (AC1)
 # =============================================================================
 
-FIXTURES=$(_dossier_safe_mktemp_dir "vuln-evidence-fixtures")
+_dossier_require_mktemp_dir FIXTURES "vuln-evidence-fixtures"
 
 # --- SARIF: security-severity property drives CVSS bucketing ----------------
 cat >"$FIXTURES/scan.sarif.json" <<'EOF'
@@ -412,7 +412,7 @@ g19_evidence() { # dir
 }
 
 # --- FAIL: a High finding with no disposition anywhere ----------------------
-G19_FAIL_DIR=$(_dossier_safe_mktemp_dir "g19-fail")
+_dossier_require_mktemp_dir G19_FAIL_DIR "g19-fail"
 g19_fixture "$G19_FAIL_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0002 | osv-scanner reports GHSA-4w2v-q235-vp99 in axios@0.21.1, severity High | R | `scan.json` — osv-scanner, GHSA-4w2v-q235-vp99, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding severity=High |' \
@@ -423,7 +423,7 @@ G19_FAIL_EVIDENCE=$(g19_evidence "$G19_FAIL_DIR")
 assert_contains "EV-0002" "$G19_FAIL_EVIDENCE" "AC2: G19's evidence names the specific unresolved EV-#### row"
 
 # --- FAIL: a Risk register row exists but Status is still open --------------
-G19_OPEN_DIR=$(_dossier_safe_mktemp_dir "g19-open")
+_dossier_require_mktemp_dir G19_OPEN_DIR "g19-open"
 g19_fixture "$G19_OPEN_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0002 | osv-scanner reports GHSA-4w2v-q235-vp99 in axios@0.21.1, severity High | R | `scan.json` — osv-scanner, GHSA-4w2v-q235-vp99, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding severity=High |' \
@@ -437,7 +437,7 @@ assert_equal "FAIL" "$G19_OPEN_RESULT" "AC2: a Risk register row with Status=ope
 
 # --- PASS: an Accepted risks row with a named accepter, valid dates, and a
 # stated basis disposes a High finding (AC3) --------------------------------
-G19_ACCEPTED_DIR=$(_dossier_safe_mktemp_dir "g19-accepted")
+_dossier_require_mktemp_dir G19_ACCEPTED_DIR "g19-accepted"
 g19_fixture "$G19_ACCEPTED_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0042 | osv-scanner reports GHSA-4w2v-q235-vp99 in axios@0.21.1, severity High | R | `scan.json` — osv-scanner, GHSA-4w2v-q235-vp99, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding severity=High |' \
@@ -451,7 +451,7 @@ assert_equal "PASS" "$G19_ACCEPTED_RESULT" "AC3: a High finding with a named acc
 
 # --- PASS: a Risk register row alone (Category=dependency, owned, not open)
 # also disposes a Critical finding — Accepted risks is not the only path ----
-G19_MITIGATING_DIR=$(_dossier_safe_mktemp_dir "g19-mitigating")
+_dossier_require_mktemp_dir G19_MITIGATING_DIR "g19-mitigating"
 g19_fixture "$G19_MITIGATING_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0043 | osv-scanner reports GHSA-9999-9999-9999 in lodash@4.17.15, severity Critical | R | `scan.json` — osv-scanner, GHSA-9999-9999-9999, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding severity=Critical |' \
@@ -465,7 +465,7 @@ assert_equal "PASS" "$G19_MITIGATING_RESULT" "AC3: a Risk register row with Cate
 
 # --- PASS: a clean scan (coverage recorded, zero Critical/High findings) is
 # a legitimate pass, not an omission ------------------------------------------
-G19_CLEAN_DIR=$(_dossier_safe_mktemp_dir "g19-clean")
+_dossier_require_mktemp_dir G19_CLEAN_DIR "g19-clean"
 g19_fixture "$G19_CLEAN_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0002 | osv-scanner aggregate: 2 Low-severity findings in package-lock.json | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding-aggregate severity=Low count=2 |' \
@@ -476,7 +476,7 @@ assert_equal "PASS" "$G19_CLEAN_RESULT" "AC3/AC4: a parsed scan with zero Critic
 # --- Negative control: a calendar-invalid rollover Review date must NOT
 # dispose the finding — proves validate_calendar_date() is actually applied,
 # not merely present in the source file --------------------------------------
-G19_ROLLOVER_DIR=$(_dossier_safe_mktemp_dir "g19-rollover")
+_dossier_require_mktemp_dir G19_ROLLOVER_DIR "g19-rollover"
 g19_fixture "$G19_ROLLOVER_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0044 | osv-scanner reports GHSA-8888-8888-8888 in axios@0.21.1, severity High | R | `scan.json` — osv-scanner, GHSA-8888-8888-8888, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding severity=High |' \
@@ -495,7 +495,7 @@ fi
 # --- INCONCLUSIVE: no vulnerability evidence at all (AC4, gate half) --------
 # Confirmed design decision (.decisions/issue-136.md): zero evidence means
 # INCONCLUSIVE, never PASS — not a bug to work around.
-G19_NOEVIDENCE_DIR=$(_dossier_safe_mktemp_dir "g19-noevidence")
+_dossier_require_mktemp_dir G19_NOEVIDENCE_DIR "g19-noevidence"
 g19_fixture "$G19_NOEVIDENCE_DIR" \
 '| EV-0001 | The HTTP API authenticates with OAuth 2.0 | V | `src/api/auth.ts::authenticate` | yes | 2 | main | 2026-07-28 | none | Internal | no | 02-architecture/interfaces-and-integrations.md | — |' \
 ''
@@ -525,7 +525,7 @@ fi
 # --- INCONCLUSIVE: a scan artifact that failed to parse, distinct wording ---
 # from the "never scanned" branch above — the ERR-3-style distinction must
 # survive into the gate's own reported reason, not just the ingestion script.
-G19_PARSEERR_DIR=$(_dossier_safe_mktemp_dir "g19-parseerr")
+_dossier_require_mktemp_dir G19_PARSEERR_DIR "g19-parseerr"
 g19_fixture "$G19_PARSEERR_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | U | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parse-error |' \
 ''
@@ -590,7 +590,7 @@ fi
 # hand-typed, bypassing the parser) -> the real gate. Distinct from Part 2's
 # fixtures, which hand-write ledger rows to test G19's logic in isolation.
 
-E2E_DIR=$(_dossier_safe_mktemp_dir "e2e-planted-vuln")
+_dossier_require_mktemp_dir E2E_DIR "e2e-planted-vuln"
 mkdir -p "$E2E_DIR/docs/dossier/00-control"
 
 cat >"$E2E_DIR/planted-scan.json" <<'EOF'
@@ -645,7 +645,7 @@ assert_contains "EV-0002" "$E2E_G19_EVIDENCE" "AC5: G19's evidence names the pla
 # spaces before the pipe renders identically in Markdown but was previously
 # lost between the (unanchored) selection grep and the (anchored) extraction
 # grep. ------------------------------------------------------------------
-G19_INDENT_DIR=$(_dossier_safe_mktemp_dir "g19-indent")
+_dossier_require_mktemp_dir G19_INDENT_DIR "g19-indent"
 mkdir -p "$G19_INDENT_DIR/docs/dossier/00-control"
 printf '%s\n' \
   '# Evidence Ledger' \
@@ -660,7 +660,7 @@ assert_equal "FAIL" "$G19_INDENT_RESULT" "F1 regression: a vuln-finding row inde
 
 # --- F2: format detection on a genuinely clean scan for the two formats
 # whose empty shape does not carry a nested array to key off -----------------
-G19_F2_DIR=$(_dossier_safe_mktemp_dir "f2-clean-detect")
+_dossier_require_mktemp_dir G19_F2_DIR "f2-clean-detect"
 printf '[]' >"$G19_F2_DIR/empty.json"
 F2_DEP_OUT=$(cd "$G19_F2_DIR" && CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" "$VULN_SCRIPT" --scan empty.json 2>&1)
 F2_DEP_RC=$?
@@ -678,7 +678,7 @@ assert_equal "osv-scanner" "$F2_OSV_FORMAT" "F2 regression: a results-only-empty
 # --- F3: a disposition citing the finding alongside another id in the same
 # bracket, and a finding cited by a second (qualifying) row after a first
 # (non-qualifying) row, must both be recognized. -----------------------------
-G19_MULTI_DIR=$(_dossier_safe_mktemp_dir "g19-multi-citation")
+_dossier_require_mktemp_dir G19_MULTI_DIR "g19-multi-citation"
 g19_fixture "$G19_MULTI_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0005 | osv-scanner reports GHSA-multi-0001 in requests@2.25.0, severity High | R | `scan.json` — osv-scanner, GHSA-multi-0001, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding severity=High |' \
@@ -690,7 +690,7 @@ g19_fixture "$G19_MULTI_DIR" \
 G19_MULTI_RESULT=$(g19_result "$G19_MULTI_DIR")
 assert_equal "PASS" "$G19_MULTI_RESULT" "F3 regression: a Risk register row citing the finding alongside another id in the same bracket ([EV-0004, EV-0005]) still disposes it"
 
-G19_SECONDROW_DIR=$(_dossier_safe_mktemp_dir "g19-second-row")
+_dossier_require_mktemp_dir G19_SECONDROW_DIR "g19-second-row"
 g19_fixture "$G19_SECONDROW_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0006 | osv-scanner reports GHSA-multi-0002 in flask@1.1.0, severity Critical | R | `scan.json` — osv-scanner, GHSA-multi-0002, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding severity=Critical |' \
@@ -712,7 +712,7 @@ assert_equal "PASS" "$G19_SECONDROW_RESULT" "F3 regression: a second Risk regist
 # jq object-construction error on one array element previously propagated
 # out of the whole array comprehension, discarding every finding, not just
 # the bad one. -----------------------------------------------------------
-H1_DIR=$(_dossier_safe_mktemp_dir "h1-partial-record")
+_dossier_require_mktemp_dir H1_DIR "h1-partial-record"
 cat >"$H1_DIR/mixed.json" <<'EOF'
 {
   "runs": [
@@ -750,7 +750,7 @@ assert_contains "security-severity" "$H1_PARSE_ERROR" "H1: the unparseable recor
 
 # --- H2: SARIF's own empty-runs clean-scan shape must parse cleanly, the
 # same guarantee already regression-tested for Dependabot/osv-scanner -------
-H2_DIR=$(_dossier_safe_mktemp_dir "h2-sarif-empty")
+_dossier_require_mktemp_dir H2_DIR "h2-sarif-empty"
 printf '{"runs":[]}' >"$H2_DIR/empty-runs.json"
 H2_OUT=$(cd "$H2_DIR" && CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" "$VULN_SCRIPT" --scan empty-runs.json 2>&1)
 H2_RC=$?
@@ -761,7 +761,7 @@ H2_FINDINGS_COUNT=$(printf '%s' "$H2_OUT" | jq '.findings | length' 2>/dev/null)
 assert_equal "0" "$H2_FINDINGS_COUNT" "H2: zero findings, correctly — not a parse error"
 
 # --- H3: CVSS bucket boundaries are exact, not approximate ------------------
-H3_DIR=$(_dossier_safe_mktemp_dir "h3-cvss-boundaries")
+_dossier_require_mktemp_dir H3_DIR "h3-cvss-boundaries"
 cat >"$H3_DIR/boundaries.json" <<'EOF'
 {
   "runs": [{
@@ -797,7 +797,7 @@ assert_equal "null" "$H3_ZERO_SEV" "H3: a 0.0 score is unresolved, not fabricate
 # --- H4: two Critical/High findings, one disposed and one not — the gate
 # must FAIL for the undisposed one without being satisfied by the other's
 # valid disposition, and the evidence must name the undisposed one specifically
-H4_DIR=$(_dossier_safe_mktemp_dir "h4-mixed-disposition")
+_dossier_require_mktemp_dir H4_DIR "h4-mixed-disposition"
 g19_fixture "$H4_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0010 | osv-scanner reports GHSA-disposed-0001 in flask@1.1.0, severity Critical | R | `scan.json` — osv-scanner, GHSA-disposed-0001, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding severity=Critical |
@@ -824,7 +824,7 @@ assert_not_contains "EV-0010" "$H4_EVIDENCE" "H4: the evidence does not also nam
 
 # --- H5: a malformed top-level scan-metadata field (tool) must not cost the
 # scan its actual findings ----------------------------------------------------
-H5_DIR=$(_dossier_safe_mktemp_dir "h5-bad-tool-field")
+_dossier_require_mktemp_dir H5_DIR "h5-bad-tool-field"
 cat >"$H5_DIR/bad-tool.json" <<'EOF'
 {
   "runs": [
@@ -848,7 +848,7 @@ assert_equal "unknown" "$H5_TOOL" "H5: the malformed tool field itself degrades 
 # --- H6: a malformed individual entry ABOVE the final record (a bad `.runs[]`
 # entry sitting next to a well-formed one) must not cost the WELL-FORMED
 # run's findings --------------------------------------------------------------
-H6_DIR=$(_dossier_safe_mktemp_dir "h6-bad-run-entry")
+_dossier_require_mktemp_dir H6_DIR "h6-bad-run-entry"
 cat >"$H6_DIR/bad-run.json" <<'EOF'
 {
   "runs": [
@@ -870,7 +870,7 @@ assert_equal "CVE-2024-88888" "$H6_FINDING_ID" "H6: the well-formed run's genuin
 
 # --- H7: same isolation for osv-scanner's own nested structure (a malformed
 # `packages` field on one result must not cost a sibling result's findings) --
-H7_DIR=$(_dossier_safe_mktemp_dir "h7-osv-bad-packages")
+_dossier_require_mktemp_dir H7_DIR "h7-osv-bad-packages"
 cat >"$H7_DIR/osv-bad-packages.json" <<'EOF'
 {
   "results": [
@@ -905,7 +905,7 @@ assert_equal "GHSA-valid-0001" "$H7_FINDING_ID" "H7: a sibling result's genuine 
 # alongside a well-formed one. Dependabot's shape is flat (a single top-level
 # array, no intermediate nesting), so this is a narrower case than H5-H7, but
 # it closes out the same fault-isolation guarantee across all three formats.
-H8_DIR=$(_dossier_safe_mktemp_dir "h8-dependabot-bad-element")
+_dossier_require_mktemp_dir H8_DIR "h8-dependabot-bad-element"
 cat >"$H8_DIR/dependabot-bad-element.json" <<'EOF'
 [
   "this-element-is-a-string-not-an-alert-object",
@@ -932,7 +932,7 @@ assert_equal "1" "$H8_UNPARSEABLE_COUNT" "H8: the malformed element is flagged, 
 # Risk register row for one finding, whose free-text description happens to
 # mention a completely different finding's id, previously disposed that
 # other, genuinely-unresolved finding. ---------------------------------------
-H9_RISK_DIR=$(_dossier_safe_mktemp_dir "h9-coincidental-mention-risk")
+_dossier_require_mktemp_dir H9_RISK_DIR "h9-coincidental-mention-risk"
 g19_fixture "$H9_RISK_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0099 | osv-scanner reports GHSA-real-target in axios@0.21.1, severity Critical | R | `scan.json` — osv-scanner, GHSA-real-target, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding severity=Critical |' \
@@ -946,7 +946,7 @@ assert_equal "FAIL" "$H9_RISK_RESULT" "H9: a coincidental EV-#### mention in the
 H9_RISK_EVIDENCE=$(g19_evidence "$H9_RISK_DIR")
 assert_contains "EV-0099" "$H9_RISK_EVIDENCE" "H9: the genuinely undisposed finding is still correctly named"
 
-H9_ACC_DIR=$(_dossier_safe_mktemp_dir "h9-coincidental-mention-accepted")
+_dossier_require_mktemp_dir H9_ACC_DIR "h9-coincidental-mention-accepted"
 g19_fixture "$H9_ACC_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0099 | osv-scanner reports GHSA-real-target in axios@0.21.1, severity Critical | R | `scan.json` — osv-scanner, GHSA-real-target, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding severity=Critical |' \
@@ -967,7 +967,7 @@ assert_equal "FAIL" "$H9_ACC_RESULT" "H9: a coincidental EV-#### mention in the 
 # an injection vector without a test catching it. ---------------------------
 SEC4_MARKER="/tmp/dossier-sec4-pwned-marker-$$"
 rm -f "$SEC4_MARKER" 2>/dev/null
-SEC4_DIR=$(_dossier_safe_mktemp_dir "sec4-injection-safety")
+_dossier_require_mktemp_dir SEC4_DIR "sec4-injection-safety"
 cat >"$SEC4_DIR/scan.json" <<EOF
 [
   {
@@ -1016,7 +1016,7 @@ fi
 # result indistinguishable from that container legitimately having nothing
 # — a scan where EVERY container is malformed must not read as a clean,
 # zero-findings scan. --------------------------------------------------------
-ERR1_DIR=$(_dossier_safe_mktemp_dir "err1-container-tracking")
+_dossier_require_mktemp_dir ERR1_DIR "err1-container-tracking"
 cat >"$ERR1_DIR/all-bad-runs.json" <<'EOF'
 {"runs": ["a string, not an object", 42]}
 EOF
@@ -1037,7 +1037,7 @@ assert_equal "1" "$ERR1_PKG_UNPARSEABLE" "ERR-1: a wrong-typed packages field on
 # did not) must make G19 INCONCLUSIVE, never PASS just because every record
 # that DID parse happens to be disposed — the unparsed portion's materiality
 # is unknown. -----------------------------------------------------------
-ERR2_DIR=$(_dossier_safe_mktemp_dir "err2-status-partial")
+_dossier_require_mktemp_dir ERR2_DIR "err2-status-partial"
 g19_fixture "$ERR2_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 (1 record could not be normalized) | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=partial |
 | EV-0002 | osv-scanner: one record could not be normalized, severity unknown | U | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding-unresolved |' \
@@ -1068,7 +1068,7 @@ assert_contains "parsed partially" "$ERR2_EVIDENCE" "ERR-2/F1: the partial-parse
 # field, in ANY shape, is now simply irrelevant to extraction — proven below),
 # but shifts the "malformed record must not silently vanish" risk to the
 # groups[] iteration itself, tested separately after this. -----------------
-F1_DIR=$(_dossier_safe_mktemp_dir "f1-severity-swallow")
+_dossier_require_mktemp_dir F1_DIR "f1-severity-swallow"
 cat >"$F1_DIR/bad-severity-shape.json" <<'EOF'
 {
   "results": [
@@ -1111,7 +1111,7 @@ assert_equal "0" "$F1_ABSENT_UNPARSEABLE" "F1: an absent severity field is not m
 # object) must throw inside safe_finding's try/catch and land in
 # unparseable_records — never silently vanish with zero trace, the same
 # failure mode the original F1 fix closed one field over. -------------------
-F1B_DIR=$(_dossier_safe_mktemp_dir "f1-successor-bad-group-entry")
+_dossier_require_mktemp_dir F1B_DIR "f1-successor-bad-group-entry"
 cat >"$F1B_DIR/bad-group-entry.json" <<'EOF'
 {
   "results": [
@@ -1149,7 +1149,7 @@ assert_equal "1" "$F1B_UNPARSEABLE_COUNT" "F1-successor: a non-object groups[] e
 # to unparseable_records with a generic id — silently discarding two real
 # findings. Confirmed by direct reproduction that this is reachable from
 # ingested scan-artifact content, not only from a live scanner bug. -------
-F1C_DIR=$(_dossier_safe_mktemp_dir "f1-successor-2-bad-vuln-element")
+_dossier_require_mktemp_dir F1C_DIR "f1-successor-2-bad-vuln-element"
 cat >"$F1C_DIR/bad-vuln-element.json" <<'EOF'
 {
   "results": [
@@ -1199,7 +1199,7 @@ assert_contains "missing or invalid argument" "$HELP_OUT" "--help includes exit 
 
 # --- --out: previously untested. Confirms the file is actually written, its
 # content matches stdout, and the flag doesn't change exit behaviour. -------
-OUT_DIR=$(_dossier_safe_mktemp_dir "out-flag")
+_dossier_require_mktemp_dir OUT_DIR "out-flag"
 mkdir -p "$OUT_DIR/target"
 printf '{"results":[]}' >"$OUT_DIR/clean.json"
 OUT_STDOUT=$(cd "$OUT_DIR" && CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" "$VULN_SCRIPT" --scan clean.json --out target 2>&1)
@@ -1233,7 +1233,7 @@ assert_contains "parse-error" "$OUT_ERR_FILE" "--out: a failed run overwrites th
 # capitalized variant or an unfilled template placeholder disposed a
 # genuinely undisposed Critical/High finding. Now an allowlist against the
 # template's own closed enum, case-normalized, with placeholder rejection. --
-G19_STATUS_CASE_DIR=$(_dossier_safe_mktemp_dir "f2-status-case")
+_dossier_require_mktemp_dir G19_STATUS_CASE_DIR "f2-status-case"
 g19_fixture "$G19_STATUS_CASE_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0050 | osv-scanner reports GHSA-f2-0001 in axios@0.21.1, severity High | R | `scan.json` — osv-scanner, GHSA-f2-0001, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding severity=High |' \
@@ -1244,7 +1244,7 @@ g19_fixture "$G19_STATUS_CASE_DIR" \
 | RISK-0010 | axios SSRF | dependency | medium | high | high | high | [EV-0050] | upgrade planned | Jane Doe | Open |'
 assert_equal "FAIL" "$(g19_result "$G19_STATUS_CASE_DIR")" "F2: a capitalized Status value (\"Open\") no longer disposes a Critical/High finding"
 
-G19_STATUS_PLACEHOLDER_DIR=$(_dossier_safe_mktemp_dir "f2-status-placeholder")
+_dossier_require_mktemp_dir G19_STATUS_PLACEHOLDER_DIR "f2-status-placeholder"
 g19_fixture "$G19_STATUS_PLACEHOLDER_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0051 | osv-scanner reports GHSA-f2-0002 in axios@0.21.1, severity High | R | `scan.json` — osv-scanner, GHSA-f2-0002, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding severity=High |' \
@@ -1258,7 +1258,7 @@ assert_equal "FAIL" "$(g19_result "$G19_STATUS_PLACEHOLDER_DIR")" "F2/F4: an unf
 # --- F5/SEC-4 (code-reviewer-verifier, security-skeptic): Category is now
 # case-insensitive — a capitalized "Dependency" must still dispose a
 # genuinely-mitigated finding, not spuriously FAIL. --------------------------
-G19_CATEGORY_CASE_DIR=$(_dossier_safe_mktemp_dir "f5-category-case")
+_dossier_require_mktemp_dir G19_CATEGORY_CASE_DIR "f5-category-case"
 g19_fixture "$G19_CATEGORY_CASE_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0052 | osv-scanner reports GHSA-f5-0001 in axios@0.21.1, severity Critical | R | `scan.json` — osv-scanner, GHSA-f5-0001, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding severity=Critical |' \
@@ -1274,7 +1274,7 @@ assert_equal "PASS" "$(g19_result "$G19_CATEGORY_CASE_DIR")" "F5/SEC-4: a capita
 # named human with the authority to accept, which a bare Owner cell does not
 # establish. An accepted disposition must go through the Accepted risks
 # table, with its accepter/date/basis/review-date accountability fields. ----
-G19_RISKACCEPTED_DIR=$(_dossier_safe_mktemp_dir "f3-risk-register-accepted")
+_dossier_require_mktemp_dir G19_RISKACCEPTED_DIR "f3-risk-register-accepted"
 g19_fixture "$G19_RISKACCEPTED_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0053 | osv-scanner reports GHSA-f3-0001 in axios@0.21.1, severity Critical | R | `scan.json` — osv-scanner, GHSA-f3-0001, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding severity=Critical |' \
@@ -1287,7 +1287,7 @@ assert_equal "FAIL" "$(g19_result "$G19_RISKACCEPTED_DIR")" "F3: Status=accepted
 
 # --- F4 (code-reviewer-verifier): Accepted risks' Accepter/Basis cells
 # accepted the literal unfilled template placeholder {fill}. -----------------
-G19_ACC_PLACEHOLDER_DIR=$(_dossier_safe_mktemp_dir "f4-accepted-placeholder")
+_dossier_require_mktemp_dir G19_ACC_PLACEHOLDER_DIR "f4-accepted-placeholder"
 g19_fixture "$G19_ACC_PLACEHOLDER_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0054 | osv-scanner reports GHSA-f4-0001 in axios@0.21.1, severity Critical | R | `scan.json` — osv-scanner, GHSA-f4-0001, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding severity=Critical |' \
@@ -1304,7 +1304,7 @@ assert_equal "FAIL" "$(g19_result "$G19_ACC_PLACEHOLDER_DIR")" "F4: unfilled {fi
 # severity, and zero confirmed Critical/High rows, must be INCONCLUSIVE —
 # materiality unknown is not the same as clean. Distinct from the existing
 # status=partial test above: here the COVERAGE row itself is status=parsed. -
-G19_UNRESOLVED_ONLY_DIR=$(_dossier_safe_mktemp_dir "unresolved-only")
+_dossier_require_mktemp_dir G19_UNRESOLVED_ONLY_DIR "unresolved-only"
 g19_fixture "$G19_UNRESOLVED_ONLY_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0060 | osv-scanner: severity could not be derived for GHSA-unresolved-0001 | U | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding-unresolved |' \
@@ -1317,7 +1317,7 @@ assert_contains "unresolved severity" "$G19_UNRESOLVED_ONLY_EVIDENCE" "New: the 
 # A confirmed, undisposed Critical finding alongside an unrelated unresolved
 # row must still FAIL, not soften to INCONCLUSIVE — FAIL outranks
 # INCONCLUSIVE, matching the gate's existing overall precedence.
-G19_UNRESOLVED_PLUS_FAIL_DIR=$(_dossier_safe_mktemp_dir "unresolved-plus-fail")
+_dossier_require_mktemp_dir G19_UNRESOLVED_PLUS_FAIL_DIR "unresolved-plus-fail"
 g19_fixture "$G19_UNRESOLVED_PLUS_FAIL_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0061 | osv-scanner: severity could not be derived for GHSA-unresolved-0002 | U | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding-unresolved |
@@ -1329,7 +1329,7 @@ assert_equal "FAIL" "$(g19_result "$G19_UNRESOLVED_PLUS_FAIL_DIR")" "New: a conf
 # independent agents): the Accepted risks Review date was only checked for
 # calendar validity, never compared to "now" — a review date from years ago
 # disposed a Critical finding permanently. -----------------------------------
-G19_STALE_REVIEW_DIR=$(_dossier_safe_mktemp_dir "stale-review-date")
+_dossier_require_mktemp_dir G19_STALE_REVIEW_DIR "stale-review-date"
 g19_fixture "$G19_STALE_REVIEW_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0070 | osv-scanner reports GHSA-stale-0001 in axios@0.21.1, severity Critical | R | `scan.json` — osv-scanner, GHSA-stale-0001, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding severity=Critical |' \
@@ -1342,7 +1342,7 @@ assert_equal "FAIL" "$(g19_result "$G19_STALE_REVIEW_DIR")" "New: an Accepted-ri
 
 # A review date in the future (not yet elapsed) must still dispose normally —
 # negative control proving the fix checks "elapsed", not "always reject".
-G19_FUTURE_REVIEW_DIR=$(_dossier_safe_mktemp_dir "future-review-date")
+_dossier_require_mktemp_dir G19_FUTURE_REVIEW_DIR "future-review-date"
 g19_fixture "$G19_FUTURE_REVIEW_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0071 | osv-scanner reports GHSA-future-0001 in axios@0.21.1, severity Critical | R | `scan.json` — osv-scanner, GHSA-future-0001, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding severity=Critical |' \
@@ -1359,7 +1359,7 @@ assert_equal "PASS" "$(g19_result "$G19_FUTURE_REVIEW_DIR")" "New: an Accepted-r
 # unrelated EV-0050 that merely fell numerically between the two listed,
 # non-adjacent ids. g19_row_cites now splits on the list separator before
 # ever looking for a range. --------------------------------------------------
-G19_COMMA_NOT_RANGE_DIR=$(_dossier_safe_mktemp_dir "err2-comma-not-range")
+_dossier_require_mktemp_dir G19_COMMA_NOT_RANGE_DIR "err2-comma-not-range"
 g19_fixture "$G19_COMMA_NOT_RANGE_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0042 | osv-scanner reports GHSA-list-0001 in axios@0.21.1, severity High | R | `scan.json` — osv-scanner, GHSA-list-0001, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding severity=High |
@@ -1383,7 +1383,7 @@ assert_not_contains "EV-0099" "$G19_COMMA_EVIDENCE" "ERR-2: EV-0099, actually ci
 # strict selection loop — silently treated as "nothing to see" rather than
 # flagged. Now reconciled: a leftover, unrecognized row makes G19
 # INCONCLUSIVE instead of vanishing. ------------------------------------------
-G19_MALFORMED_TAG_DIR=$(_dossier_safe_mktemp_dir "err3-malformed-tag")
+_dossier_require_mktemp_dir G19_MALFORMED_TAG_DIR "err3-malformed-tag"
 g19_fixture "$G19_MALFORMED_TAG_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0080 | osv-scanner reports GHSA-err3-0001 in axios@0.21.1, severity High | R | `scan.json` — osv-scanner, GHSA-err3-0001, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding severity = High |' \
@@ -1395,7 +1395,7 @@ assert_contains "did not match" "$G19_MALFORMED_TAG_EVIDENCE" "ERR-3: the reconc
 
 # Case drift alone (not spacing) must now be tolerated directly by the main
 # selection loop, not merely caught by the reconciliation fallback.
-G19_CASE_DRIFT_DIR=$(_dossier_safe_mktemp_dir "err3-case-drift")
+_dossier_require_mktemp_dir G19_CASE_DRIFT_DIR "err3-case-drift"
 g19_fixture "$G19_CASE_DRIFT_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0081 | osv-scanner reports GHSA-err3-0002 in axios@0.21.1, severity critical | R | `scan.json` — osv-scanner, GHSA-err3-0002, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding severity=critical |' \
@@ -1410,7 +1410,7 @@ assert_contains "EV-0081 (Critical)" "$G19_CASE_DRIFT_EVIDENCE" "ERR-3: the reco
 # permissions problem misdirected remediation toward triaging findings that
 # may already be disposed in a file G19 simply couldn't open. ----------------
 if [ "$(id -u)" != "0" ]; then
-  G19_UNREADABLE_DIR=$(_dossier_safe_mktemp_dir "err6-unreadable-risks")
+  _dossier_require_mktemp_dir G19_UNREADABLE_DIR "err6-unreadable-risks"
   g19_fixture "$G19_UNREADABLE_DIR" \
 '| EV-0001 | Dependency vulnerability scan: osv-scanner on package-lock.json, 2026-07-28 | R | `scan.json` — osv-scanner, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-scan-coverage status=parsed |
 | EV-0090 | osv-scanner reports GHSA-err6-0001 in axios@0.21.1, severity Critical | R | `scan.json` — osv-scanner, GHSA-err6-0001, retrieved 2026-07-28 | yes | 2 | main | 2026-07-28 | none | Internal | no | 05-due-diligence/assets-dependencies-and-licenses.md | vuln-finding severity=Critical |' \

--- a/plugins/dossier/tests/vuln-scan-execution.test.sh
+++ b/plugins/dossier/tests/vuln-scan-execution.test.sh
@@ -22,7 +22,7 @@ fi
 # that writes a marker file if ever executed. If the disabled path is
 # genuinely short-circuited before any tool lookup, the marker never appears.
 # =============================================================================
-DIR_DISABLED=$(_dossier_safe_mktemp_dir "disabled")
+_dossier_require_mktemp_dir DIR_DISABLED "disabled"
 mkdir -p "$DIR_DISABLED/target" "$DIR_DISABLED/tripwire-bin"
 TRIPWIRE_MARKER="$DIR_DISABLED/osv-scanner-was-invoked"
 cat >"$DIR_DISABLED/tripwire-bin/osv-scanner" <<EOF
@@ -74,7 +74,7 @@ assert_equal "unavailable" "$STATUS_NOTOOL" "tool-unavailable: distinct status, 
 # and its (nonexistent, since it never got to print) output is never read
 # as a result.
 # =============================================================================
-DIR_TIMEOUT=$(_dossier_safe_mktemp_dir "timeout")
+_dossier_require_mktemp_dir DIR_TIMEOUT "timeout"
 mkdir -p "$DIR_TIMEOUT/fakebin" "$DIR_TIMEOUT/target"
 cat >"$DIR_TIMEOUT/fakebin/osv-scanner" <<'EOF'
 #!/usr/bin/env bash
@@ -106,7 +106,7 @@ assert_equal "timeout" "$STATUS_TIMEOUT" "timeout: distinct status, wording dist
 # at some location this wrapper's own guess missed) emit an offline_caveat
 # unconditionally claiming the result is "age-checked before this scan ran"
 # when no age check occurred at all.
-DIR_MISSING_CACHE=$(_dossier_safe_mktemp_dir "offline-missing-cache")
+_dossier_require_mktemp_dir DIR_MISSING_CACHE "offline-missing-cache"
 mkdir -p "$DIR_MISSING_CACHE/target" "$DIR_MISSING_CACHE/tripwire-bin"
 TRIPWIRE_OFFLINE_MARKER="$DIR_MISSING_CACHE/osv-scanner-was-invoked"
 cat >"$DIR_MISSING_CACHE/tripwire-bin/osv-scanner" <<EOF
@@ -115,7 +115,7 @@ touch "$TRIPWIRE_OFFLINE_MARKER"
 echo '{"results":[]}'
 EOF
 chmod +x "$DIR_MISSING_CACHE/tripwire-bin/osv-scanner"
-DIR_MISSING_CACHE_HOME=$(_dossier_safe_mktemp_dir "offline-missing-cache-home")
+_dossier_require_mktemp_dir DIR_MISSING_CACHE_HOME "offline-missing-cache-home"
 OUT_MISSING_CACHE=$(DOSSIER_ENGAGEMENT_ALLOWED_ACTIONS_RUN_SECURITY_SCAN=true CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
   HOME="$DIR_MISSING_CACHE_HOME" PATH="$DIR_MISSING_CACHE/tripwire-bin:$PATH" \
   "$SCRIPT" --target "$DIR_MISSING_CACHE/target" --offline 2>&1)
@@ -137,7 +137,7 @@ fi
 # to be saved by the real tool's own behavior. Without the upstream refusal
 # this stub would return "ok" carrying an offline_caveat that falsely
 # claims "age-checked before this scan ran."
-DIR_EMPTY_CACHE=$(_dossier_safe_mktemp_dir "offline-empty-cache")
+_dossier_require_mktemp_dir DIR_EMPTY_CACHE "offline-empty-cache"
 mkdir -p "$DIR_EMPTY_CACHE/target" "$DIR_EMPTY_CACHE/tripwire-bin"
 TRIPWIRE_EMPTY_MARKER="$DIR_EMPTY_CACHE/osv-scanner-was-invoked"
 cat >"$DIR_EMPTY_CACHE/tripwire-bin/osv-scanner" <<EOF
@@ -146,7 +146,7 @@ touch "$TRIPWIRE_EMPTY_MARKER"
 echo '{"results":[]}'
 EOF
 chmod +x "$DIR_EMPTY_CACHE/tripwire-bin/osv-scanner"
-DIR_EMPTY_CACHE_HOME=$(_dossier_safe_mktemp_dir "offline-empty-cache-home")
+_dossier_require_mktemp_dir DIR_EMPTY_CACHE_HOME "offline-empty-cache-home"
 if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
   mkdir -p "$DIR_EMPTY_CACHE_HOME/Library/Caches/osv-scanner"
 else
@@ -163,7 +163,7 @@ else
   _dossier_assert_pass "--offline with an empty cache directory: osv-scanner tripwire was never invoked — refused before any tool lookup, not merely saved by the real tool's own fallback behavior"
 fi
 
-DIR_OFFLINE=$(_dossier_safe_mktemp_dir "offline-no-db")
+_dossier_require_mktemp_dir DIR_OFFLINE "offline-no-db"
 mkdir -p "$DIR_OFFLINE/target"
 printf 'requests==2.32.3\n' >"$DIR_OFFLINE/target/requirements.txt"
 
@@ -185,7 +185,7 @@ else
 fi
 
 if command -v osv-scanner >/dev/null 2>&1; then
-  DIR_OFFLINE_HOME=$(_dossier_safe_mktemp_dir "offline-no-db-home")
+  _dossier_require_mktemp_dir DIR_OFFLINE_HOME "offline-no-db-home"
   OUT_OFFLINE=$(DOSSIER_ENGAGEMENT_ALLOWED_ACTIONS_RUN_SECURITY_SCAN=true CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
     HOME="$DIR_OFFLINE_HOME" \
     "$SCRIPT" --target "$DIR_OFFLINE/target" --offline 2>&1)
@@ -212,7 +212,7 @@ fi
 # consulted PyPI, deterministically, so these tests run everywhere,
 # independent of whether the real tool is installed.
 # =============================================================================
-DIR_STALE_HOME=$(_dossier_safe_mktemp_dir "offline-stale-home")
+_dossier_require_mktemp_dir DIR_STALE_HOME "offline-stale-home"
 mkdir -p "$DIR_STALE_HOME/$OSV_CACHE_REL" "$DIR_STALE_HOME/fakebin"
 printf 'stale placeholder db\n' >"$DIR_STALE_HOME/$OSV_CACHE_REL/all.zip"
 touch -t 202001010000 "$DIR_STALE_HOME/$OSV_CACHE_REL/all.zip"
@@ -232,7 +232,7 @@ assert_contains "stale_advisory_data" "$DETAIL_STALE" "--offline stale-cache det
 assert_contains "PyPI" "$DETAIL_STALE" "--offline stale-cache detail names the specific ecosystem"
 
 # A cache within the configured max age must NOT be refused by the age check.
-DIR_FRESH_HOME=$(_dossier_safe_mktemp_dir "offline-fresh-home")
+_dossier_require_mktemp_dir DIR_FRESH_HOME "offline-fresh-home"
 mkdir -p "$DIR_FRESH_HOME/$OSV_CACHE_REL" "$DIR_FRESH_HOME/fakebin"
 printf 'fresh placeholder db\n' >"$DIR_FRESH_HOME/$OSV_CACHE_REL/all.zip"
 cat >"$DIR_FRESH_HOME/fakebin/osv-scanner" <<'EOF'
@@ -249,7 +249,7 @@ assert_equal "ok" "$STATUS_FRESH" "--offline with a fresh (just-created) cache f
 
 # DOSSIER_SCAN_OFFLINE_MAX_AGE_DAYS override: a cache that would fail the
 # default 7-day threshold must NOT be refused as stale under a wide override.
-DIR_OVERRIDE_HOME=$(_dossier_safe_mktemp_dir "offline-max-age-override-home")
+_dossier_require_mktemp_dir DIR_OVERRIDE_HOME "offline-max-age-override-home"
 mkdir -p "$DIR_OVERRIDE_HOME/$OSV_CACHE_REL" "$DIR_OVERRIDE_HOME/fakebin"
 printf 'placeholder db\n' >"$DIR_OVERRIDE_HOME/$OSV_CACHE_REL/all.zip"
 touch -t 202001010000 "$DIR_OVERRIDE_HOME/$OSV_CACHE_REL/all.zip"
@@ -268,7 +268,7 @@ assert_equal "ok" "$STATUS_OVERRIDE" "DOSSIER_SCAN_OFFLINE_MAX_AGE_DAYS override
 # Mixed-ecosystem, stale TARGET ecosystem (holdout finding P1, original
 # repro): a fresh, UNRELATED sibling ecosystem (npm) must not mask a stale
 # database in the ecosystem the scan actually consulted (PyPI).
-DIR_MIXED_HOME=$(_dossier_safe_mktemp_dir "offline-mixed-ecosystem-home")
+_dossier_require_mktemp_dir DIR_MIXED_HOME "offline-mixed-ecosystem-home"
 mkdir -p "$DIR_MIXED_HOME/$OSV_CACHE_REL" "$DIR_MIXED_HOME/$OSV_CACHE_REL_NPM" "$DIR_MIXED_HOME/fakebin"
 printf 'stale PyPI db\n' >"$DIR_MIXED_HOME/$OSV_CACHE_REL/all.zip"
 touch -t 202001010000 "$DIR_MIXED_HOME/$OSV_CACHE_REL/all.zip"
@@ -292,7 +292,7 @@ assert_contains "stale_advisory_data" "$DETAIL_MIXED" "mixed-ecosystem cache: de
 # UNRELATED npm db must NOT block a scan whose actually-consulted ecosystem
 # (PyPI) is fresh. A whole-tree "oldest file" check would incorrectly
 # refuse this scan forever, on a database it never needed.
-DIR_MIXED2_HOME=$(_dossier_safe_mktemp_dir "offline-mixed-ecosystem-2-home")
+_dossier_require_mktemp_dir DIR_MIXED2_HOME "offline-mixed-ecosystem-2-home"
 mkdir -p "$DIR_MIXED2_HOME/$OSV_CACHE_REL" "$DIR_MIXED2_HOME/$OSV_CACHE_REL_NPM" "$DIR_MIXED2_HOME/fakebin"
 printf 'fresh PyPI db\n' >"$DIR_MIXED2_HOME/$OSV_CACHE_REL/all.zip"
 printf 'stale npm db\n' >"$DIR_MIXED2_HOME/$OSV_CACHE_REL_NPM/all.zip"
@@ -314,7 +314,7 @@ assert_equal "ok" "$STATUS_MIXED2" "--offline with a fresh PyPI db (the consulte
 # network/cache access) — this wrapper cannot tell "a cached database
 # silently backed this" from "no advisory data was checked at all" from the
 # JSON alone, so it refuses rather than guess.
-DIR_NOCACHE_HOME=$(_dossier_safe_mktemp_dir "offline-consulted-ecosystem-no-cache-home")
+_dossier_require_mktemp_dir DIR_NOCACHE_HOME "offline-consulted-ecosystem-no-cache-home"
 mkdir -p "$DIR_NOCACHE_HOME/fakebin"
 if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
   mkdir -p "$DIR_NOCACHE_HOME/Library/Caches/osv-scanner"
@@ -342,7 +342,7 @@ assert_equal "unavailable" "$STATUS_NOCACHE" "--offline where the consulted ecos
 # mode it exists to prevent, on the single most common outcome). A stub
 # that captures its own argv proves the flag is wired into SCAN_ARGS,
 # independent of whichever osv-scanner version happens to be installed.
-DIR_ALLPKGS=$(_dossier_safe_mktemp_dir "offline-all-packages-flag")
+_dossier_require_mktemp_dir DIR_ALLPKGS "offline-all-packages-flag"
 mkdir -p "$DIR_ALLPKGS/$OSV_CACHE_REL" "$DIR_ALLPKGS/fakebin"
 printf 'fresh placeholder db\n' >"$DIR_ALLPKGS/$OSV_CACHE_REL/all.zip"
 ARGV_CAPTURE="$DIR_ALLPKGS/osv-scanner-argv"
@@ -366,10 +366,10 @@ if command -v osv-scanner >/dev/null 2>&1; then
   # --all-packages fix. Uses a real downloaded database (not a placeholder),
   # since the per-ecosystem check now runs AFTER invocation and needs
   # osv-scanner to actually load and report against real content.
-  DIR_CLEAN_E2E=$(_dossier_safe_mktemp_dir "offline-clean-e2e")
+  _dossier_require_mktemp_dir DIR_CLEAN_E2E "offline-clean-e2e"
   mkdir -p "$DIR_CLEAN_E2E/target"
   printf 'tomli==2.0.1\n' >"$DIR_CLEAN_E2E/target/requirements.txt"
-  DIR_CLEAN_E2E_DOWNLOAD_HOME=$(_dossier_safe_mktemp_dir "offline-clean-e2e-download-home")
+  _dossier_require_mktemp_dir DIR_CLEAN_E2E_DOWNLOAD_HOME "offline-clean-e2e-download-home"
   HOME="$DIR_CLEAN_E2E_DOWNLOAD_HOME" osv-scanner scan source --offline-vulnerabilities --download-offline-databases \
     --format json -r "$DIR_CLEAN_E2E/target" >/dev/null 2>&1
   if [ -f "$DIR_CLEAN_E2E_DOWNLOAD_HOME/$OSV_CACHE_REL/all.zip" ]; then
@@ -399,7 +399,7 @@ fi
 # missing-directory refusal (checked before invocation) doesn't itself fire
 # first — this test isolates the DOWNSTREAM defense-in-depth specifically.
 # =============================================================================
-DIR_REWORDED=$(_dossier_safe_mktemp_dir "offline-reworded-stderr")
+_dossier_require_mktemp_dir DIR_REWORDED "offline-reworded-stderr"
 mkdir -p "$DIR_REWORDED/fakebin" "$DIR_REWORDED/target"
 cat >"$DIR_REWORDED/fakebin/osv-scanner" <<'EOF'
 #!/usr/bin/env bash
@@ -413,7 +413,7 @@ if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
 else
   REWORDED_CACHE_REL=".cache/osv-scanner/PyPI"
 fi
-DIR_REWORDED_HOME=$(_dossier_safe_mktemp_dir "offline-reworded-stderr-home")
+_dossier_require_mktemp_dir DIR_REWORDED_HOME "offline-reworded-stderr-home"
 mkdir -p "$DIR_REWORDED_HOME/$REWORDED_CACHE_REL"
 printf 'fresh placeholder db\n' >"$DIR_REWORDED_HOME/$REWORDED_CACHE_REL/all.zip"
 OUT_REWORDED=$(DOSSIER_ENGAGEMENT_ALLOWED_ACTIONS_RUN_SECURITY_SCAN=true CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
@@ -434,7 +434,7 @@ assert_equal "unavailable" "$STATUS_REWORDED" "--offline with exit 127 + empty r
 # installs it so the skip path is never exercised there.
 # =============================================================================
 if command -v osv-scanner >/dev/null 2>&1; then
-  DIR_E2E=$(_dossier_safe_mktemp_dir "ac1-e2e")
+  _dossier_require_mktemp_dir DIR_E2E "ac1-e2e"
   mkdir -p "$DIR_E2E/target" "$DIR_E2E/out"
   # django 2.0.1 and requests 2.6.0 both carry multiple real, published
   # Critical/High CVEs (confirmed via a live osv-scanner run against this
@@ -477,7 +477,7 @@ fi
 # not exercised as an `ok` case here.)
 # =============================================================================
 if command -v osv-scanner >/dev/null 2>&1; then
-  DIR_CLEAN=$(_dossier_safe_mktemp_dir "genuine-scan")
+  _dossier_require_mktemp_dir DIR_CLEAN "genuine-scan"
   mkdir -p "$DIR_CLEAN/target"
   printf 'requests==2.32.3\n' >"$DIR_CLEAN/target/requirements.txt"
   OUT_CLEAN=$(DOSSIER_ENGAGEMENT_ALLOWED_ACTIONS_RUN_SECURITY_SCAN=true CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
@@ -509,7 +509,7 @@ assert_equal "disabled" "$STATUS_CROSSFLAG" "AC3: runCodeQualityScan=true alone 
 # =============================================================================
 QUALITY_SCRIPT="$(pwd)/plugins/dossier/bin/dossier-scan-quality.sh"
 if [ -x "$QUALITY_SCRIPT" ]; then
-  DIR_JOINT=$(_dossier_safe_mktemp_dir "ac3-joint")
+  _dossier_require_mktemp_dir DIR_JOINT "ac3-joint"
   mkdir -p "$DIR_JOINT/sec-target" "$DIR_JOINT/qual-target"
   printf 'def f():\n    pass\n' >"$DIR_JOINT/qual-target/mod.py"
 
@@ -553,7 +553,7 @@ assert_equal "2" "$?" "exits 2 on an unrecognized flag"
 # mkdir -p fails structurally (not a permissions flake), independent of
 # whether the test runs as root.
 # =============================================================================
-DIR_OUTFAIL=$(_dossier_safe_mktemp_dir "out-write-failure")
+_dossier_require_mktemp_dir DIR_OUTFAIL "out-write-failure"
 mkdir -p "$DIR_OUTFAIL/target"
 printf 'not a directory\n' >"$DIR_OUTFAIL/blocker"
 OUT_OUTFAIL=$(CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" "$SCRIPT" --target "$DIR_OUTFAIL/target" --out "$DIR_OUTFAIL/blocker/nested" 2>/dev/null)
@@ -577,7 +577,7 @@ assert_contains "could not create --out directory" "$STDERR_OUTFAIL" "--out unde
 # its own, just with no upper bound). A stub that runs for ~2 real seconds
 # forces the poll loop to iterate at least once, so a stderr comparison
 # error would appear if the guard's own internal check were still broken.
-DIR_BADTIMEOUT=$(_dossier_safe_mktemp_dir "bad-timeout-env")
+_dossier_require_mktemp_dir DIR_BADTIMEOUT "bad-timeout-env"
 mkdir -p "$DIR_BADTIMEOUT/fakebin" "$DIR_BADTIMEOUT/target"
 cat >"$DIR_BADTIMEOUT/fakebin/osv-scanner" <<'EOF'
 #!/usr/bin/env bash
@@ -598,7 +598,7 @@ if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
 else
   BADAGE_CACHE_REL=".cache/osv-scanner/PyPI"
 fi
-DIR_BADAGE_HOME=$(_dossier_safe_mktemp_dir "bad-max-age-env-home")
+_dossier_require_mktemp_dir DIR_BADAGE_HOME "bad-max-age-env-home"
 mkdir -p "$DIR_BADAGE_HOME/$BADAGE_CACHE_REL"
 printf 'placeholder db\n' >"$DIR_BADAGE_HOME/$BADAGE_CACHE_REL/all.zip"
 OUT_BADAGE=$(DOSSIER_ENGAGEMENT_ALLOWED_ACTIONS_RUN_SECURITY_SCAN=true DOSSIER_SCAN_OFFLINE_MAX_AGE_DAYS=not-a-number \
@@ -626,7 +626,7 @@ assert_contains "Exit: 0 for every case" "$HELP_OUT" "--help output reaches the 
 # =============================================================================
 # A plain FILE as --target (not merely a nonexistent path) must be the same
 # explicit error as a nonexistent target -- the -d check's own job.
-DIR_FILETARGET=$(_dossier_safe_mktemp_dir "file-as-target")
+_dossier_require_mktemp_dir DIR_FILETARGET "file-as-target"
 printf 'not a directory\n' >"$DIR_FILETARGET/plainfile"
 OUT_FILETARGET=$(DOSSIER_ENGAGEMENT_ALLOWED_ACTIONS_RUN_SECURITY_SCAN=true CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
   "$SCRIPT" --target "$DIR_FILETARGET/plainfile" 2>&1)
@@ -639,7 +639,7 @@ assert_equal "error" "$STATUS_FILETARGET" "a plain file as --target (not a direc
 # permission checks entirely), so this degrades honestly rather than
 # false-failing in that environment.
 if [ "$(id -u)" != "0" ]; then
-  DIR_NOEXEC_PARENT=$(_dossier_safe_mktemp_dir "noexec-target")
+  _dossier_require_mktemp_dir DIR_NOEXEC_PARENT "noexec-target"
   mkdir -p "$DIR_NOEXEC_PARENT/locked"
   chmod 644 "$DIR_NOEXEC_PARENT/locked"
   OUT_NOEXEC=$(DOSSIER_ENGAGEMENT_ALLOWED_ACTIONS_RUN_SECURITY_SCAN=true CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
@@ -654,7 +654,7 @@ fi
 # osv-scanner emitting non-JSON stdout with exit 0 (a malformed-tool-output
 # case distinct from every other error path, which all involve either a
 # nonzero exit or valid-but-empty JSON).
-DIR_MALFORMED=$(_dossier_safe_mktemp_dir "malformed-stdout")
+_dossier_require_mktemp_dir DIR_MALFORMED "malformed-stdout"
 mkdir -p "$DIR_MALFORMED/fakebin" "$DIR_MALFORMED/target"
 cat >"$DIR_MALFORMED/fakebin/osv-scanner" <<'EOF'
 #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

Closes #149. `plugins/dossier/tests/lib/assert.sh`'s `_dossier_safe_mktemp_dir()` was hardened to `exit 2` on any internal failure (unset `RUN_TMPDIR`, failed `mktemp -d`, unusable path), specifically so a caller doing `VAR=$(_dossier_safe_mktemp_dir ...)` could never silently receive an empty string — `cd ""` returns 0 in bash, a silent no-op, not an abort. But `exit 2` inside a `$(...)` command substitution only kills that subshell; a caller that doesn't check the assignment's own exit status proceeds with `VAR=""` anyway. `local-merge-hook.test.sh`'s two call sites had exactly this gap, and it corrupted this repo's real working directory twice this session (stray local branches, a briefly-misattributed commit author).

## What changed

- **New**: `_dossier_require_mktemp_dir <varname> <prefix>` in `plugins/dossier/tests/lib/assert.sh` — the sanctioned way to consume `_dossier_safe_mktemp_dir`'s output. Does the capture-and-check exactly once, as a plain function call (never itself wrapped in `$(...)`), so an internal failure's `exit 2` actually propagates through the caller's real shell.
- **Fixed**: `local-merge-hook.test.sh`'s two named call sites (`FLOWLESS_ROOT`, `REPO`).
- **Repo-wide**: the issue flagged this file as "unlikely to be the only caller with the gap." A repo-wide audit confirmed that: 108 more unguarded call sites across 8 other test files, none with any existing exit-code or emptiness guard. All converted to the new helper, including 7 sites in `rotation-check.test.sh` that appended a path suffix to the substitution (e.g. `SUMMARY1=$(...)/summary.md`), split into a two-line dir-then-compose form.
- **Second-order fix** (found by `/flow:pr` review): `setup_fixture()`/`no_gh_path()` in `rotation-check.test.sh` and `setup_fixture()` in `staleness-trigger.test.sh` called the new guard correctly *internally*, but were themselves invoked via `$(...)` at ~24 call sites — reopening the exact bug one level up, since `$(...)` forks a subshell around the whole function body too. Converted both to the same out-parameter convention (`printf -v` into a caller-named variable, called as a plain statement) as the guard itself, and updated every call site.
- **Third-order fix** (found by `/flow:review`'s paired-reviewer round): the wrapper functions' own out-parameter handoff was itself unguarded — the same "`printf -v` can fail silently" class already fixed in the main helper had been reintroduced one level up, in the second-order fix's own new code. Extracted a shared `_dossier_assign_outvar <varname> <value>` helper (guarded, matching the FATAL+exit-2 pattern) and had every out-parameter assignment in the file delegate to it. Also added a static lint (`mktemp-guard.test.sh` scenario 6, pure awk/grep) that permanently guards against any future helper reintroducing this whole bug class, `local`-scoped `no_gh_path`/`setup_fixture`'s internal variables (previously inert only by accident of always running in a subshell — now actually enforced), and added `local _dir` to `_dossier_safe_mktemp_dir` as proactive hardening.

## Review

Two rounds. `/flow:pr`'s 5-agent parallel review (code-quality, convention, security, test-runner, error-handling): convention and test-runner clean; code-quality, security, and error-handling independently converged on the second-order guard-swallow from three different angles, fixed and re-verified. A reviewer's `local _dir` suggestion was investigated and empirically disproven as a *live-bug* fix at the time (the guard's own internal `$(...)` call already isolates `_dir`) — not applied in that round.

`/flow:review`'s Path A paired-reviewer round (10 agents, 5 facets × skeptic/verifier) re-reviewed the PR at that HEAD and found 14 more findings, converging across 2-4 independent reviewers each on: the wrapper out-parameter handoff being unguarded, `no_gh_path`/`setup_fixture` needing `local` scoping, no durable lint against reintroduction, and `local _dir` re-raised with a different framing (not "fixes a live bug" but "the file's own docstring actively directs future contributors toward a refactor that would make it live") — accepted this time as cheap, zero-behavior-change proactive hardening. 8 findings fixed in-PR, 1 filed as a separate tracked issue ([#151](https://github.com/synaptiai/synapti-marketplace/issues/151) — an unrelated, pre-existing vacuous-pass bug in `disclosure-gate.test.sh`, not touched by this PR), 5 documented as reasoned not-fixed. Full per-finding breakdown in the [review comment](https://github.com/synaptiai/synapti-marketplace/pull/150#pullrequestreview-4843425289) and [resolution comment](https://github.com/synaptiai/synapti-marketplace/pull/150#issuecomment-5165619674).

## Verification

- [x] Full suite: `bash plugins/dossier/tests/run.sh` — **1852/1852** (1798 pre-change → 1844 after round 1 → 1848 after round 2 → 1852 after round 3)
- [x] `shellcheck -S warning -x plugins/dossier/tests/*.sh` (exact CI invocation) — clean, exit 0
- [x] `bash -n` on every modified file — clean
- [x] Regression test (`mktemp-guard.test.sh`) reproduces the exact corruption mechanism RED against the pre-fix `local-merge-hook.test.sh`, then confirms GREEN — plus pattern-level regression tests for the second-order (scenario 4) and third-order (scenario 5) fixes, independent of any specific file
- [x] Static lint (`mktemp-guard.test.sh` scenario 6): no `*.test.sh` file defines a guard-consuming function that's also invoked via `$(...)`/backticks anywhere in that file — verified it actually catches a deliberately-introduced violation before trusting it as a permanent regression guard
- [x] CI: 4/4 checks green (`test`, `CodeQL`, `Analyze (actions)`, `Analyze (python)`), independently re-checked via `gh pr checks` per this project's own memory of prior local-green/CI-red divergence on this exact plugin
- [x] TDD throughout: every fix reproduced RED against the pre-fix code before being confirmed GREEN

Full detail (specification, acceptance criteria, verification evidence, all three rounds' findings) in `.decisions/issue-149.md`.
