### PR TITLE
fix(dossier): hook/policy hardening — find-exec bypass, fork-PR hijack, rotation telemetry

### DIFF
--- a/.decisions/issue-143.md
+++ b/.decisions/issue-143.md
@@ -22,6 +22,9 @@ artifacts:
   captured_at: '2026-08-03T11:58:58Z'
   result: PASS
   task_count: 5
+- type: verdict
+  captured_at: '2026-08-03T12:11:27Z'
+  result: PASS
 ---
 # Issue #143 — enforce-allowed-actions.sh: find -exec / xargs -I{} bypass the action-ceiling backstop
 
@@ -127,3 +130,48 @@ explicitly in the FlowGoal contract rather than silently treated as fully automa
 <!-- auto-log: 2026-08-03 13:59 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/hooks.test.sh -->
 
 <!-- auto-log: 2026-08-03 14:00 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh -->
+
+<!-- auto-log: 2026-08-03 14:01 commit "fix(dossier): classify find/xargs as WRAPPER commands, closing the -exec/-I{} action-ceiling bypass" -->
+
+<!-- auto-log: 2026-08-03 14:01 Write /Users/danielbentes/synapti-marketplace/.decisions/issue-146.md -->
+
+<!-- auto-log: 2026-08-03 14:02 Write /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/policy-existing-pr.test.sh -->
+
+<!-- auto-log: 2026-08-03 14:03 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/policy-existing-pr.test.sh -->
+
+<!-- auto-log: 2026-08-03 14:03 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/policy-existing-pr.test.sh -->
+
+<!-- auto-log: 2026-08-03 14:03 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-policy.sh -->
+
+<!-- auto-log: 2026-08-03 14:04 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-146.md -->
+
+<!-- auto-log: 2026-08-03 14:04 commit "fix(dossier): scope dossier-policy.sh's EXISTING_PR lookup to same-repo PRs" -->
+
+<!-- auto-log: 2026-08-03 14:04 Write /Users/danielbentes/synapti-marketplace/.decisions/issue-148.md -->
+
+<!-- auto-log: 2026-08-03 14:04 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/workflow-template.test.sh -->
+
+<!-- auto-log: 2026-08-03 14:05 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/workflow-template.test.sh -->
+
+<!-- auto-log: 2026-08-03 14:05 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/templates/ci/dossier-docs-refresh.yml -->
+
+<!-- auto-log: 2026-08-03 14:05 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/templates/ci/dossier-docs-refresh.yml -->
+
+<!-- auto-log: 2026-08-03 14:06 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/workflow-template.test.sh -->
+
+<!-- auto-log: 2026-08-03 14:06 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-148.md -->
+
+<!-- auto-log: 2026-08-03 14:06 commit "feat(dossier): surface rotation-check telemetry as policy job outputs" -->
+
+## Verification
+
+- Full suite: `bash plugins/dossier/tests/run.sh` — 1882/1882 (up from 1852 pre-bundle).
+- `shellcheck -S warning -x plugins/dossier/tests/*.sh plugins/dossier/bin/*.sh
+  plugins/dossier/hooks/scripts/*.sh` — clean, exit 0, across every script in the plugin.
+- `bash -n` on every modified/new file — clean.
+- Each of the three bundled fixes (#143, #146, #148) TDD RED-confirmed against the
+  unpatched code first, then GREEN after its own fix, with per-file regression checks
+  (staleness-trigger.test.sh for #146; no cross-file breakage anywhere for #143/#148).
+- One test-authoring bug caught and fixed during #148's RED->GREEN cycle: an
+  assert_not_contains collision check matched as a substring of its own sibling
+  assertion; fixed by anchoring on exact YAML key position.

--- a/.decisions/issue-143.md
+++ b/.decisions/issue-143.md
@@ -123,6 +123,24 @@ live script, before this skill was invoked)._
 
 <!-- auto-log: 2026-08-03 13:57 Write /Users/danielbentes/synapti-marketplace/.flow/runs/2026-08-03T115319Z-issue-143/run.yaml -->
 
+## Acceptance Criteria (as validated)
+
+1. `find ... -exec <denied-command> ...`, `find ... -execdir <denied-command> ...`, and
+   `xargs -I{} <denied-command> {}` (and their common flag variants) are correctly denied
+   when the corresponding capability is off, for every existing deny-block (`runTests`,
+   `runBuild`, `networkAccess`, `runSecurityScan`, `runCodeQualityScan`), not just
+   newly-added ones. Verification: `bash plugins/dossier/tests/run.sh hooks.test.sh`
+2. The fix does not regress any existing passing case in `plugins/dossier/tests/hooks.test.sh`
+   (the wrapper-indirection and grep-about-a-command cases especially). Verification: same
+   command, full file green (94/94, up from 85/85 pre-fix).
+3. The approach is documented as classifying command structure rather than enumerating more
+   literal indirection tokens, so a future new indirection shape doesn't require another
+   narrowing/widening round. Verification: `grep -n "find"
+   plugins/dossier/hooks/scripts/enforce-allowed-actions.sh` + manual read of the revised
+   comment block.
+4. Covered by new test cases in `hooks.test.sh` for each denied-command class named above.
+   Verification: same command as AC1/AC2.
+
 ## Stranger Test
 
 PASS — 5 tasks reviewed. Each names exact file paths/lines, the exact regex/field
@@ -193,3 +211,47 @@ explicitly in the FlowGoal contract rather than silently treated as fully automa
 <!-- auto-log: 2026-08-03 14:18 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/verdict-issue-143.json -->
 
 <!-- auto-log: 2026-08-03 14:26 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/issue-143-lifecycle-achieved.yaml -->
+
+<!-- auto-log: 2026-08-03 14:28 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/cmd_backslash.txt -->
+
+<!-- auto-log: 2026-08-03 14:41 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/policy-existing-pr.test.sh -->
+
+<!-- auto-log: 2026-08-03 14:42 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/policy-existing-pr.test.sh -->
+
+<!-- auto-log: 2026-08-03 14:42 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-policy.sh -->
+
+<!-- auto-log: 2026-08-03 14:42 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-policy.sh -->
+
+<!-- auto-log: 2026-08-03 14:42 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-policy.sh -->
+
+<!-- auto-log: 2026-08-03 14:42 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-policy.sh -->
+
+<!-- auto-log: 2026-08-03 14:43 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-policy.sh -->
+
+<!-- auto-log: 2026-08-03 14:43 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-policy.sh -->
+
+<!-- auto-log: 2026-08-03 14:43 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/templates/ci/dossier-docs-refresh.yml -->
+
+<!-- auto-log: 2026-08-03 14:44 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/templates/ci/dossier-docs-refresh.yml -->
+
+<!-- auto-log: 2026-08-03 14:44 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/templates/ci/dossier-docs-refresh.yml -->
+
+<!-- auto-log: 2026-08-03 14:44 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/workflow-template.test.sh -->
+
+<!-- auto-log: 2026-08-03 14:46 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/hooks.test.sh -->
+
+<!-- auto-log: 2026-08-03 14:47 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh -->
+
+<!-- auto-log: 2026-08-03 14:48 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh -->
+
+<!-- auto-log: 2026-08-03 14:49 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh -->
+
+<!-- auto-log: 2026-08-03 14:49 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-146.md -->
+
+<!-- auto-log: 2026-08-03 14:49 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-148.md -->
+
+<!-- auto-log: 2026-08-03 14:50 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-143.md -->
+
+<!-- auto-log: 2026-08-03 14:55 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-146.md -->
+
+<!-- auto-log: 2026-08-03 14:55 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-148.md -->

--- a/.decisions/issue-143.md
+++ b/.decisions/issue-143.md
@@ -1,0 +1,129 @@
+---
+issue: 143
+created: '2026-08-03T11:53:19Z'
+artifacts:
+- type: specification
+  captured_at: '2026-08-03T11:54:46Z'
+  by: specification-capture
+  elements:
+  - non-goals
+  - failure-modes
+  - interface-contracts
+- type: goal-created
+  captured_at: '2026-08-03T11:57:32Z'
+  goal_id: issue-143
+  source: github_issue:143
+- type: workflow-run
+  captured_at: '2026-08-03T11:57:55Z'
+  workflow: start-issue
+  run_id: 2026-08-03T115319Z-issue-143
+  status: active
+- type: stranger-test
+  captured_at: '2026-08-03T11:58:58Z'
+  result: PASS
+  task_count: 5
+---
+# Issue #143 — enforce-allowed-actions.sh: find -exec / xargs -I{} bypass the action-ceiling backstop
+
+**Title**: dossier: enforce-allowed-actions.sh's action-ceiling backstop can be bypassed via find -exec / xargs -I{}
+**Labels**: bug, plugin
+
+## Bundle note
+
+This PR bundles three issues under one hook/policy-hardening theme, per user-approved
+sequencing: #143 (this issue, driving `/flow:start`'s branch/goal/journal machinery),
+#146 (`dossier-policy.sh` fork-PR hijack, `.decisions/issue-146.md`), and #148
+(rotation telemetry not wired to CI job outputs, `.decisions/issue-148.md`). The three
+fixes touch disjoint files and ship as separate atomic commits within one PR, which
+closes all three issues.
+
+## Specification
+
+_Captured by specification-capture skill on 2026-08-03. Source: user-confirmed (resolved via
+a direct AskUserQuestion interview, cross-checked against empirical reproduction on the
+live script, before this skill was invoked)._
+
+### Non-goals
+
+- Not building a full POSIX/bash shell-grammar parser. This hook is a local/interactive-only
+  backstop with zero CI reach (the CI refresh job's `--allowedTools` allowlist doesn't include
+  `find`/`xargs`/a bare shell at all), so a grammar parser is disproportionate to the blast
+  radius.
+- Not closing every command that can embed an arbitrary sub-command in its arguments (GNU
+  `parallel`, `awk 'system(...)'`, `perl -e 'exec(...)'`, `watch -x`, etc.) — only `find`
+  (`-exec`/`-execdir`/`-ok`/`-okdir`) and `xargs` (`-I`/`-i`), the two named in the issue's
+  acceptance criteria. The residual class is left as a documented, deliberately out-of-scope
+  code comment, not a new tracked issue — no concrete forcing function exists for it yet,
+  unlike this issue, which came from an actual review finding on PR #145's traffic.
+- No code change needed for `xargs` specifically: empirically verified (direct reproduction
+  against the live script) that `xargs -I{} curl {}` and `xargs -I{} pyscn {}` — both named in
+  the issue body as unblocked — are in fact ALREADY blocked today, because `xargs` already
+  matches the existing `WRAPPER` token list as a standalone word, which already flips the whole
+  command into whitespace-boundary mode. Only `find` is a live gap. The issue's own
+  reproduction claim about `xargs` does not hold against the current committed code and is
+  treated as already resolved.
+- Not touching `BOUND` (the strict no-wrapper anchor) or the `SCAN`/`BOUND_ACTIVE` derivation
+  logic — the fix is entirely a `WRAPPER`-token-list addition (one alternative, `find`, added
+  to the existing token-alternation group).
+
+### Failure modes
+
+- **Timeouts** — none — this is a synchronous regex-based hook with no I/O or network calls
+  that could hang; nothing to time out.
+- **Partial failures** — none — the fix is a single-line regex alternation addition with no
+  multi-step operation that could partially complete.
+- **Invalid input** — a wrapper-mode false positive: `find . -name "npm test"` (no `-exec` at
+  all, just a filename pattern that happens to contain a denied phrase) becomes over-blocked
+  once `find` is a `WRAPPER` token, because `WRAPPER`-mode makes every whitespace run a
+  boundary. This is the SAME accepted-tradeoff class already documented and shipped for every
+  other `WRAPPER` token (e.g. `timeout 5 grep -r "npm test" docs/` is already over-blocked
+  today) — not a new failure mode being introduced, but pinned down with an explicit regression
+  test for the first time (previously this tradeoff class was only ever documented in a
+  comment, never asserted in `hooks.test.sh`).
+- **Missing context** — none — no new config/env dependency is introduced; the fix reuses the
+  existing `WRAPPER` variable, which is already resolved unconditionally at hook-invocation
+  time with no external state.
+
+### Interface contracts
+
+- `WRAPPER` regex in `plugins/dossier/hooks/scripts/enforce-allowed-actions.sh`: add the
+  literal alternative `find` to the existing token-alternation group (alongside
+  `bash|sh|zsh|...|python|python3`), preserving the exact same anchoring/lookaround structure.
+  No new variables, no new functions, no change to `BOUND`, `BOUND_ACTIVE` derivation, or the
+  `SCAN` sed rewrite.
+- No change to any deny-block's own detection regex (`runTests`/`runBuild`/`networkAccess`/
+  `runSecurityScan`/`runCodeQualityScan`) — the fix is entirely upstream of them, in the shared
+  `WRAPPER`/`BOUND_ACTIVE` mechanism they all consume. This is what makes the fix apply to
+  "every existing deny-block... not just newly-added ones" (AC1) without touching five separate
+  blocks.
+- Test additions land in `plugins/dossier/tests/hooks.test.sh` only, following the file's
+  existing loop-based `"sees through the wrapper: $BAD"` assertion pattern (see the existing
+  wrapper-indirection loops around line 122 and line 190).
+- The existing "Known limitation, not fixed here (issue synaptiai/synapti-marketplace#143)"
+  comment block (lines 94-107) is revised, not deleted: it documents what got fixed (`find`)
+  and what remains a deliberately out-of-scope residual class (`parallel`/`awk`/`perl`/etc.),
+  per the Non-goals above.
+
+<!-- auto-log: 2026-08-03 13:56 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/issue-143.goal.yaml -->
+
+<!-- auto-log: 2026-08-03 13:57 Edit /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/issue-143.goal.yaml -->
+
+<!-- auto-log: 2026-08-03 13:57 Edit /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/issue-143.goal.yaml -->
+
+<!-- auto-log: 2026-08-03 13:57 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/issue-143-lifecycle-active.yaml -->
+
+<!-- auto-log: 2026-08-03 13:57 Write /Users/danielbentes/synapti-marketplace/.flow/runs/2026-08-03T115319Z-issue-143/run.yaml -->
+
+## Stranger Test
+
+PASS — 5 tasks reviewed. Each names exact file paths/lines, the exact regex/field
+changes, the exact existing-code precedent being mirrored (PR #145's SEC-1 fix for
+task 3; the existing WRAPPER token-list mechanism for tasks 1-2; the should_run/reason
+outputs pattern for task 4), and an exact verification command. Task 2 (AC3, comment
+documentation) carries one fuzzy/manual verification component (does the revised
+comment read as structural framing) alongside its automated grep check — flagged
+explicitly in the FlowGoal contract rather than silently treated as fully automatable.
+
+<!-- auto-log: 2026-08-03 13:59 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/hooks.test.sh -->
+
+<!-- auto-log: 2026-08-03 14:00 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh -->

--- a/.decisions/issue-143.md
+++ b/.decisions/issue-143.md
@@ -31,6 +31,12 @@ artifacts:
   result: achieved
   evidence_bundle: .flow/runs/2026-08-03T115319Z-issue-143
   failures: none
+- type: review-cycle
+  captured_at: '2026-08-03T12:57:58Z'
+  cycle: 1
+  path: B
+  findings_count: 8
+  pr: 153
 ---
 # Issue #143 — enforce-allowed-actions.sh: find -exec / xargs -I{} bypass the action-ceiling backstop
 
@@ -255,3 +261,7 @@ explicitly in the FlowGoal contract rather than silently treated as fully automa
 <!-- auto-log: 2026-08-03 14:55 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-146.md -->
 
 <!-- auto-log: 2026-08-03 14:55 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-148.md -->
+
+<!-- auto-log: 2026-08-03 14:56 commit "fix(dossier): guard the docs-branch recreate path against a failed PR lookup" -->
+
+<!-- auto-log: 2026-08-03 14:57 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/pr-150-body.md -->

--- a/.decisions/issue-143.md
+++ b/.decisions/issue-143.md
@@ -92,8 +92,10 @@ live script, before this skill was invoked)._
 
 - **Timeouts** — none — this is a synchronous regex-based hook with no I/O or network calls
   that could hang; nothing to time out.
-- **Partial failures** — none — the fix is a single-line regex alternation addition with no
-  multi-step operation that could partially complete.
+- **Partial failures** — none — the fix (originally a single-line regex alternation addition;
+  shipped as a new `FIND_EXEC` variable plus a widened trigger condition, see Interface
+  contracts) is still a synchronous regex evaluation with no multi-step operation that could
+  partially complete.
 - **Invalid input** — **superseded during review, correction**: the paragraph originally here
   described `find . -name "npm test"` as an accepted over-block tradeoff, matching the original
   bare-`find`-in-`WRAPPER` design. A code-review pass on this PR demonstrated live that this
@@ -103,9 +105,9 @@ live script, before this skill was invoked)._
   `FIND_EXEC` regex requiring `find` to co-occur with `-exec`/`-execdir`/`-ok`/`-okdir`) resolves
   this rather than accepting it: `hooks.test.sh` now asserts `find . -name "npm test"` and the
   commit-message case both correctly return RC=0 (not blocked).
-- **Missing context** — none — no new config/env dependency is introduced; the fix reuses the
-  existing `WRAPPER` variable, which is already resolved unconditionally at hook-invocation
-  time with no external state.
+- **Missing context** — none — no new config/env dependency is introduced; the fix's inputs
+  (`FIND_EXEC`, like `WRAPPER` before it) are resolved unconditionally at hook-invocation time
+  with no external state.
 
 ### Interface contracts
 
@@ -382,3 +384,7 @@ pre-bundle). `shellcheck -S warning -x` across every touched script — clean, e
 <!-- auto-log: 2026-08-03 15:57 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/pr-153-self-review.md -->
 
 <!-- auto-log: 2026-08-03 15:57 commit "fix(dossier): capture git rev-list's stderr separately from its stdout" -->
+
+<!-- auto-log: 2026-08-03 16:10 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-143.md -->
+
+<!-- auto-log: 2026-08-03 16:10 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-143.md -->

--- a/.decisions/issue-143.md
+++ b/.decisions/issue-143.md
@@ -25,6 +25,12 @@ artifacts:
 - type: verdict
   captured_at: '2026-08-03T12:11:27Z'
   result: PASS
+- type: goal-evaluation
+  captured_at: '2026-08-03T12:19:05Z'
+  goal_id: issue-143
+  result: achieved
+  evidence_bundle: .flow/runs/2026-08-03T115319Z-issue-143
+  failures: none
 ---
 # Issue #143 — enforce-allowed-actions.sh: find -exec / xargs -I{} bypass the action-ceiling backstop
 
@@ -175,3 +181,15 @@ explicitly in the FlowGoal contract rather than silently treated as fully automa
 - One test-authoring bug caught and fixed during #148's RED->GREEN cycle: an
   assert_not_contains collision check matched as a substring of its own sibling
   assertion; fixed by anchoring on exact YAML key position.
+
+<!-- auto-log: 2026-08-03 14:12 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/evidence-AC1.yaml -->
+
+<!-- auto-log: 2026-08-03 14:12 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/evidence-AC2.yaml -->
+
+<!-- auto-log: 2026-08-03 14:12 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/evidence-AC3.yaml -->
+
+<!-- auto-log: 2026-08-03 14:12 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/evidence-AC4.yaml -->
+
+<!-- auto-log: 2026-08-03 14:18 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/verdict-issue-143.json -->
+
+<!-- auto-log: 2026-08-03 14:26 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/issue-143-lifecycle-achieved.yaml -->

--- a/.decisions/issue-143.md
+++ b/.decisions/issue-143.md
@@ -78,8 +78,15 @@ live script, before this skill was invoked)._
   reproduction claim about `xargs` does not hold against the current committed code and is
   treated as already resolved.
 - Not touching `BOUND` (the strict no-wrapper anchor) or the `SCAN`/`BOUND_ACTIVE` derivation
-  logic — the fix is entirely a `WRAPPER`-token-list addition (one alternative, `find`, added
-  to the existing token-alternation group).
+  logic itself — the fix only widens the *trigger condition* that decides whether that
+  derivation runs (see Interface contracts below for the final shape, which diverged from the
+  original single-token-addition approach captured here).
+
+  > **Superseded during review** (kept for audit trail, not current): the original design below
+  > added `find` directly to the `WRAPPER` token-alternation group. A code-review pass on this
+  > PR found that over-blocked any command merely containing the word "find" (not just actual
+  > `find -exec` invocations), and the shipped fix instead uses a separate `FIND_EXEC` regex —
+  > see the Interface contracts and Failure modes sections' correction notes below.
 
 ### Failure modes
 
@@ -87,25 +94,30 @@ live script, before this skill was invoked)._
   that could hang; nothing to time out.
 - **Partial failures** — none — the fix is a single-line regex alternation addition with no
   multi-step operation that could partially complete.
-- **Invalid input** — a wrapper-mode false positive: `find . -name "npm test"` (no `-exec` at
-  all, just a filename pattern that happens to contain a denied phrase) becomes over-blocked
-  once `find` is a `WRAPPER` token, because `WRAPPER`-mode makes every whitespace run a
-  boundary. This is the SAME accepted-tradeoff class already documented and shipped for every
-  other `WRAPPER` token (e.g. `timeout 5 grep -r "npm test" docs/` is already over-blocked
-  today) — not a new failure mode being introduced, but pinned down with an explicit regression
-  test for the first time (previously this tradeoff class was only ever documented in a
-  comment, never asserted in `hooks.test.sh`).
+- **Invalid input** — **superseded during review, correction**: the paragraph originally here
+  described `find . -name "npm test"` as an accepted over-block tradeoff, matching the original
+  bare-`find`-in-`WRAPPER` design. A code-review pass on this PR demonstrated live that this
+  tradeoff class is broader than "npm test" specifically — it swept in any command merely
+  containing the word "find" (e.g. a commit message `git commit -m "docs: find and document the
+  test workflow"`), not just actual `find -exec` invocations. The shipped fix (a dedicated
+  `FIND_EXEC` regex requiring `find` to co-occur with `-exec`/`-execdir`/`-ok`/`-okdir`) resolves
+  this rather than accepting it: `hooks.test.sh` now asserts `find . -name "npm test"` and the
+  commit-message case both correctly return RC=0 (not blocked).
 - **Missing context** — none — no new config/env dependency is introduced; the fix reuses the
   existing `WRAPPER` variable, which is already resolved unconditionally at hook-invocation
   time with no external state.
 
 ### Interface contracts
 
-- `WRAPPER` regex in `plugins/dossier/hooks/scripts/enforce-allowed-actions.sh`: add the
-  literal alternative `find` to the existing token-alternation group (alongside
-  `bash|sh|zsh|...|python|python3`), preserving the exact same anchoring/lookaround structure.
-  No new variables, no new functions, no change to `BOUND`, `BOUND_ACTIVE` derivation, or the
-  `SCAN` sed rewrite.
+- **Superseded during review** (final shipped shape): a new `FIND_EXEC` regex variable,
+  `'(^|[;&|(]|[[:space:]])[[:space:]]*([A-Za-z0-9_.-]*/)*find([[:space:]]|$).*[[:space:]]-(exec|execdir|ok|okdir)([[:space:]]|$)'`,
+  requiring `find` to actually co-occur with one of its four sub-command-execution primaries.
+  The trigger condition for boundary-widening becomes
+  `grep -qE "$WRAPPER" || grep -qE "$FIND_EXEC"` — `find` itself is never added to `WRAPPER`.
+  No change to `BOUND`, `BOUND_ACTIVE`'s own derivation logic, or the `SCAN` sed rewrite — only
+  the condition that decides whether that derivation runs. (Superseded original design, kept
+  for audit trail: adding the literal alternative `find` to `WRAPPER` directly. See the
+  Non-goals and Failure modes correction notes above for why this was replaced.)
 - No change to any deny-block's own detection regex (`runTests`/`runBuild`/`networkAccess`/
   `runSecurityScan`/`runCodeQualityScan`) — the fix is entirely upstream of them, in the shared
   `WRAPPER`/`BOUND_ACTIVE` mechanism they all consume. This is what makes the fix apply to
@@ -138,10 +150,10 @@ live script, before this skill was invoked)._
    newly-added ones. Verification: `bash plugins/dossier/tests/run.sh hooks.test.sh`
 2. The fix does not regress any existing passing case in `plugins/dossier/tests/hooks.test.sh`
    (the wrapper-indirection and grep-about-a-command cases especially). Verification: same
-   command, full file green (94/94, up from 85/85 pre-fix).
+   command, full file green (98/98 as of the final `FIND_EXEC` shape, up from 85/85 pre-fix).
 3. The approach is documented as classifying command structure rather than enumerating more
    literal indirection tokens, so a future new indirection shape doesn't require another
-   narrowing/widening round. Verification: `grep -n "find"
+   narrowing/widening round. Verification: `grep -n "FIND_EXEC"
    plugins/dossier/hooks/scripts/enforce-allowed-actions.sh` + manual read of the revised
    comment block.
 4. Covered by new test cases in `hooks.test.sh` for each denied-command class named above.
@@ -356,3 +368,17 @@ pre-bundle). `shellcheck -S warning -x` across every touched script — clean, e
 <!-- auto-log: 2026-08-03 15:45 commit "fix(dossier): paginate the EXISTING_PR lookup and distinguish a failed lookup from a confirmed none" -->
 
 <!-- auto-log: 2026-08-03 15:45 commit "fix(dossier): fail closed on an ambiguous PR-lookup signal and verify rev-list's exit status before trusting its output" -->
+
+<!-- auto-log: 2026-08-03 15:54 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/templates/ci/dossier-docs-refresh.yml -->
+
+<!-- auto-log: 2026-08-03 15:55 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-143.md -->
+
+<!-- auto-log: 2026-08-03 15:55 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-143.md -->
+
+<!-- auto-log: 2026-08-03 15:56 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-143.md -->
+
+<!-- auto-log: 2026-08-03 15:56 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-143.md -->
+
+<!-- auto-log: 2026-08-03 15:57 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/pr-153-self-review.md -->
+
+<!-- auto-log: 2026-08-03 15:57 commit "fix(dossier): capture git rev-list's stderr separately from its stdout" -->

--- a/.decisions/issue-143.md
+++ b/.decisions/issue-143.md
@@ -206,6 +206,43 @@ explicitly in the FlowGoal contract rather than silently treated as fully automa
   assert_not_contains collision check matched as a substring of its own sibling
   assertion; fixed by anchoring on exact YAML key position.
 
+### Review-driven fix-forward (PR #153's `/flow:review`, Path A paired-reviewer protocol)
+
+A 10-agent paired-reviewer pass (5 facets x {skeptic, verifier}) plus 2 holdout-validation
+lenses converged on several findings beyond the three original fixes, all fixed in the same
+PR before merge:
+
+- **ERR-2 / P1 (doubly-confirmed)**: `enforce-allowed-actions.sh`'s config-resolver call could
+  return an empty `OUTPUT_ROOT`, which — read literally — meant "the empty string is the output
+  root," silently defeating the inertness check. Fixed with an explicit non-empty fallback.
+- **P1/P2/P3 (convergent)**: the hook's jq-parse-failure check ran after the inertness check,
+  so a malformed payload on a non-dossier command could still surface a spurious BLOCKED.
+  Reordered so inertness is decided before any JSON parsing.
+- **P2 (code-verifier)**: the bare `find` token in `WRAPPER` over-blocked commands like
+  `find . -name "npm test"` that never use `-exec`. Replaced with a dedicated `FIND_EXEC` regex
+  requiring `find` to actually co-occur with `-exec`/`-execdir`/`-ok`/`-okdir`.
+- **P2 (cross-facet convergent, raised independently by security-skeptic and code-skeptic)**:
+  the `EXISTING_PR` lookup in `dossier-policy.sh` had no `--limit`, unlike the file's own
+  circuit-breaker precedent. Added `--limit 100`.
+- **P2/P3 (triple-convergent)**: `write_summary()`'s "Existing docs PR" row couldn't distinguish
+  a genuinely-confirmed `none` from an `unknown (lookup failed)` state. Fixed with an explicit
+  `elif` branch.
+- **SEC-1 (security-skeptic)**: `dossier-docs-refresh.yml`'s branch-recreate guard checked
+  `existing_pr_lookup_failed = "true"`, which fails OPEN on any other value (including absent).
+  Inverted to `!= "false"`, which fails closed on unexpected/absent values too.
+- **ERR-1 (error-handler skeptic+verifier auto-consensus)**: the same file's `git rev-list` call
+  feeding the FOREIGN-commit-detection loop never checked its own exit status, so a rev-list
+  failure was indistinguishable from "genuinely no foreign commits." Added explicit exit-status
+  capture and a refusal path matching the file's existing FOREIGN/lookup-failed refusal pattern.
+- Both YAML fixes got new line-order-aware static assertions in `workflow-template.test.sh`
+  (a plain `assert_contains` cannot detect a correct-looking guard that is unreachable because
+  it was moved after the code path it's meant to gate).
+- One shellcheck warning (SC2034, an unused captured-but-discarded command substitution in a
+  new test scenario) found and fixed during this pass.
+
+Final: `bash plugins/dossier/tests/run.sh` — 1912/1912 (up from 1882 pre-review-pass, 1852
+pre-bundle). `shellcheck -S warning -x` across every touched script — clean, exit 0.
+
 <!-- auto-log: 2026-08-03 14:12 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/evidence-AC1.yaml -->
 
 <!-- auto-log: 2026-08-03 14:12 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/evidence-AC2.yaml -->
@@ -265,3 +302,57 @@ explicitly in the FlowGoal contract rather than silently treated as fully automa
 <!-- auto-log: 2026-08-03 14:56 commit "fix(dossier): guard the docs-branch recreate path against a failed PR lookup" -->
 
 <!-- auto-log: 2026-08-03 14:57 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/pr-150-body.md -->
+
+<!-- auto-log: 2026-08-03 15:03 Write /Users/danielbentes/synapti-marketplace/.flow/runs/2026-08-03T130332Z-review/run.yaml -->
+
+<!-- auto-log: 2026-08-03 15:21 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh -->
+
+<!-- auto-log: 2026-08-03 15:22 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh -->
+
+<!-- auto-log: 2026-08-03 15:22 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh -->
+
+<!-- auto-log: 2026-08-03 15:22 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh -->
+
+<!-- auto-log: 2026-08-03 15:23 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/hooks.test.sh -->
+
+<!-- auto-log: 2026-08-03 15:23 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/hooks.test.sh -->
+
+<!-- auto-log: 2026-08-03 15:24 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/hooks.test.sh -->
+
+<!-- auto-log: 2026-08-03 15:25 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/policy-existing-pr.test.sh -->
+
+<!-- auto-log: 2026-08-03 15:26 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-policy.sh -->
+
+<!-- auto-log: 2026-08-03 15:26 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-policy.sh -->
+
+<!-- auto-log: 2026-08-03 15:26 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/policy-existing-pr.test.sh -->
+
+<!-- auto-log: 2026-08-03 15:28 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/templates/ci/dossier-docs-refresh.yml -->
+
+<!-- auto-log: 2026-08-03 15:33 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/templates/ci/dossier-docs-refresh.yml -->
+
+<!-- auto-log: 2026-08-03 15:35 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/workflow-template.test.sh -->
+
+<!-- auto-log: 2026-08-03 15:37 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/workflow-template.test.sh -->
+
+<!-- auto-log: 2026-08-03 15:37 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-146.md -->
+
+<!-- auto-log: 2026-08-03 15:38 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-146.md -->
+
+<!-- auto-log: 2026-08-03 15:38 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-146.md -->
+
+<!-- auto-log: 2026-08-03 15:38 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-148.md -->
+
+<!-- auto-log: 2026-08-03 15:38 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-148.md -->
+
+<!-- auto-log: 2026-08-03 15:39 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-148.md -->
+
+<!-- auto-log: 2026-08-03 15:40 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/policy-existing-pr.test.sh -->
+
+<!-- auto-log: 2026-08-03 15:41 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-143.md -->
+
+<!-- auto-log: 2026-08-03 15:45 commit "fix(dossier): fail closed on hook ordering/empty-resolver gaps, narrow find matching to its exec-family flags" -->
+
+<!-- auto-log: 2026-08-03 15:45 commit "fix(dossier): paginate the EXISTING_PR lookup and distinguish a failed lookup from a confirmed none" -->
+
+<!-- auto-log: 2026-08-03 15:45 commit "fix(dossier): fail closed on an ambiguous PR-lookup signal and verify rev-list's exit status before trusting its output" -->

--- a/.decisions/issue-146.md
+++ b/.decisions/issue-146.md
@@ -1,0 +1,83 @@
+---
+issue: 146
+created: '2026-08-03T11:53:19Z'
+---
+# Issue #146 — dossier-policy.sh: gh pr list --head is unscoped by repo
+
+**Title**: dossier-policy.sh: gh pr list --head is unscoped by repo, allowing a fork PR to hijack the docs-refresh publish flow
+**Labels**: bug, plugin
+
+## Bundle note
+
+Part of the hook/policy-hardening bundle driven by `/flow:start` on #143 (see
+`.decisions/issue-143.md`). This journal is hand-authored, matching the same
+Specification/AC/Verification schema `/flow:start`'s own skills would have produced,
+since `/flow:start` was not run separately against this issue number — the
+bundle's mechanics were resolved via a direct user interview before implementation
+began (see the `## Bundle note` in `.decisions/issue-143.md`).
+
+## Specification
+
+### Non-goals
+
+- Not touching `dossier-rotation-check.sh`'s own `gh pr list --head` call — it already
+  carries this exact fix (`isCrossRepository == false` filtering), shipped in PR #145's
+  SEC-1. This issue is the pre-existing original that fix was copied from.
+- Not touching either of the two OTHER `gh pr list` call sites in this codebase
+  (`dossier-policy.sh:448` circuit-breaker count, `dossier-docs-refresh.yml:736`
+  publish-job circuit-breaker audit) — both use `--state all --label`, never `--head`,
+  so they are not affected by this vulnerability class: a fork PR would need the
+  privileged `dossier:generated` label already applied by a write-token job to be
+  counted, which an external contributor cannot do on their own fork PR.
+- Not adding a generic "always filter cross-repo PRs" helper function — this is a
+  single, narrow, already-proven fix pattern (identical to PR #145's), not a new
+  abstraction.
+
+### Failure modes
+
+- **Timeouts** — none — no new network call; same `gh pr list` invocation, filtered
+  more precisely.
+- **Partial failures** — none — `gh` unavailability is already handled by the
+  surrounding `command -v gh` guard (degradation: publish rediscovers the PR anyway).
+- **Invalid input** — a fork PR opening a branch with the exact same name as
+  `$DOCS_BRANCH` (e.g. `docs/dossier`) must never be selected in place of, or ahead
+  of, the real same-repo PR — this is the exact exploit shape the issue describes.
+- **Missing context** — none — no new config/env dependency.
+
+### Interface contracts
+
+- `dossier-policy.sh:390`: `EXISTING_PR=$(gh pr list --head "$DOCS_BRANCH" --state open
+  --json number,isCrossRepository --jq '[.[] | select(.isCrossRepository == false)][0].number
+  // empty' 2>/dev/null)` — adds `isCrossRepository` to the requested JSON fields and
+  filters it out before taking `.[0]`, mirroring PR #145's SEC-1 fix verbatim.
+- New test file `plugins/dossier/tests/policy-existing-pr.test.sh`, using a fake `gh`
+  stub on `PATH` that applies the real `--jq` filter via actual `jq` (not a fixed
+  echo), porting `rotation-check.test.sh`'s scenario-17 technique.
+
+## Acceptance Criteria (as validated)
+
+1. `EXISTING_PR` resolution in `dossier-policy.sh` filters out cross-repository PRs
+   before selecting the first match. Verification: `bash plugins/dossier/tests/run.sh
+   policy-existing-pr.test.sh`
+2. A cross-repository decoy PR (same branch name, more recently created) never masks
+   or is preferred over the real same-repo PR. Verification: same test, scenario
+   asserting the same-repo PR's number is returned, not the decoy's.
+3. The full dossier test suite passes with no regression. Verification: `bash
+   plugins/dossier/tests/run.sh`
+
+## Stranger Test
+
+PASS — inherits task #78 from `.decisions/issue-143.md`'s Stranger Test, which named
+the exact file:line, the exact existing-code precedent (PR #145 SEC-1) being mirrored,
+and the exact test technique to port.
+
+## Verification
+
+- New regression test: `bash plugins/dossier/tests/run.sh policy-existing-pr.test.sh` —
+  6/6, RED-confirmed against the unpatched script first (fork decoy #99 won over the
+  real PR #7), GREEN after the fix.
+- No regression: `bash plugins/dossier/tests/run.sh staleness-trigger.test.sh
+  policy-existing-pr.test.sh` — 20/20.
+- `shellcheck -S warning -x plugins/dossier/bin/dossier-policy.sh
+  plugins/dossier/tests/policy-existing-pr.test.sh` — clean, exit 0.
+- `bash -n` on both modified/new files — clean.

--- a/.decisions/issue-146.md
+++ b/.decisions/issue-146.md
@@ -1,6 +1,6 @@
 ---
 issue: 146
-created: '2026-08-03T11:53:19Z'
+created: '2026-08-03T12:01:00Z'
 ---
 # Issue #146 — dossier-policy.sh: gh pr list --head is unscoped by repo
 
@@ -81,3 +81,19 @@ and the exact test technique to port.
 - `shellcheck -S warning -x plugins/dossier/bin/dossier-policy.sh
   plugins/dossier/tests/policy-existing-pr.test.sh` — clean, exit 0.
 - `bash -n` on both modified/new files — clean.
+
+### Review-driven follow-up (P1, fixed in the same PR)
+
+The error-handler-inspector review pass on the bundle PR found that this fix's own
+`gh pr list` call swallows the lookup's exit code — pre-existing shape, not introduced
+here, but now demonstrably reachable: a transient `gh` failure leaves `existing_pr`
+empty, indistinguishable from a genuine no-PR result, and the publish job's branch-
+preparation step treats that emptiness as license to delete and recreate the
+documentation branch whenever it already exists with no foreign commits — exactly the
+steady state whenever a real docs PR IS open. Fixed by adding a new
+`existing_pr_lookup_failed` output (set on both a `gh pr list` failure and `gh`
+unavailability) and a matching guard in the publish job that refuses the destructive
+recreate path when the signal is set, rather than delete-and-rebuild — same posture as
+the file's own FOREIGN-commits refusal a few lines above it. New test scenarios 4/5 in
+`policy-existing-pr.test.sh`; new static assertions in `workflow-template.test.sh`.
+Final: `bash plugins/dossier/tests/run.sh policy-existing-pr.test.sh` — 13/13.

--- a/.decisions/issue-146.md
+++ b/.decisions/issue-146.md
@@ -67,9 +67,10 @@ began (see the `## Bundle note` in `.decisions/issue-143.md`).
 
 ## Stranger Test
 
-PASS — inherits task #78 from `.decisions/issue-143.md`'s Stranger Test, which named
-the exact file:line, the exact existing-code precedent (PR #145 SEC-1) being mirrored,
-and the exact test technique to port.
+PASS — inherits task 3 from `.decisions/issue-143.md`'s Stranger Test (the task covering
+the `dossier-policy.sh` fork-hijack fix), which named the exact file:line, the exact
+existing-code precedent (PR #145's SEC-1 fix) being mirrored, and the exact test
+technique to port.
 
 ## Verification
 
@@ -96,4 +97,20 @@ unavailability) and a matching guard in the publish job that refuses the destruc
 recreate path when the signal is set, rather than delete-and-rebuild — same posture as
 the file's own FOREIGN-commits refusal a few lines above it. New test scenarios 4/5 in
 `policy-existing-pr.test.sh`; new static assertions in `workflow-template.test.sh`.
-Final: `bash plugins/dossier/tests/run.sh policy-existing-pr.test.sh` — 13/13.
+
+### Second review-driven follow-up (P1/P2, fixed in the same PR)
+
+A second `/flow:review` pass (Path A paired-reviewer protocol) converged on further
+gaps in the same lookup/guard mechanism: the `EXISTING_PR` lookup had no `--limit`,
+matching the file's own circuit-breaker precedent but missing here; the publish job's
+`existing_pr_lookup_failed` comparison (`= "true"`) failed OPEN on any unexpected or
+absent value instead of failing closed (`!= "false"`); the `git rev-list` call feeding
+the FOREIGN-commit-detection loop never checked its own exit status, so a rev-list
+failure was indistinguishable from "genuinely no foreign commits"; and
+`write_summary()`'s "Existing docs PR" row couldn't distinguish a genuine `none` from
+an `unknown (lookup failed)` state. All fixed in `dossier-docs-refresh.yml` and
+`dossier-policy.sh`, with new scenarios 6-9 in `policy-existing-pr.test.sh` and new
+ordering-aware static assertions in `workflow-template.test.sh`.
+
+Final: `bash plugins/dossier/tests/run.sh policy-existing-pr.test.sh` — 22/22.
+Final: `bash plugins/dossier/tests/run.sh workflow-template.test.sh` — 119/119.

--- a/.decisions/issue-148.md
+++ b/.decisions/issue-148.md
@@ -55,8 +55,14 @@ Part of the hook/policy-hardening bundle driven by `/flow:start` on #143 (see
 - `--github-output "$GITHUB_OUTPUT"` added to that step's script invocation.
 - Policy job `outputs:` map gains: `rotation_would_rotate`, `rotation_reason`,
   `rotation_age_days`, `rotation_age_source`, `rotation_accumulated_files`,
-  `rotation_accumulated_lines`, `rotation_policy` — each `${{ steps.rotation.outputs.<key> }}`
-  where `<key>` is the script's own unprefixed field name.
+  `rotation_accumulated_lines`, `rotation_policy` — each sourced from
+  `${{ steps.rotation.outputs.<key> }}`. For six of the seven, `<key>` is the script's own
+  unprefixed field name (`would_rotate`, `reason`, `age_days`, `age_source`,
+  `accumulated_files`, `accumulated_lines`). `rotation_policy` is the odd one out: the
+  script's own `finish()` already emits a field literally named `rotation_policy` (not
+  `policy`), so `<key>` there is `rotation_policy` itself — adding another `rotation_`
+  prefix on the output-map side would produce `rotation_rotation_policy`, which is not
+  done.
 
 ## Acceptance Criteria (as validated)
 
@@ -71,8 +77,9 @@ Part of the hook/policy-hardening bundle driven by `/flow:start` on #143 (see
 
 ## Stranger Test
 
-PASS — inherits task #79 from `.decisions/issue-143.md`'s Stranger Test, which named the
-exact step name, exact field list, exact prefix convention, and exact verification file.
+PASS — inherits task 4 from `.decisions/issue-143.md`'s Stranger Test (the task covering
+the should_run/reason outputs pattern), which named the exact step name, exact field
+list, exact prefix convention, and exact verification file.
 
 ## Verification
 
@@ -86,6 +93,11 @@ exact step name, exact field list, exact prefix convention, and exact verificati
   prefix to check the exact YAML key position instead of a bare substring.
 - YAML still parses cleanly after placeholder substitution (existing
   workflow-template.test.sh check, unaffected).
+- A later `/flow:review` fix-forward pass on the same PR (SEC-1/ERR-1 fixes to
+  `dossier-docs-refresh.yml`'s branch-preparation step, unrelated to this issue's own
+  scope but landing in the same file) added further static assertions to the same test
+  file, including line-order checks that a plain `assert_contains` cannot express.
+  Final: `bash plugins/dossier/tests/run.sh workflow-template.test.sh` — 119/119.
 
 ### Review-driven finding, deliberately deferred (P3, documented not fixed)
 

--- a/.decisions/issue-148.md
+++ b/.decisions/issue-148.md
@@ -1,0 +1,88 @@
+---
+issue: 148
+created: '2026-08-03T11:53:19Z'
+---
+# Issue #148 — rotation-check telemetry fields aren't surfaced as job outputs
+
+**Title**: dossier: rotation-check telemetry fields aren't surfaced as job outputs, undercutting the observation-period rationale
+**Labels**: enhancement, plugin
+
+## Bundle note
+
+Part of the hook/policy-hardening bundle driven by `/flow:start` on #143 (see
+`.decisions/issue-143.md`). Hand-authored journal, same reasoning as `.decisions/issue-146.md`.
+
+## Specification
+
+### Non-goals
+
+- Not wiring any downstream consumer of these outputs (a scheduled aggregation step,
+  a future rotation-design phase) — deliberately, per the issue's own text: "makes the
+  data available to any future consumer... without committing to what that consumer
+  looks like yet."
+- Not changing `dossier-rotation-check.sh` itself — it already supports `--github-output`
+  (confirmed by reading the script), so this is a workflow-YAML-only change.
+- Not resolving the naming collision by nesting fields under a single JSON blob output —
+  every existing output in this job (`should_run`/`reason`/`base_sha`/...) is a flat key,
+  and a JSON-blob output would diverge from that convention for no benefit this issue asks
+  for.
+
+### Failure modes
+
+- **Timeouts** — none — no new command execution, only new `outputs:` map wiring around
+  an already-running step.
+- **Partial failures** — the rotation step carries `continue-on-error: true` (pre-existing,
+  unchanged). On a soft failure, its `--github-output` writes may be partial or absent, so
+  the new `rotation_*` outputs may resolve empty — this matches the script's own existing
+  `would_rotate=unknown` degradation pattern and is not a new failure mode; downstream jobs
+  don't consume these outputs yet (see Non-goals), so an empty value has no consumer to
+  mislead today.
+- **Invalid input** — none — no new input surface; outputs are sourced from a script that
+  already validates/degrades its own inputs.
+- **Missing context** — none — no new config/env dependency.
+
+### Interface contracts
+
+- **Naming collision, discovered during specification, not anticipated by the issue's own
+  suggested fix**: the script emits keys `reason` and `docs_branch`, both of which already
+  exist as outputs of the policy job's `decide` step (`steps.decide.outputs.reason`,
+  `steps.decide.outputs.docs_branch`). Adding them unmodified to the same job's `outputs:`
+  map would collide. Resolved (user-confirmed): prefix every rotation-sourced output with
+  `rotation_`, and drop `docs_branch` entirely (redundant — both steps resolve it from the
+  identical `dossier.ci.rollingBranch` config in the same job run, so it can never differ
+  within one execution).
+- `id: rotation` added to the "Check whether the documentation branch would rotate" step.
+- `--github-output "$GITHUB_OUTPUT"` added to that step's script invocation.
+- Policy job `outputs:` map gains: `rotation_would_rotate`, `rotation_reason`,
+  `rotation_age_days`, `rotation_age_source`, `rotation_accumulated_files`,
+  `rotation_accumulated_lines`, `rotation_policy` — each `${{ steps.rotation.outputs.<key> }}`
+  where `<key>` is the script's own unprefixed field name.
+
+## Acceptance Criteria (as validated)
+
+1. The rotation-check step has `id: rotation` and passes `--github-output "$GITHUB_OUTPUT"`.
+   Verification: `bash plugins/dossier/tests/run.sh workflow-template.test.sh`
+2. The policy job's `outputs:` map exposes all seven rotation fields under a `rotation_`
+   prefix, with no key collision against the job's existing `should_run`/`reason`/
+   `base_sha`/`head_sha`/`base_source`/`docs_branch`/`existing_pr`/`max_turns`/`model_arg`/
+   `stale_docs` outputs. Verification: same test file, new assertions per key.
+3. The full dossier test suite passes with no regression. Verification: `bash
+   plugins/dossier/tests/run.sh`
+
+## Stranger Test
+
+PASS — inherits task #79 from `.decisions/issue-143.md`'s Stranger Test, which named the
+exact step name, exact field list, exact prefix convention, and exact verification file.
+
+## Verification
+
+- `bash plugins/dossier/tests/run.sh workflow-template.test.sh` — RED-confirmed first
+  (9 new failures: `id: rotation`, `--github-output`, and the 7 `rotation_*` outputs
+  all missing), GREEN after the fix — 109/109, no regression to the pre-existing
+  100 assertions.
+- One test-authoring bug found and fixed during RED->GREEN: the initial
+  `assert_not_contains "reason: ..."` collision check matched as a substring of the
+  legitimate `rotation_reason: ...` line; anchored with a leading 6-space indentation
+  prefix to check the exact YAML key position instead of a bare substring.
+- YAML still parses cleanly after placeholder substitution (existing
+  workflow-template.test.sh check, unaffected).

--- a/.decisions/issue-148.md
+++ b/.decisions/issue-148.md
@@ -1,6 +1,6 @@
 ---
 issue: 148
-created: '2026-08-03T11:53:19Z'
+created: '2026-08-03T12:04:00Z'
 ---
 # Issue #148 — rotation-check telemetry fields aren't surfaced as job outputs
 
@@ -86,3 +86,18 @@ exact step name, exact field list, exact prefix convention, and exact verificati
   prefix to check the exact YAML key position instead of a bare substring.
 - YAML still parses cleanly after placeholder substitution (existing
   workflow-template.test.sh check, unaffected).
+
+### Review-driven finding, deliberately deferred (P3, documented not fixed)
+
+The error-handler-inspector review pass on the bundle PR noted that `dossier-rotation-
+check.sh`'s two internal failure paths degrade inconsistently once these fields have a
+real consumer: `die_infra()` emits only 2 of 8 fields before exiting, so the newly-added
+`rotation_age_days`/`rotation_age_source`/`rotation_accumulated_files`/
+`rotation_accumulated_lines`/`rotation_policy` outputs land as genuinely-unset empty
+strings on that path, while `finish()` (the transport-failure path) emits all 8 including
+an explicit `age_source="unknown"` string — a future consumer could treat empty-string
+and the literal `"unknown"` as different signals for the same "we don't know" state.
+Not fixed here: `dossier-rotation-check.sh` is explicitly out of scope for this issue (see
+Non-goals) and no consumer of these fields exists yet (this issue's own stated purpose is
+exposure only), so normalizing `die_infra()`'s emit shape is deferred until a real
+consumer is built and the inconsistency actually matters.

--- a/.flow/goals/issue-143.goal.yaml
+++ b/.flow/goals/issue-143.goal.yaml
@@ -1,0 +1,119 @@
+apiVersion: flow.synapti.ai/v1
+kind: FlowGoal
+metadata:
+  id: issue-143
+  created_at: '2026-08-03T11:53:19Z'
+  created_by: /flow:start
+  owner: daniel.bentes@synapti.ai
+scope:
+  repo: synaptiai/synapti-marketplace
+  branch: feature/issue-143-hook-policy-hardening
+  issue: 143
+  journal: .decisions/issue-143.md
+objective:
+  outcome: 'Issue #143 is implemented and verified.'
+  source:
+    type: github_issue
+    number: 143
+    title: 'dossier: enforce-allowed-actions.sh''s action-ceiling backstop can be
+      bypassed via find -exec / xargs -I{}'
+  acceptance_criteria:
+  - id: AC1
+    text: find ... -exec <denied-command> ..., find ... -execdir <denied-command>
+      ..., and xargs -I{} <denied-command> {} (and their common flag variants) are
+      correctly denied when the corresponding capability is off, for every existing
+      deny-block (runTests, runBuild, networkAccess, runSecurityScan, runCodeQualityScan),
+      not just newly-added ones.
+    verification_command: bash plugins/dossier/tests/run.sh hooks.test.sh
+    must_pass: true
+    status: pending
+    evidence_ref: null
+    last_evaluated_at: null
+    last_result: null
+  - id: AC2
+    text: The fix does not regress any existing passing case in plugins/dossier/tests/hooks.test.sh
+      (the wrapper-indirection and grep-about-a-command cases especially).
+    verification_command: bash plugins/dossier/tests/run.sh hooks.test.sh
+    must_pass: true
+    status: pending
+    evidence_ref: null
+    last_evaluated_at: null
+    last_result: null
+  - id: AC3
+    text: The approach is documented as classifying command structure rather than
+      enumerating more literal indirection tokens, so a future new indirection shape
+      doesn't require another narrowing/widening round.
+    verification_command: grep -n "find" plugins/dossier/hooks/scripts/enforce-allowed-actions.sh
+    must_pass: true
+    status: pending
+    evidence_ref: null
+    last_evaluated_at: null
+    last_result: null
+  - id: AC4
+    text: Covered by new test cases in hooks.test.sh for each denied-command class
+      named above.
+    verification_command: bash plugins/dossier/tests/run.sh hooks.test.sh
+    must_pass: true
+    status: pending
+    evidence_ref: null
+    last_evaluated_at: null
+    last_result: null
+specification:
+  non_goals:
+  - Not building a full POSIX/bash shell-grammar parser — this hook has zero CI reach,
+    so a grammar parser is disproportionate to the blast radius.
+  - Not closing every command that can embed an arbitrary sub-command (GNU parallel,
+    awk system(...), perl -e exec(...), etc.) — only find and xargs, the two named
+    in the acceptance criteria. Left as a documented out-of-scope comment, not a new
+    tracked issue.
+  - No code change needed for xargs specifically — empirically verified it is already
+    blocked today via the existing WRAPPER token list. Only find is a live gap.
+  - Not touching BOUND or the SCAN/BOUND_ACTIVE derivation logic — the fix is entirely
+    a WRAPPER-token-list addition.
+  failure_modes:
+  - 'Timeouts: none — synchronous regex-based hook, no I/O or network calls.'
+  - 'Partial failures: none — single-line regex alternation addition, no multi-step
+    operation.'
+  - 'Invalid input: find . -name "npm test" (no -exec) becomes an accepted over-block
+    once find is a WRAPPER token — same tradeoff class already shipped for every other
+    WRAPPER token, now pinned down with an explicit regression test.'
+  - 'Missing context: none — no new config/env dependency; reuses the existing WRAPPER
+    variable resolved unconditionally at hook-invocation time.'
+  interface_contracts:
+  - 'WRAPPER regex in plugins/dossier/hooks/scripts/enforce-allowed-actions.sh: add
+    the literal alternative "find" to the existing token-alternation group, preserving
+    the exact same anchoring/lookaround structure.'
+  - No change to any deny-block's own detection regex — the fix is entirely upstream,
+    in the shared WRAPPER/BOUND_ACTIVE mechanism they all consume.
+  - Test additions land in plugins/dossier/tests/hooks.test.sh only, following the
+    file's existing loop-based assertion pattern.
+  - 'The existing "Known limitation... issue #143" comment block is revised, not deleted,
+    to document what was fixed and what remains out of scope.'
+constraints:
+  tdd_required: true
+  require_all_pass: true
+  no_calendar_estimates: true
+  no_tier3_without_confirmation: true
+evaluator:
+  type: flow_verdict_judge
+  command: /flow:goal evaluate
+  judge_agent: goal-evaluator-judge
+  evidence_bundle_format: plugins/flow/references/evidence-bundle-format.md
+  denied_context:
+  - implementation_rationale
+  - self_review_findings
+continuation:
+  mode: flow_managed
+  on_incomplete: continue_next_activity
+  on_blocked: six_field_escalation
+  on_complete: mark_achieved
+  max_iterations: 20
+lifecycle:
+  status: active
+  current_phase: explore
+  current_activity: explore
+  turns_evaluated: 0
+  last_evaluation:
+    result: incomplete
+    reason: Goal activated at /flow:start Phase 1; evidence not yet collected.
+    at: '2026-08-03T11:53:19Z'

--- a/.flow/goals/issue-143.goal.yaml
+++ b/.flow/goals/issue-143.goal.yaml
@@ -109,11 +109,12 @@ continuation:
   on_complete: mark_achieved
   max_iterations: 20
 lifecycle:
-  status: active
-  current_phase: explore
-  current_activity: explore
-  turns_evaluated: 0
+  status: achieved
+  current_phase: verify
+  current_activity: complete
+  turns_evaluated: 1
   last_evaluation:
-    result: incomplete
-    reason: Goal activated at /flow:start Phase 1; evidence not yet collected.
-    at: '2026-08-03T11:53:19Z'
+    result: pass
+    reason: All 4 acceptance criteria PASS via independent goal-evaluator-judge (confidence
+      0.8), hooks.test.sh 94/94 (up from 85 pre-fix).
+    at: '2026-08-03T14:20:00Z'

--- a/plugins/dossier/bin/dossier-policy.sh
+++ b/plugins/dossier/bin/dossier-policy.sh
@@ -387,7 +387,15 @@ esac
 # privileged token anyway.
 # ---------------------------------------------------------------------------
 if command -v gh >/dev/null 2>&1; then
-  EXISTING_PR=$(gh pr list --head "$DOCS_BRANCH" --state open --json number --jq '.[0].number // empty' 2>/dev/null)
+  # --head matches by branch name only, across every fork with an open PR
+  # against this repo -- gh has no owner:branch syntax to scope --head to a
+  # specific fork. isCrossRepository==false restricts the match to PRs whose
+  # head lives in this repo, so a same-named decoy branch opened from a fork
+  # cannot be returned in place of (or ahead of) the real docs-refresh PR.
+  # Mirrors the identical fix already shipped in dossier-rotation-check.sh
+  # (PR #145, SEC-1) -- this is the pre-existing original that fix was copied
+  # from.
+  EXISTING_PR=$(gh pr list --head "$DOCS_BRANCH" --state open --json number,isCrossRepository --jq '[.[] | select(.isCrossRepository == false)][0].number // empty' 2>/dev/null)
 else
   note 'gh CLI unavailable; existing-PR lookup and the circuit-breaker count were skipped.'
 fi

--- a/plugins/dossier/bin/dossier-policy.sh
+++ b/plugins/dossier/bin/dossier-policy.sh
@@ -218,7 +218,18 @@ write_summary() {
     printf '| Base source | `%s` |\n' "$BASE_SOURCE"
     printf '| Head | `%s` |\n' "${HEAD_SHA:-unresolved}"
     printf '| Docs branch | `%s` |\n' "$DOCS_BRANCH"
-    printf '| Existing docs PR | `%s` |\n' "${EXISTING_PR:-none}"
+    # A failed lookup and a genuinely confirmed "no PR open" both leave
+    # $EXISTING_PR empty -- the table must not render them identically, or an
+    # operator skimming it (rather than the free-text Notes below) could read
+    # a failure as a confirmed fact, exactly the ambiguity
+    # existing_pr_lookup_failed exists to close.
+    if [ -n "$EXISTING_PR" ]; then
+      printf '| Existing docs PR | `%s` |\n' "$EXISTING_PR"
+    elif [ "$EXISTING_PR_LOOKUP_FAILED" = "true" ]; then
+      printf '| Existing docs PR | `unknown (lookup failed)` |\n'
+    else
+      printf '| Existing docs PR | `none` |\n'
+    fi
     if [ -n "${STALE_SWEEP_LIST:-}" ]; then
       printf '| Stale documents (this sweep) | `%s` |\n' "$STALE_SWEEP_LIST"
     fi
@@ -408,8 +419,12 @@ if command -v gh >/dev/null 2>&1; then
   # cannot be returned in place of (or ahead of) the real docs-refresh PR.
   # Mirrors the identical fix already shipped in dossier-rotation-check.sh
   # (PR #145, SEC-1) -- this is the pre-existing original that fix was copied
-  # from.
-  EXISTING_PR=$(gh pr list --head "$DOCS_BRANCH" --state open --json number,isCrossRepository --jq '[.[] | select(.isCrossRepository == false)][0].number // empty' 2>/dev/null)
+  # from. --limit is explicit (matching the circuit-breaker call below) so
+  # gh's own default page size (30) can't paginate the real same-repo PR off
+  # the page before the isCrossRepository filter ever runs -- a "successful"
+  # (exit 0) lookup that quietly omits the one entry that mattered would
+  # bypass this fix and the existing_pr_lookup_failed guard alike.
+  EXISTING_PR=$(gh pr list --head "$DOCS_BRANCH" --state open --limit 100 --json number,isCrossRepository --jq '[.[] | select(.isCrossRepository == false)][0].number // empty' 2>/dev/null)
   PR_LIST_RC=$?
   if [ "$PR_LIST_RC" -ne 0 ]; then
     # An API failure (auth, rate limit, transient error) must never look like

--- a/plugins/dossier/bin/dossier-policy.sh
+++ b/plugins/dossier/bin/dossier-policy.sh
@@ -32,7 +32,7 @@
 #
 # Output (stdout, and --github-output when given):
 #   should_run  base_sha  head_sha  base_source  docs_branch
-#   reason      existing_pr  max_turns  model  model_arg
+#   reason      existing_pr  existing_pr_lookup_failed  max_turns  model  model_arg
 #
 # Exit:
 #   0 — a decision was reached (should_run may be true or false)
@@ -99,6 +99,7 @@ HEAD_SHA=""
 BASE_SOURCE="none"
 DOCS_BRANCH=""
 EXISTING_PR=""
+EXISTING_PR_LOOKUP_FAILED="false"
 MAX_TURNS=""
 MODEL=""
 MODEL_ARG=""
@@ -237,6 +238,7 @@ finish() {
   emit base_source "$BASE_SOURCE"
   emit docs_branch "$DOCS_BRANCH"
   emit existing_pr "$EXISTING_PR"
+  emit existing_pr_lookup_failed "$EXISTING_PR_LOOKUP_FAILED"
   emit max_turns   "$MAX_TURNS"
   emit model       "$MODEL"
   emit model_arg   "$MODEL_ARG"
@@ -252,6 +254,16 @@ finish() {
 CI_ENABLED=$(cfg '.dossier.ci.enabled' 'true')
 OUTPUT_ROOT=$(cfg '.dossier.project.outputRoot' 'docs/dossier')
 DOCS_BRANCH=$(cfg '.dossier.ci.rollingBranch' 'docs/dossier')
+# An explicitly-empty override (dossier.ci.rollingBranch: "") beats the
+# cascade default by design, same as dossier-rotation-check.sh's identical
+# guard -- without this, the two scripts would resolve DOCS_BRANCH
+# differently from the same config in the same job run.
+case "$DOCS_BRANCH" in
+  '')
+    DOCS_BRANCH='docs/dossier'
+    note "dossier.ci.rollingBranch resolved to an empty value; falling back to the documented default (docs/dossier)."
+    ;;
+esac
 LABEL_GENERATED=$(cfg '.dossier.ci.labels.generated' 'dossier:generated')
 LABEL_FORCE=$(cfg '.dossier.ci.labels.force' 'docs:refresh')
 LABEL_SKIP=$(cfg '.dossier.ci.labels.skip' 'docs:skip')
@@ -383,8 +395,10 @@ esac
 
 # ---------------------------------------------------------------------------
 # Existing docs PR (advisory; drives the publish job's create-vs-update path).
-# Absent gh is a degradation, not a failure: publish rediscovers the PR with a
-# privileged token anyway.
+# A missing or failed lookup is a degradation, not a guess: EXISTING_PR_LOOKUP_
+# FAILED tells the publish job the emptiness of EXISTING_PR is uninformative,
+# so it refuses to delete-and-recreate the documentation branch rather than
+# treating "we don't know" as "no PR is open".
 # ---------------------------------------------------------------------------
 if command -v gh >/dev/null 2>&1; then
   # --head matches by branch name only, across every fork with an open PR
@@ -396,7 +410,22 @@ if command -v gh >/dev/null 2>&1; then
   # (PR #145, SEC-1) -- this is the pre-existing original that fix was copied
   # from.
   EXISTING_PR=$(gh pr list --head "$DOCS_BRANCH" --state open --json number,isCrossRepository --jq '[.[] | select(.isCrossRepository == false)][0].number // empty' 2>/dev/null)
+  PR_LIST_RC=$?
+  if [ "$PR_LIST_RC" -ne 0 ]; then
+    # An API failure (auth, rate limit, transient error) must never look like
+    # "no PR is open": the publish job's branch-preparation step treats an
+    # empty EXISTING_PR as license to delete and recreate the documentation
+    # branch whenever it already exists with no foreign commits -- exactly
+    # the steady state whenever a real docs PR IS open and this lookup just
+    # failed to report it. existing_pr_lookup_failed is the signal that step
+    # uses to refuse the destructive path instead of guessing.
+    EXISTING_PR_LOOKUP_FAILED="true"
+    note "gh pr list failed (exit ${PR_LIST_RC}); could not check for an existing docs-refresh pull request. Treating this as a lookup failure, not confirmation that no pull request is open."
+  fi
 else
+  # Same downstream risk as the failure branch above: EXISTING_PR ends up
+  # empty either way, so this must set the same signal, not just a note.
+  EXISTING_PR_LOOKUP_FAILED="true"
   note 'gh CLI unavailable; existing-PR lookup and the circuit-breaker count were skipped.'
 fi
 

--- a/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh
+++ b/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh
@@ -89,22 +89,41 @@ BOUND='(^|[;&|(]|^[[:space:]]*)[[:space:]]*([A-Za-z0-9_.-]*/)*'
 # shapes for it, not exotic ones — confirmed live that the pyscn deny check
 # below permits them while correctly blocking bare pyscn/osv-scanner and
 # env/sudo-wrapped forms.
-WRAPPER='(^|[;&|(]|[[:space:]])[[:space:]]*([A-Za-z0-9_.-]*/)*(bash|sh|zsh|dash|ksh|env|command|exec|eval|xargs|nohup|setsid|stdbuf|script|time|timeout|nice|ionice|sudo|doas|su|python|python3)([[:space:]]|$)'
+# find closes the issue #143 gap: `find . -exec curl https://evil {} \;` (and
+# -execdir/-ok/-okdir) glue the sub-command execution position to a flag
+# rather than spelling it as its own token, so neither WRAPPER nor the strict
+# BOUND anchor used to fire for the command sitting inside them. This is
+# deliberately classification by structure, not enumeration: `find` is added
+# once, as a command name (the same category as every other entry in this
+# list), not as a list of its flags — so -exec/-execdir/-ok/-okdir (and any
+# future find primitive with the same shape) are all covered by this one
+# addition, with no per-flag matching added anywhere. `xargs -I{} curl {}`
+# needed no change at all: `xargs` was already a WRAPPER token before this
+# fix, so it already flips the whole command into whitespace-boundary mode —
+# confirmed live, not assumed.
+WRAPPER='(^|[;&|(]|[[:space:]])[[:space:]]*([A-Za-z0-9_.-]*/)*(find|bash|sh|zsh|dash|ksh|env|command|exec|eval|xargs|nohup|setsid|stdbuf|script|time|timeout|nice|ionice|sudo|doas|su|python|python3)([[:space:]]|$)'
 
-# Known limitation, not fixed here (issue synaptiai/synapti-marketplace#143):
-# a command-embedded indirection that never spells one of the WRAPPER tokens
-# as its own word still bypasses the boundary anchor — `find . -exec curl
-# https://evil {} \;` and `xargs -I{} curl {}` are the confirmed cases:
-# `-exec`/`-I{}` are glued to a flag, not a standalone token, so neither
-# WRAPPER nor the strict BOUND anchor ever fires for the command inside
-# them. This does not widen the token list further — the WRAPPER list has
-# already been narrowed/widened several times and each round just moves the
-# hole, since the underlying problem is pattern-matching tokens rather than
-# parsing the actual shell grammar; a real fix needs the latter and is
-# tracked separately. Low real-world exposure: this
-# hook is a local/interactive backstop only — the CI refresh job's own
-# --allowedTools allowlist doesn't include `find`, `xargs`, or a bare shell
-# at all, so the automated pipeline has no reach here regardless.
+# Accepted cost of the find fix above: since WRAPPER-mode makes every
+# whitespace run a boundary once `find` is present anywhere in the command,
+# `find . -name "npm test"` (no -exec at all — just a filename pattern that
+# happens to contain a denied phrase) is now over-blocked too. Same tradeoff
+# class already shipped for every other WRAPPER token (e.g. `timeout 5 grep
+# -r "npm test" docs/`); hooks.test.sh pins this one down with its own
+# assertion rather than leaving it only documented here.
+#
+# Known limitation, deliberately not fixed here: this file's mechanism is
+# "does this command name introduce an arbitrary sub-command execution
+# position, regardless of which flag spells that out" — but only for the
+# finite set of command names actually listed above. Genuinely different
+# tools with the same shape (GNU `parallel`, `awk 'system(...)'`, `perl -e
+# "exec(...)"`, `watch -x`, and others) are not covered and have no WRAPPER
+# entry. This is not tracked as a separate issue: unlike `find`/`xargs`
+# above, which came from an actual review finding on real PR traffic, this
+# residual class has no concrete trigger yet. Real-world exposure stays low
+# regardless — this hook is a local/interactive backstop only; the CI refresh
+# job's own --allowedTools allowlist doesn't include `find`, `xargs`,
+# `parallel`, `awk`, `perl`, or a bare shell at all, so the automated
+# pipeline has no reach here.
 SCAN="$COMMAND"
 BOUND_ACTIVE="$BOUND"
 if printf '%s' "$COMMAND" | grep -qE "$WRAPPER"; then

--- a/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh
+++ b/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh
@@ -19,6 +19,17 @@ fi
 
 INPUT=$(cat)
 COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+JQ_RC=$?
+# A jq parse failure (malformed/truncated hook payload) is a different
+# failure than "no tool_input.command field present" -- both produce an
+# empty $COMMAND, but only the latter means "nothing to enforce". Checked
+# separately so a parse failure fails closed rather than silently taking the
+# same exit-0 path as a genuinely inert command, matching this file's own
+# declared fail-closed posture (see the jq-availability check above).
+if [ "$JQ_RC" -ne 0 ]; then
+  echo "BLOCKED: dossier could not parse the tool input JSON to enforce its action ceiling." >&2
+  exit 2
+fi
 [ -z "$COMMAND" ] && exit 0
 
 # A missing resolver means the ceiling cannot be read, not that it is absent.
@@ -100,7 +111,10 @@ BOUND='(^|[;&|(]|^[[:space:]]*)[[:space:]]*([A-Za-z0-9_.-]*/)*'
 # addition, with no per-flag matching added anywhere. `xargs -I{} curl {}`
 # needed no change at all: `xargs` was already a WRAPPER token before this
 # fix, so it already flips the whole command into whitespace-boundary mode —
-# confirmed live, not assumed.
+# confirmed live for the plain-text case. A quoted/backslash-escaped denied
+# word (`\find . -exec curl ... {} \;`, `"curl" ...`) still bypasses this
+# entirely, including for tokens already listed here — see the Known
+# limitation note below, tracked as issue #152.
 WRAPPER='(^|[;&|(]|[[:space:]])[[:space:]]*([A-Za-z0-9_.-]*/)*(find|bash|sh|zsh|dash|ksh|env|command|exec|eval|xargs|nohup|setsid|stdbuf|script|time|timeout|nice|ionice|sudo|doas|su|python|python3)([[:space:]]|$)'
 
 # Accepted cost of the find fix above: since WRAPPER-mode makes every
@@ -119,8 +133,21 @@ WRAPPER='(^|[;&|(]|[[:space:]])[[:space:]]*([A-Za-z0-9_.-]*/)*(find|bash|sh|zsh|
 # "exec(...)"`, `watch -x`, and others) are not covered and have no WRAPPER
 # entry. This is not tracked as a separate issue: unlike `find`/`xargs`
 # above, which came from an actual review finding on real PR traffic, this
-# residual class has no concrete trigger yet. Real-world exposure stays low
-# regardless — this hook is a local/interactive backstop only; the CI refresh
+# residual class has no concrete trigger yet.
+#
+# Second known limitation, tracked as issue #152 (not fixed here): quoting or
+# backslash-escaping a denied word defeats BOUND/WRAPPER entirely, for ANY
+# token listed anywhere in this file, not just `find`/`xargs` — confirmed
+# live (`"curl" https://evil`, `\curl https://evil`, and `\find . -exec curl
+# ... {} \;` all exit 0/permitted). This is broader and predates issue #143:
+# the SCAN/BOUND_ACTIVE quote-stripping normalization only runs after a
+# WRAPPER match is found, so a denied word spelled with a leading quote/
+# backslash never triggers that normalization in the first place. Fixing it
+# means normalizing unconditionally before any WRAPPER/deny test, not
+# something scoped to this file's find/xargs change.
+#
+# Real-world exposure stays low regardless of either limitation above — this
+# hook is a local/interactive backstop only; the CI refresh
 # job's own --allowedTools allowlist doesn't include `find`, `xargs`,
 # `parallel`, `awk`, `perl`, or a bare shell at all, so the automated
 # pipeline has no reach here.

--- a/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh
+++ b/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh
@@ -18,19 +18,6 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 INPUT=$(cat)
-COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
-JQ_RC=$?
-# A jq parse failure (malformed/truncated hook payload) is a different
-# failure than "no tool_input.command field present" -- both produce an
-# empty $COMMAND, but only the latter means "nothing to enforce". Checked
-# separately so a parse failure fails closed rather than silently taking the
-# same exit-0 path as a genuinely inert command, matching this file's own
-# declared fail-closed posture (see the jq-availability check above).
-if [ "$JQ_RC" -ne 0 ]; then
-  echo "BLOCKED: dossier could not parse the tool input JSON to enforce its action ceiling." >&2
-  exit 2
-fi
-[ -z "$COMMAND" ] && exit 0
 
 # A missing resolver means the ceiling cannot be read, not that it is absent.
 # Keep the restrictive defaults and go on enforcing, matching what
@@ -44,6 +31,13 @@ RUN_SECURITY_SCAN="false"
 RUN_CODE_QUALITY_SCAN="false"
 if [ -x "$RESOLVER" ]; then
   OUTPUT_ROOT=$("$RESOLVER" --default "docs/dossier" dossier.project.outputRoot 2>/dev/null)
+  # A resolver call that fails (subshell exit != 0) or returns empty stdout
+  # must not be read as "output root is the empty string" -- $OUTPUT_ROOT
+  # feeds directly into the scope-file existence check below, and an empty
+  # value there resolves to an absolute-root path check that is essentially
+  # always false, silently disabling the entire action ceiling for this run
+  # with no error surfaced anywhere. Restrictive default, not an empty one.
+  [ -n "$OUTPUT_ROOT" ] || OUTPUT_ROOT="docs/dossier"
   RUN_TESTS=$("$RESOLVER" --default "false" dossier.engagement.allowedActions.runTests 2>/dev/null)
   RUN_BUILD=$("$RESOLVER" --default "false" dossier.engagement.allowedActions.runBuild 2>/dev/null)
   NETWORK=$("$RESOLVER"   --default "false" dossier.engagement.allowedActions.networkAccess 2>/dev/null)
@@ -51,7 +45,27 @@ if [ -x "$RESOLVER" ]; then
   RUN_CODE_QUALITY_SCAN=$("$RESOLVER" --default "false" dossier.engagement.allowedActions.runCodeQualityScan 2>/dev/null)
 fi
 
+# Inertness is decided entirely by OUTPUT_ROOT/the scope file, never by
+# $INPUT's own shape -- checked before any JSON parsing so that a malformed
+# hook payload on an ordinary, non-dossier command (no active run at all)
+# stays inert rather than blocking it, matching this file's own header
+# contract ("Inert unless a dossier run is active").
 [ -f "$OUTPUT_ROOT/00-control/.scope.json" ] || exit 0
+
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+JQ_RC=$?
+# A jq parse failure (malformed/truncated hook payload) is a different
+# failure than "no tool_input.command field present" -- both produce an
+# empty $COMMAND, but only the latter means "nothing to enforce". Checked
+# separately so a parse failure fails closed rather than silently taking the
+# same exit-0 path as a genuinely inert command, matching this file's own
+# declared fail-closed posture (see the jq-availability check above). Only
+# reachable once a run is confirmed active (see the scope-file check above).
+if [ "$JQ_RC" -ne 0 ]; then
+  echo "BLOCKED: dossier could not parse the tool input JSON to enforce its action ceiling." >&2
+  exit 2
+fi
+[ -z "$COMMAND" ] && exit 0
 
 deny() { # capability | setting | matched-class
   cat >&2 <<EOF
@@ -100,31 +114,32 @@ BOUND='(^|[;&|(]|^[[:space:]]*)[[:space:]]*([A-Za-z0-9_.-]*/)*'
 # shapes for it, not exotic ones — confirmed live that the pyscn deny check
 # below permits them while correctly blocking bare pyscn/osv-scanner and
 # env/sudo-wrapped forms.
-# find closes the issue #143 gap: `find . -exec curl https://evil {} \;` (and
-# -execdir/-ok/-okdir) glue the sub-command execution position to a flag
-# rather than spelling it as its own token, so neither WRAPPER nor the strict
-# BOUND anchor used to fire for the command sitting inside them. This is
-# deliberately classification by structure, not enumeration: `find` is added
-# once, as a command name (the same category as every other entry in this
-# list), not as a list of its flags — so -exec/-execdir/-ok/-okdir (and any
-# future find primitive with the same shape) are all covered by this one
-# addition, with no per-flag matching added anywhere. `xargs -I{} curl {}`
-# needed no change at all: `xargs` was already a WRAPPER token before this
-# fix, so it already flips the whole command into whitespace-boundary mode —
-# confirmed live for the plain-text case. A quoted/backslash-escaped denied
-# word (`\find . -exec curl ... {} \;`, `"curl" ...`) still bypasses this
-# entirely, including for tokens already listed here — see the Known
-# limitation note below, tracked as issue #152.
-WRAPPER='(^|[;&|(]|[[:space:]])[[:space:]]*([A-Za-z0-9_.-]*/)*(find|bash|sh|zsh|dash|ksh|env|command|exec|eval|xargs|nohup|setsid|stdbuf|script|time|timeout|nice|ionice|sudo|doas|su|python|python3)([[:space:]]|$)'
+# xargs -I{} curl {} needed no change at all for issue #143: `xargs` was
+# already a WRAPPER token before that fix, so it already flips the whole
+# command into whitespace-boundary mode — confirmed live for the plain-text
+# case. A quoted/backslash-escaped denied word (`\xargs ...`, `"curl" ...`)
+# still bypasses this entirely, including for tokens already listed here —
+# see the Known limitation note below, tracked as issue #152.
+WRAPPER='(^|[;&|(]|[[:space:]])[[:space:]]*([A-Za-z0-9_.-]*/)*(bash|sh|zsh|dash|ksh|env|command|exec|eval|xargs|nohup|setsid|stdbuf|script|time|timeout|nice|ionice|sudo|doas|su|python|python3)([[:space:]]|$)'
 
-# Accepted cost of the find fix above: since WRAPPER-mode makes every
-# whitespace run a boundary once `find` is present anywhere in the command,
-# `find . -name "npm test"` (no -exec at all — just a filename pattern that
-# happens to contain a denied phrase) is now over-blocked too. Same tradeoff
-# class already shipped for every other WRAPPER token (e.g. `timeout 5 grep
-# -r "npm test" docs/`); hooks.test.sh pins this one down with its own
-# assertion rather than leaving it only documented here.
-#
+# find closes the issue #143 gap on its own regex, not by joining WRAPPER:
+# `find . -exec curl https://evil {} \;` (and -execdir/-ok/-okdir) glue the
+# sub-command execution position to a flag rather than spelling it as its own
+# token, so neither WRAPPER nor the strict BOUND anchor used to fire for the
+# command sitting inside them. This is classification by structure, not
+# enumeration: `find` combined with ANY of its four sub-command-execution
+# primaries (-exec/-execdir/-ok/-okdir) is what triggers boundary-widening —
+# no per-denied-command matching, and no per-flag matching beyond the fixed,
+# stable set find(1) itself defines. Requiring the co-occurrence (rather than
+# putting bare `find` in WRAPPER) is deliberately more precise than the
+# original fix: a bare `find . -name "npm test"` (or any other command that
+# merely contains the word "find" elsewhere, e.g. a commit message like
+# "docs: find and document the test workflow") is no longer swept into
+# boundary-widening mode at all, closing a broader false-positive class a
+# code-review pass demonstrated live on real-shaped input, not just this
+# file's own already-accepted narrow "npm test" tradeoff.
+FIND_EXEC='(^|[;&|(]|[[:space:]])[[:space:]]*([A-Za-z0-9_.-]*/)*find([[:space:]]|$).*[[:space:]]-(exec|execdir|ok|okdir)([[:space:]]|$)'
+
 # Known limitation, deliberately not fixed here: this file's mechanism is
 # "does this command name introduce an arbitrary sub-command execution
 # position, regardless of which flag spells that out" — but only for the
@@ -143,8 +158,8 @@ WRAPPER='(^|[;&|(]|[[:space:]])[[:space:]]*([A-Za-z0-9_.-]*/)*(find|bash|sh|zsh|
 # the SCAN/BOUND_ACTIVE quote-stripping normalization only runs after a
 # WRAPPER match is found, so a denied word spelled with a leading quote/
 # backslash never triggers that normalization in the first place. Fixing it
-# means normalizing unconditionally before any WRAPPER/deny test, not
-# something scoped to this file's find/xargs change.
+# means normalizing unconditionally before any WRAPPER/FIND_EXEC/deny test,
+# not something scoped to this file's find/xargs change.
 #
 # Real-world exposure stays low regardless of either limitation above — this
 # hook is a local/interactive backstop only; the CI refresh
@@ -153,7 +168,7 @@ WRAPPER='(^|[;&|(]|[[:space:]])[[:space:]]*([A-Za-z0-9_.-]*/)*(find|bash|sh|zsh|
 # pipeline has no reach here.
 SCAN="$COMMAND"
 BOUND_ACTIVE="$BOUND"
-if printf '%s' "$COMMAND" | grep -qE "$WRAPPER"; then
+if printf '%s' "$COMMAND" | grep -qE "$WRAPPER" || printf '%s' "$COMMAND" | grep -qE "$FIND_EXEC"; then
   # Quotes and command-substitution openers stop hiding a boundary, and every
   # whitespace run becomes one.
   SCAN=$(printf '%s' "$COMMAND" | sed -E -e 's,["'"'"'`],;,g' -e 's,\$\(,;,g')
@@ -161,7 +176,8 @@ if printf '%s' "$COMMAND" | grep -qE "$WRAPPER"; then
 fi
 
 # Every check below tests $SCAN with $BOUND_ACTIVE, which are $COMMAND and the
-# strict anchor unless a wrapper was found.
+# strict anchor unless a wrapper (or find's own exec-family primaries) was
+# found.
 
 if [ "$RUN_TESTS" != "true" ]; then
   if printf '%s' "$SCAN" | grep -qE "${BOUND_ACTIVE}(npm|yarn|pnpm|bun)[[:space:]]+(run[[:space:]]+)?test\b"; then

--- a/plugins/dossier/templates/ci/dossier-docs-refresh.yml
+++ b/plugins/dossier/templates/ci/dossier-docs-refresh.yml
@@ -154,6 +154,7 @@ jobs:
       base_source: ${{ steps.decide.outputs.base_source }}
       docs_branch: ${{ steps.decide.outputs.docs_branch }}
       existing_pr: ${{ steps.decide.outputs.existing_pr }}
+      existing_pr_lookup_failed: ${{ steps.decide.outputs.existing_pr_lookup_failed }}
       max_turns: ${{ steps.decide.outputs.max_turns }}
       model_arg: ${{ steps.decide.outputs.model_arg }}
       stale_docs: ${{ steps.decide.outputs.stale_docs }}
@@ -775,6 +776,7 @@ jobs:
         env:
           DOCS_BRANCH: ${{ needs.policy.outputs.docs_branch }}
           EXISTING_PR: ${{ needs.policy.outputs.existing_pr }}
+          EXISTING_PR_LOOKUP_FAILED: ${{ needs.policy.outputs.existing_pr_lookup_failed }}
           BASE_SHA: ${{ needs.policy.outputs.base_sha }}
           HEAD_SHA: ${{ needs.policy.outputs.head_sha }}
           BASE_REF: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
@@ -830,6 +832,27 @@ jobs:
                 echo
                 echo 'Nothing was deleted. Merge or move that work, or delete the branch yourself'
                 echo 'once you are sure it is finished, then re-run this workflow.'
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+            elif [ "$EXISTING_PR_LOOKUP_FAILED" = "true" ]; then
+              # An empty EXISTING_PR here is uninformative, not a confirmed
+              # "no PR is open" -- the policy job's own lookup failed or gh
+              # was unavailable. This is exactly the steady state whenever a
+              # real docs PR IS open and the lookup just couldn't see it:
+              # deleting and recreating the branch would discard the commits
+              # that PR is reviewing. Refuse, matching the FOREIGN-commits
+              # refusal above rather than silently guessing.
+              echo "::error title=Dossier::Could not confirm whether ${DOCS_BRANCH} has an open pull request (the lookup failed or gh was unavailable). Refusing to delete and recreate a branch that might have review history attached."
+              {
+                echo '### Dossier publish stopped: could not confirm the documentation branch has no open pull request'
+                echo
+                echo "\`${DOCS_BRANCH}\` exists and carries no unrecognised commits, which would normally mean"
+                echo "it is safe to recreate from the base branch. But the pull-request lookup that"
+                echo 'decision depends on failed (or gh was unavailable), so an empty result cannot be'
+                echo 'trusted as "no pull request is open".'
+                echo
+                echo 'Nothing was deleted. Re-run the workflow once the lookup can succeed, or verify'
+                echo 'by hand whether a pull request is open before deleting the branch yourself.'
               } >> "$GITHUB_STEP_SUMMARY"
               exit 1
             else

--- a/plugins/dossier/templates/ci/dossier-docs-refresh.yml
+++ b/plugins/dossier/templates/ci/dossier-docs-refresh.yml
@@ -157,6 +157,20 @@ jobs:
       max_turns: ${{ steps.decide.outputs.max_turns }}
       model_arg: ${{ steps.decide.outputs.model_arg }}
       stale_docs: ${{ steps.decide.outputs.stale_docs }}
+      # Rotation telemetry (issue #148): prefixed rotation_* to avoid colliding
+      # with this same job's decide-step-sourced reason/docs_branch above --
+      # both scripts resolve docs_branch from the identical
+      # dossier.ci.rollingBranch config in the same job run, so rotation's own
+      # copy is not re-exposed here at all. No consumer reads these yet; this
+      # is exposure only, so a real observation period produces queryable
+      # data (issue #138 AC4) rather than N job summaries nobody aggregates.
+      rotation_would_rotate: ${{ steps.rotation.outputs.would_rotate }}
+      rotation_reason: ${{ steps.rotation.outputs.reason }}
+      rotation_age_days: ${{ steps.rotation.outputs.age_days }}
+      rotation_age_source: ${{ steps.rotation.outputs.age_source }}
+      rotation_accumulated_files: ${{ steps.rotation.outputs.accumulated_files }}
+      rotation_accumulated_lines: ${{ steps.rotation.outputs.accumulated_lines }}
+      rotation_policy: ${{ steps.rotation.outputs.rotation_policy }}
     steps:
       # fetch-depth: 0 in every job. The watermark can be arbitrarily far back,
       # and a shallow clone turns "resolve the range" into "fail confusingly".
@@ -217,6 +231,7 @@ jobs:
       # ::error annotation and $GITHUB_STEP_SUMMARY write both happen before
       # the script's own exit.
       - name: Check whether the documentation branch would rotate
+        id: rotation
         continue-on-error: true
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
@@ -225,6 +240,7 @@ jobs:
           set -uo pipefail
           chmod +x "$DOSSIER_BIN"/*.sh
           "$DOSSIER_BIN/dossier-rotation-check.sh" \
+            --github-output "$GITHUB_OUTPUT" \
             --summary "$GITHUB_STEP_SUMMARY"
 
       - name: Build the evidence bundle

--- a/plugins/dossier/templates/ci/dossier-docs-refresh.yml
+++ b/plugins/dossier/templates/ci/dossier-docs-refresh.yml
@@ -806,8 +806,33 @@ jobs:
             # identity created the commit, and it is trivially spoofable; a
             # trailer we write ourselves on every commit is not a stronger
             # secret, but it is a far more reliable label.
+            #
+            # git rev-list's own exit status is captured explicitly: an
+            # unrelated failure (object-store issue, disk pressure) must not
+            # look like "genuinely no foreign commits" -- that is the exact
+            # "empty result treated as confirmed-safe" bug class the
+            # EXISTING_PR_LOOKUP_FAILED guard below exists to close, one hop
+            # earlier in this same step.
             FOREIGN=''
-            for C in $(git rev-list "origin/${BASE_REF}..origin/${DOCS_BRANCH}" 2>/dev/null); do
+            REV_LIST_OUT=$(git rev-list "origin/${BASE_REF}..origin/${DOCS_BRANCH}" 2>&1)
+            REV_LIST_RC=$?
+            if [ "$REV_LIST_RC" -ne 0 ]; then
+              echo "::error title=Dossier::Could not enumerate commits on ${DOCS_BRANCH} to check for foreign (non-Dossier-Generated) history. Refusing to guess."
+              {
+                echo '### Dossier publish stopped: could not verify the documentation branch history'
+                echo
+                echo "\`git rev-list\` failed while checking \`${DOCS_BRANCH}\` for commits this job"
+                echo 'did not write, so it cannot be confirmed safe to delete and recreate.'
+                echo
+                echo '```'
+                echo "$REV_LIST_OUT"
+                echo '```'
+                echo
+                echo 'Nothing was deleted. Re-run the workflow once this can be checked.'
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+            fi
+            for C in $REV_LIST_OUT; do
               if ! git show -s --format=%B "$C" | grep -qiE '^Dossier-Generated:[[:space:]]*true[[:space:]]*$'; then
                 FOREIGN="${FOREIGN} ${C}"
               fi
@@ -819,12 +844,18 @@ jobs:
                 echo "::notice title=Dossier::The documentation branch carries commits this job did not write. They are preserved; the refresh lands on top of them."
               fi
             elif [ -n "$FOREIGN" ]; then
-              echo "::error title=Dossier::The documentation branch has no open pull request but carries commits without a Dossier-Generated trailer."
+              echo "::error title=Dossier::The documentation branch has no confirmed open pull request but carries commits without a Dossier-Generated trailer."
               {
                 echo '### Dossier publish stopped: unrecognised commits on the documentation branch'
                 echo
-                echo "\`${DOCS_BRANCH}\` has no open pull request, so it would normally be recreated"
-                echo 'from the base branch. It carries commits this job did not write:'
+                if [ "$EXISTING_PR_LOOKUP_FAILED" = "false" ]; then
+                  echo "\`${DOCS_BRANCH}\` has no open pull request, so it would normally be recreated"
+                  echo 'from the base branch. It carries commits this job did not write:'
+                else
+                  echo "\`${DOCS_BRANCH}\`'s pull-request lookup failed (or gh was unavailable), so it is"
+                  echo 'not confirmed whether an open pull request exists. Either way, it carries'
+                  echo 'commits this job did not write:'
+                fi
                 echo
                 echo '```'
                 for C in $FOREIGN; do git log -1 --format='%h %an %s' "$C"; done
@@ -834,7 +865,14 @@ jobs:
                 echo 'once you are sure it is finished, then re-run this workflow.'
               } >> "$GITHUB_STEP_SUMMARY"
               exit 1
-            elif [ "$EXISTING_PR_LOOKUP_FAILED" = "true" ]; then
+            elif [ "$EXISTING_PR_LOOKUP_FAILED" != "false" ]; then
+              # Checked against the explicit safe value ("false"), not against
+              # the unsafe one ("true") -- an absent/unexpected value (e.g. a
+              # rendered workflow paired with a dossier-policy.sh pinned to a
+              # tag from before this field existed at all, which this
+              # plugin's own version-decoupling design allows) must also
+              # refuse, not silently fall through to the destructive path.
+              #
               # An empty EXISTING_PR here is uninformative, not a confirmed
               # "no PR is open" -- the policy job's own lookup failed or gh
               # was unavailable. This is exactly the steady state whenever a
@@ -842,14 +880,15 @@ jobs:
               # deleting and recreating the branch would discard the commits
               # that PR is reviewing. Refuse, matching the FOREIGN-commits
               # refusal above rather than silently guessing.
-              echo "::error title=Dossier::Could not confirm whether ${DOCS_BRANCH} has an open pull request (the lookup failed or gh was unavailable). Refusing to delete and recreate a branch that might have review history attached."
+              echo "::error title=Dossier::Could not confirm whether ${DOCS_BRANCH} has an open pull request (the lookup failed, gh was unavailable, or the signal was unexpectedly absent). Refusing to delete and recreate a branch that might have review history attached."
               {
                 echo '### Dossier publish stopped: could not confirm the documentation branch has no open pull request'
                 echo
                 echo "\`${DOCS_BRANCH}\` exists and carries no unrecognised commits, which would normally mean"
                 echo "it is safe to recreate from the base branch. But the pull-request lookup that"
-                echo 'decision depends on failed (or gh was unavailable), so an empty result cannot be'
-                echo 'trusted as "no pull request is open".'
+                echo 'decision depends on failed, gh was unavailable, or the signal was unexpectedly'
+                echo 'absent -- an empty result cannot be trusted as "no pull request is open" unless'
+                echo 'it is explicitly confirmed.'
                 echo
                 echo 'Nothing was deleted. Re-run the workflow once the lookup can succeed, or verify'
                 echo 'by hand whether a pull request is open before deleting the branch yourself.'

--- a/plugins/dossier/templates/ci/dossier-docs-refresh.yml
+++ b/plugins/dossier/templates/ci/dossier-docs-refresh.yml
@@ -814,7 +814,15 @@ jobs:
             # EXISTING_PR_LOOKUP_FAILED guard below exists to close, one hop
             # earlier in this same step.
             FOREIGN=''
-            REV_LIST_OUT=$(git rev-list "origin/${BASE_REF}..origin/${DOCS_BRANCH}" 2>&1)
+            # stderr captured separately from stdout -- on the success path,
+            # any warning git writes to stderr (ambiguous-refname, reflog-gap,
+            # advice text) must never be merged into $REV_LIST_OUT: the loop
+            # below word-splits it unquoted, and a stray warning word treated
+            # as a commit SHA would fail `git show`, be silently misread as
+            # foreign (no Dossier-Generated trailer found), and land in the
+            # refusal message the operator actually reads.
+            REV_LIST_ERR=$(mktemp 2>/dev/null) || REV_LIST_ERR="${RUNNER_TEMP:-/tmp}/dossier-rev-list-err.$$"
+            REV_LIST_OUT=$(git rev-list "origin/${BASE_REF}..origin/${DOCS_BRANCH}" 2>"$REV_LIST_ERR")
             REV_LIST_RC=$?
             if [ "$REV_LIST_RC" -ne 0 ]; then
               echo "::error title=Dossier::Could not enumerate commits on ${DOCS_BRANCH} to check for foreign (non-Dossier-Generated) history. Refusing to guess."
@@ -825,13 +833,15 @@ jobs:
                 echo 'did not write, so it cannot be confirmed safe to delete and recreate.'
                 echo
                 echo '```'
-                echo "$REV_LIST_OUT"
+                cat "$REV_LIST_ERR" 2>/dev/null
                 echo '```'
                 echo
                 echo 'Nothing was deleted. Re-run the workflow once this can be checked.'
               } >> "$GITHUB_STEP_SUMMARY"
+              rm -f "$REV_LIST_ERR" 2>/dev/null
               exit 1
             fi
+            rm -f "$REV_LIST_ERR" 2>/dev/null
             for C in $REV_LIST_OUT; do
               if ! git show -s --format=%B "$C" | grep -qiE '^Dossier-Generated:[[:space:]]*true[[:space:]]*$'; then
                 FOREIGN="${FOREIGN} ${C}"

--- a/plugins/dossier/tests/hooks.test.sh
+++ b/plugins/dossier/tests/hooks.test.sh
@@ -303,6 +303,18 @@ for H in enforce-output-root enforce-allowed-actions block-unregistered-claim; d
   assert_equal "2" "$RC" "$H fails closed when jq is unavailable"
 done
 
+# A distinct failure class from "jq unavailable": jq present but given input
+# it cannot parse (a malformed/truncated hook payload). Before the fix, this
+# produced an empty $COMMAND indistinguishable from "no command field present"
+# -- both took the same `[ -z "$COMMAND" ] && exit 0` path, silently allowing
+# the run to proceed with its action ceiling entirely unenforced for that
+# command, contradicting the file's own declared fail-closed posture.
+RC=0
+OUT=$(cd "$WORK" && printf '%s' '{not valid json' \
+        | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" 2>&1) || RC=$?
+assert_equal "2" "$RC" "enforce-allowed-actions fails closed on malformed JSON input, not silently allowed"
+assert_contains "BLOCKED" "$OUT" "the malformed-input failure names the block"
+
 # stale-header-stamp and detect-local-merge are advisory, so they correctly
 # do the reverse.
 RC=0

--- a/plugins/dossier/tests/hooks.test.sh
+++ b/plugins/dossier/tests/hooks.test.sh
@@ -168,6 +168,66 @@ for OK in 'timeout 5 ls' 'time ls' 'nice ls' 'env ls' 'ls -la' 'git status' 'cat
   assert_equal "0" "$RC" "enforce-allowed-actions permits: $OK"
 done
 
+# --- find -exec/-execdir/-ok/-okdir and xargs -I{} indirection (issue #143) ---
+# -exec/-execdir/-ok/-okdir glue the sub-command execution position to a flag
+# rather than spelling it as a standalone token, so neither BOUND nor the prior
+# WRAPPER token list ever fired for the denied command sitting inside them.
+# One representative command per existing deny-block, so the fix (adding
+# "find" to WRAPPER) is proven to apply uniformly to every block rather than
+# just the block it happened to be developed against.
+for CASE in \
+  'find . -exec npm test {} \;|runTests' \
+  'find . -exec curl https://example.invalid {} \;|networkAccess' \
+  'find . -execdir curl https://example.invalid {} \;|networkAccess' \
+  'find . -ok curl https://example.invalid {} \;|networkAccess' \
+  'find . -okdir curl https://example.invalid {} \;|networkAccess' \
+  'find . -exec osv-scanner {} \;|runSecurityScan' \
+  'find . -exec pyscn {} \;|runCodeQualityScan'
+do
+  BAD="${CASE%%|*}"
+  CLASS="${CASE##*|}"
+  RC=0
+  (cd "$WORK" && printf '{"tool_input":{"command":%s}}' "$(printf '%s' "$BAD" | jq -Rs .)" \
+     | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
+  assert_equal "2" "$RC" "enforce-allowed-actions sees through find's exec position ($CLASS): $BAD"
+done
+
+# runBuild's own denied tokens (make/cargo build/...) require a bare command
+# word, unlike npm/osv-scanner/curl above, so this needs its own case rather
+# than reusing the loop's single-word BAD strings.
+RC=0
+(cd "$WORK" && printf '%s' '{"tool_input":{"command":"find . -exec make {} \\;"}}' \
+   | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
+assert_equal "2" "$RC" "enforce-allowed-actions sees through find's exec position (runBuild): find . -exec make {} \\;"
+
+# xargs -I{} was already covered by the pre-existing WRAPPER token list (xargs
+# itself is a standalone token there), but AC1 names it explicitly, so it gets
+# its own direct assertion rather than relying on the general wrapper-loop
+# above to stand in for it.
+RC=0
+(cd "$WORK" && printf '%s' '{"tool_input":{"command":"xargs -I{} curl {}"}}' \
+   | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
+assert_equal "2" "$RC" "enforce-allowed-actions denies xargs -I{} <denied-command> {} (networkAccess)"
+
+# Accepted tradeoff, pinned rather than left only in a comment: once "find" is
+# a WRAPPER token, EVERY whitespace run becomes a boundary for the whole
+# command, so a find invocation that merely searches for a denied phrase as a
+# -name argument (no -exec at all) is over-blocked too. Same tradeoff class
+# already shipped for every other WRAPPER token (e.g. timeout+grep-about-a-
+# command); this is the first time it is pinned down with its own assertion
+# instead of only documented in prose.
+RC=0
+(cd "$WORK" && printf '%s' '{"tool_input":{"command":"find . -name \"npm test\""}}' \
+   | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
+assert_equal "2" "$RC" "accepted tradeoff: find . -name \"npm test\" is over-blocked once find is a WRAPPER token"
+
+# Ordinary find usage with no embedded denied command must still pass — the
+# fix must not turn every find invocation into a denial.
+RC=0
+(cd "$WORK" && printf '%s' '{"tool_input":{"command":"find . -type f -name \"*.md\""}}' \
+   | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
+assert_equal "0" "$RC" "ordinary find usage with no denied command embedded is still permitted"
+
 # --- Scanner deny-blocks (issue #137): a defense-in-depth backstop for the
 # two new runSecurityScan/runCodeQualityScan flags, on top of the primary
 # architectural containment (the scanners run as an isolated CI step, never

--- a/plugins/dossier/tests/hooks.test.sh
+++ b/plugins/dossier/tests/hooks.test.sh
@@ -209,17 +209,25 @@ RC=0
    | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
 assert_equal "2" "$RC" "enforce-allowed-actions denies xargs -I{} <denied-command> {} (networkAccess)"
 
-# Accepted tradeoff, pinned rather than left only in a comment: once "find" is
-# a WRAPPER token, EVERY whitespace run becomes a boundary for the whole
-# command, so a find invocation that merely searches for a denied phrase as a
-# -name argument (no -exec at all) is over-blocked too. Same tradeoff class
-# already shipped for every other WRAPPER token (e.g. timeout+grep-about-a-
-# command); this is the first time it is pinned down with its own assertion
-# instead of only documented in prose.
+# A find invocation with no -exec/-execdir/-ok/-okdir must never trip
+# boundary-widening at all, even when it merely searches for a denied phrase
+# as a -name argument -- this was an accepted over-block under the original
+# bare-"find"-in-WRAPPER fix, and is now correctly resolved by requiring
+# find to actually co-occur with one of its own sub-command-execution
+# primaries (FIND_EXEC) rather than triggering on the bare token. Also
+# covers a broader real-shape false positive a code-review pass demonstrated
+# live: an ordinary commit-message-shaped string that merely contains both
+# "find" and a denied phrase as separate words, with no find invocation at
+# all.
 RC=0
 (cd "$WORK" && printf '%s' '{"tool_input":{"command":"find . -name \"npm test\""}}' \
    | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
-assert_equal "2" "$RC" "accepted tradeoff: find . -name \"npm test\" is over-blocked once find is a WRAPPER token"
+assert_equal "0" "$RC" "find . -name \"npm test\" (no -exec) is correctly NOT over-blocked -- find alone never widens boundary mode"
+
+RC=0
+(cd "$WORK" && printf '%s' '{"tool_input":{"command":"git commit -m \"docs: find and document the npm test workflow\""}}' \
+   | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
+assert_equal "0" "$RC" "a command whose text merely contains both \"find\" and a denied phrase as separate words (no find invocation) is not over-blocked"
 
 # Ordinary find usage with no embedded denied command must still pass — the
 # fix must not turn every find invocation into a denial.
@@ -227,6 +235,10 @@ RC=0
 (cd "$WORK" && printf '%s' '{"tool_input":{"command":"find . -type f -name \"*.md\""}}' \
    | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
 assert_equal "0" "$RC" "ordinary find usage with no denied command embedded is still permitted"
+
+# -execdir/-ok/-okdir coverage (not just -exec) is already proven above by
+# the "sees through find's exec position" loop -- no separate FIND_EXEC-
+# specific assertion needed here.
 
 # --- Scanner deny-blocks (issue #137): a defense-in-depth backstop for the
 # two new runSecurityScan/runCodeQualityScan flags, on top of the primary
@@ -309,11 +321,29 @@ done
 # -- both took the same `[ -z "$COMMAND" ] && exit 0` path, silently allowing
 # the run to proceed with its action ceiling entirely unenforced for that
 # command, contradicting the file's own declared fail-closed posture.
+# Exercised here with an active run ($WORK's .scope.json is still in place
+# from earlier in this file), and a more specific assertion than a bare
+# "BLOCKED" substring so this case is distinguishable from the jq-unavailable
+# case tested just above -- both emit "BLOCKED", only this one names parsing.
 RC=0
 OUT=$(cd "$WORK" && printf '%s' '{not valid json' \
         | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" 2>&1) || RC=$?
-assert_equal "2" "$RC" "enforce-allowed-actions fails closed on malformed JSON input, not silently allowed"
-assert_contains "BLOCKED" "$OUT" "the malformed-input failure names the block"
+assert_equal "2" "$RC" "enforce-allowed-actions fails closed on malformed JSON input during an active run, not silently allowed"
+assert_contains "could not parse" "$OUT" "the malformed-input failure specifically names parsing, distinct from the jq-unavailable failure"
+
+# But with NO active run at all (no .scope.json anywhere under the cwd), the
+# same malformed payload must stay inert -- matching this file's own header
+# contract ("Inert unless a dossier run is active") for the ordinary case of
+# a non-dossier repository that merely has the hook installed. This is the
+# regression test for the reordering fix: inertness is decided before any
+# JSON parsing is attempted, not after.
+NORUN=$(mktemp -d 2>/dev/null) || NORUN="/tmp/dossier-hooks-norun.$$"
+mkdir -p "$NORUN" 2>/dev/null
+RC=0
+OUT=$(cd "$NORUN" && printf '%s' '{not valid json' \
+        | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" 2>&1) || RC=$?
+assert_equal "0" "$RC" "malformed JSON with no active dossier run stays inert, matching the header contract"
+rm -rf "$NORUN" 2>/dev/null
 
 # stale-header-stamp and detect-local-merge are advisory, so they correctly
 # do the reverse.

--- a/plugins/dossier/tests/policy-existing-pr.test.sh
+++ b/plugins/dossier/tests/policy-existing-pr.test.sh
@@ -169,5 +169,51 @@ OUT3=$(run_policy "$STUB3")
 RC3=$?
 assert_equal "0" "$RC3" "only a same-repo PR exists: dossier-policy.sh still exits 0"
 assert_equal "42" "$(get "$OUT3" existing_pr)" "only a same-repo PR exists: it is correctly selected"
+assert_equal "false" "$(get "$OUT3" existing_pr_lookup_failed)" "a genuinely successful lookup reports existing_pr_lookup_failed=false"
+
+# =============================================================================
+# 4. A gh pr list failure (auth/rate-limit/transient API error) must be
+#    distinguishable from a genuine "no PR found" result. Left unguarded, this
+#    is not merely a missed telemetry signal: the publish job's "Prepare the
+#    documentation branch" step treats an empty existing_pr as license to
+#    delete and recreate the documentation branch (git push origin --delete)
+#    whenever the branch already exists with no foreign commits -- the exact
+#    steady state whenever a real docs PR is open and gh only failed to
+#    report it. existing_pr_lookup_failed is the signal that step uses to
+#    refuse that path rather than silently guessing "no PR".
+# =============================================================================
+_dossier_require_mktemp_dir STUB4 "policy-gh-stub-failure"
+cat > "$STUB4/gh" <<'STUBEOF'
+#!/usr/bin/env bash
+exit 1
+STUBEOF
+chmod +x "$STUB4/gh"
+
+OUT4=$(run_policy "$STUB4")
+RC4=$?
+assert_equal "0" "$RC4" "gh pr list failure: dossier-policy.sh still exits 0 (advisory, does not hard-fail the policy job)"
+assert_equal "" "$(get "$OUT4" existing_pr)" "gh pr list failure: existing_pr is empty (no data), not a guessed value"
+assert_equal "true" "$(get "$OUT4" existing_pr_lookup_failed)" "gh pr list failure: existing_pr_lookup_failed distinguishes this from a genuine no-PR result"
+
+# =============================================================================
+# 5. gh entirely unavailable on PATH carries the exact same downstream risk
+#    as scenario 4 (existing_pr ends up empty either way) and must set the
+#    same signal -- this is the pre-existing "gh CLI unavailable" branch,
+#    not a new code path.
+# =============================================================================
+# gh and git/jq live in the same real directory on this machine (Homebrew),
+# so a PATH restriction has to keep git/jq reachable by name (via symlinks
+# into an otherwise-empty directory) while genuinely excluding gh, rather
+# than just omitting one directory that happens to hold all three.
+_dossier_require_mktemp_dir STUB5 "policy-no-gh"
+ln -s "$(command -v git)" "$STUB5/git"
+ln -s "$(command -v jq)" "$STUB5/jq"
+OUT5=$(cd "$FIXTURE" && env PATH="$STUB5:/usr/bin:/bin" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
+    EVT=schedule PR_LABELS="" PR_HEAD_REF="" PR_ACTOR="" PR_NUMBER="" \
+    "$POLICY" --base "$WM" 2>&1)
+RC5=$?
+assert_equal "0" "$RC5" "gh unavailable: dossier-policy.sh still exits 0"
+assert_equal "" "$(get "$OUT5" existing_pr)" "gh unavailable: existing_pr is empty"
+assert_equal "true" "$(get "$OUT5" existing_pr_lookup_failed)" "gh unavailable: existing_pr_lookup_failed is also true (same downstream risk as a failed lookup)"
 
 _dossier_test_summary

--- a/plugins/dossier/tests/policy-existing-pr.test.sh
+++ b/plugins/dossier/tests/policy-existing-pr.test.sh
@@ -216,4 +216,157 @@ assert_equal "0" "$RC5" "gh unavailable: dossier-policy.sh still exits 0"
 assert_equal "" "$(get "$OUT5" existing_pr)" "gh unavailable: existing_pr is empty"
 assert_equal "true" "$(get "$OUT5" existing_pr_lookup_failed)" "gh unavailable: existing_pr_lookup_failed is also true (same downstream risk as a failed lookup)"
 
+# =============================================================================
+# 6. The lookup must bound its own page size explicitly, matching this same
+#    file's circuit-breaker call (--limit 100) a few lines below. Without an
+#    explicit --limit, gh applies its own default cap of 30 items BEFORE the
+#    isCrossRepository filter ever runs -- 30+ same-named fork PRs (cheap to
+#    script) could paginate the real same-repo PR off the page entirely,
+#    silently defeating both the isCrossRepository filter and the
+#    existing_pr_lookup_failed guard (gh still exits 0; nothing "failed").
+#    Asserted here by capturing the stub's own argv, not by trying to
+#    simulate 30+ PRs.
+# =============================================================================
+_dossier_require_mktemp_dir STUB6 "policy-gh-stub-limit-capture"
+STUB6_ARGS_LOG="$STUB6/args.log"
+cat > "$STUB6/gh" <<STUBEOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$STUB6_ARGS_LOG"
+FILTER=""
+HAS_HEAD=0
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    --jq) FILTER="\$2"; shift 2 ;;
+    --head) HAS_HEAD=1; shift 2 ;;
+    *) shift ;;
+  esac
+done
+JSON='[]'
+if [ -n "\$FILTER" ]; then
+  printf '%s' "\$JSON" | jq "\$FILTER"
+else
+  printf '%s' "\$JSON"
+fi
+STUBEOF
+chmod +x "$STUB6/gh"
+
+run_policy "$STUB6" >/dev/null 2>&1
+ARGS_LINE=$(grep -- '--head' "$STUB6_ARGS_LOG" 2>/dev/null | head -1)
+assert_contains "--limit" "$ARGS_LINE" "the EXISTING_PR lookup passes an explicit --limit, matching the circuit-breaker call's own precedent"
+
+# =============================================================================
+# 7. dossier.ci.rollingBranch resolving to an explicit empty override must
+#    fall back to the documented default (docs/dossier), not leave DOCS_BRANCH
+#    empty -- matching the identical guard already shipped in
+#    dossier-rotation-check.sh. Without this, this script's own DOCS_BRANCH
+#    could diverge from the sibling script's for the exact same config value.
+# =============================================================================
+_dossier_require_mktemp_dir FIXTURE7 "policy-empty-branch-override"
+mkdir -p "$FIXTURE7/docs/dossier/02-architecture"
+cat >"$FIXTURE7/docs/dossier/02-architecture/system-architecture.md" <<EOF
+dossier-header: v1
+last-verified: $TODAY
+---
+Fresh document.
+EOF
+mkdir -p "$FIXTURE7/.claude"
+cat > "$FIXTURE7/.claude/settings.dossier.json" <<'EOF'
+{"dossier":{"ci":{"rollingBranch":""}}}
+EOF
+(
+  cd "$FIXTURE7" || exit 1
+  git init -q
+  git config user.email test@example.com
+  git config user.name "Test"
+  git add -A
+  git commit -q -m "watermark"
+) >/dev/null 2>&1
+WM7=$(git -C "$FIXTURE7" rev-parse HEAD)
+( cd "$FIXTURE7" && echo noise > random-file.txt && git add -A && git commit -q -m "irrelevant change" ) >/dev/null 2>&1
+
+_dossier_require_mktemp_dir STUB7 "policy-gh-stub-empty-branch"
+cat > "$STUB7/gh" <<'STUBEOF'
+#!/usr/bin/env bash
+FILTER=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --jq) FILTER="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ -n "$FILTER" ]; then
+  printf '%s' '[]' | jq "$FILTER"
+else
+  printf '%s' '[]'
+fi
+STUBEOF
+chmod +x "$STUB7/gh"
+
+OUT7=$(cd "$FIXTURE7" && env PATH="$STUB7:$PATH" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
+    EVT=schedule PR_LABELS="" PR_HEAD_REF="" PR_ACTOR="" PR_NUMBER="" \
+    "$POLICY" --base "$WM7" 2>&1)
+RC7=$?
+assert_equal "0" "$RC7" "dossier.ci.rollingBranch=\"\": dossier-policy.sh still exits 0"
+assert_equal "docs/dossier" "$(get "$OUT7" docs_branch)" "dossier.ci.rollingBranch=\"\": docs_branch falls back to the documented default, not empty"
+
+# =============================================================================
+# 8. A cross-repository decoy PR with NO legitimate same-repo PR open at all
+#    (the "instead of" exploit shape, not "ahead of" -- scenario 1 above only
+#    covers the latter) must resolve to a genuinely empty, successful lookup,
+#    not the decoy's own number.
+# =============================================================================
+_dossier_require_mktemp_dir STUB8 "policy-gh-stub-decoy-only"
+STUB8_JSON='[{"number":99,"isCrossRepository":true}]'
+cat > "$STUB8/gh" <<STUBEOF
+#!/usr/bin/env bash
+FILTER=""
+HAS_HEAD=0
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    --jq) FILTER="\$2"; shift 2 ;;
+    --head) HAS_HEAD=1; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ "\$HAS_HEAD" -eq 1 ]; then
+  JSON='$STUB8_JSON'
+else
+  JSON='[]'
+fi
+if [ -n "\$FILTER" ]; then
+  printf '%s' "\$JSON" | jq "\$FILTER"
+else
+  printf '%s' "\$JSON"
+fi
+STUBEOF
+chmod +x "$STUB8/gh"
+
+OUT8=$(run_policy "$STUB8")
+RC8=$?
+assert_equal "0" "$RC8" "cross-repo decoy with no real PR open: dossier-policy.sh still exits 0"
+assert_equal "" "$(get "$OUT8" existing_pr)" "cross-repo decoy with no real PR open: existing_pr is empty, not the decoy's number"
+assert_equal "false" "$(get "$OUT8" existing_pr_lookup_failed)" "cross-repo decoy with no real PR open: this is a successful lookup that correctly found nothing usable, not a failure"
+
+# =============================================================================
+# 9. The human-readable job-summary table must distinguish "lookup failed" from
+#    "confirmed no PR" -- both leave existing_pr empty, but only the Notes
+#    section (easy to miss) previously carried the distinction. An operator
+#    skimming just the table must not read a failure as a confirmed fact.
+# =============================================================================
+_dossier_require_mktemp_dir STUB9 "policy-gh-stub-summary-failure"
+cat > "$STUB9/gh" <<'STUBEOF'
+#!/usr/bin/env bash
+exit 1
+STUBEOF
+chmod +x "$STUB9/gh"
+SUMMARY9="$STUB9/summary.md"
+( cd "$FIXTURE" && env PATH="$STUB9:$PATH" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
+    EVT=schedule PR_LABELS="" PR_HEAD_REF="" PR_ACTOR="" PR_NUMBER="" \
+    "$POLICY" --base "$WM" --summary "$SUMMARY9" ) >/dev/null 2>&1
+RC9=$?
+assert_equal "0" "$RC9" "summary table test: dossier-policy.sh still exits 0"
+SUMMARY9_BODY=$(cat "$SUMMARY9" 2>/dev/null)
+assert_contains "unknown (lookup failed)" "$SUMMARY9_BODY" "the summary table's Existing docs PR row distinguishes a failed lookup from a confirmed no-PR result"
+assert_not_contains "Existing docs PR | \`none\`" "$SUMMARY9_BODY" "the summary table never renders a failed lookup as the same 'none' value a confirmed no-PR result would show"
+
 _dossier_test_summary

--- a/plugins/dossier/tests/policy-existing-pr.test.sh
+++ b/plugins/dossier/tests/policy-existing-pr.test.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# dossier-policy.sh (issue #146): the EXISTING_PR lookup at line ~390 uses
+# `gh pr list --head "$DOCS_BRANCH"`, which matches by branch name only,
+# across every fork with an open PR against this repo — `gh` has no
+# owner:branch syntax to scope `--head` to a specific fork. Left unfiltered,
+# an external contributor could open a same-named decoy PR from a fork and
+# have it silently returned instead of (or ahead of) the real docs-refresh
+# PR, feeding straight into the publish job's write-token `gh pr edit` call.
+#
+# This is the pre-existing original that PR #145's SEC-1 fix (in the new
+# dossier-rotation-check.sh) was copied from — that script already carries
+# the isCrossRepository filter; this file regression-tests the same fix
+# applied to the original call site.
+
+_dossier_test_begin "policy-existing-pr"
+
+POLICY="$(pwd)/plugins/dossier/bin/dossier-policy.sh"
+PLUGIN_ROOT="$(pwd)/plugins/dossier"
+
+if [ ! -x "$POLICY" ]; then
+  _dossier_assert_fail "$POLICY missing or not executable"
+  _dossier_test_summary
+  return 0 2>/dev/null || exit 0
+fi
+
+# Minimal fixture: a real git repo with one fresh (non-stale) canonical
+# document, so the staleness sweep this script also runs has nothing to
+# report and cannot interfere with the field this file actually asserts on
+# (existing_pr) -- same fixture shape proven to work end-to-end for
+# dossier-policy.sh in staleness-trigger.test.sh's own F3 case.
+_dossier_require_mktemp_dir FIXTURE "policy-existing-pr"
+mkdir -p "$FIXTURE/docs/dossier/02-architecture"
+TODAY=$(date -u +%Y-%m-%d)
+cat >"$FIXTURE/docs/dossier/02-architecture/system-architecture.md" <<EOF
+dossier-header: v1
+last-verified: $TODAY
+---
+Fresh document.
+EOF
+(
+  cd "$FIXTURE" || exit 1
+  git init -q
+  git config user.email test@example.com
+  git config user.name "Test"
+  git add -A
+  git commit -q -m "watermark"
+) >/dev/null 2>&1
+WM=$(git -C "$FIXTURE" rev-parse HEAD)
+( cd "$FIXTURE" && echo noise > random-file.txt && git add -A && git commit -q -m "irrelevant change" ) >/dev/null 2>&1
+
+get() { printf '%s\n' "$1" | awk -F= -v k="$2" '$1==k{sub(/^[^=]*=/,""); print; exit}'; }
+
+run_policy() {
+  # $1 = PATH prefix (the fake-gh stub dir), rest is env passthrough.
+  local stub_path="$1"
+  shift
+  ( cd "$FIXTURE" && env PATH="$stub_path:$PATH" "$@" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
+      EVT=schedule PR_LABELS="" PR_HEAD_REF="" PR_ACTOR="" PR_NUMBER="" \
+      "$POLICY" --base "$WM" 2>&1 )
+}
+
+# =============================================================================
+# 1. A cross-repository decoy PR (same branch name, more recently opened, from
+#    a fork) must never be preferred over the real same-repo PR. The stub
+#    applies gh's real --jq filter via actual jq against a JSON array carrying
+#    both PRs -- not a fixed echo -- so this exercises the exact jq expression
+#    dossier-policy.sh sends, the same technique rotation-check.test.sh uses
+#    in its own scenario 17 for the sibling script this fix was copied from.
+# =============================================================================
+_dossier_require_mktemp_dir STUB1 "policy-gh-stub-decoy"
+STUB1_JSON='[{"number":99,"isCrossRepository":true},{"number":7,"isCrossRepository":false}]'
+cat > "$STUB1/gh" <<STUBEOF
+#!/usr/bin/env bash
+FILTER=""
+HAS_HEAD=0
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    --jq) FILTER="\$2"; shift 2 ;;
+    --head) HAS_HEAD=1; shift 2 ;;
+    *) shift ;;
+  esac
+done
+# Distinguish the EXISTING_PR lookup (passes --head "\$DOCS_BRANCH") from the
+# circuit-breaker count (passes --state all --label, no --head) by the flag
+# actually used to select between the two call shapes -- not by which --json
+# fields were requested, since the FIX under test is exactly a change to
+# which fields the EXISTING_PR call requests (number -> number,isCrossRepository).
+# A stub keyed on --json content would silently test the wrong thing against
+# pre-fix code. isCrossRepository is always present in the served JSON
+# regardless of what --json asked for, same as a real GitHub API response
+# would carry -- only the caller's own --jq filter decides what it extracts.
+if [ "\$HAS_HEAD" -eq 1 ]; then
+  JSON='$STUB1_JSON'
+else
+  JSON='[]'
+fi
+if [ -n "\$FILTER" ]; then
+  printf '%s' "\$JSON" | jq "\$FILTER"
+else
+  printf '%s' "\$JSON"
+fi
+STUBEOF
+chmod +x "$STUB1/gh"
+
+OUT1=$(run_policy "$STUB1")
+RC1=$?
+assert_equal "0" "$RC1" "cross-repository decoy PR present: dossier-policy.sh still exits 0"
+assert_equal "7" "$(get "$OUT1" existing_pr)" "cross-repository decoy PR present: the real same-repo PR (#7) is selected, not the fork decoy (#99)"
+
+# =============================================================================
+# 2. No open PR at all (both same-repo and cross-repo): existing_pr is empty,
+#    not a stale/wrong value from a prior lookup.
+# =============================================================================
+_dossier_require_mktemp_dir STUB2 "policy-gh-stub-none"
+cat > "$STUB2/gh" <<'STUBEOF'
+#!/usr/bin/env bash
+FILTER=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --jq) FILTER="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ -n "$FILTER" ]; then
+  printf '%s' '[]' | jq "$FILTER"
+else
+  printf '%s' '[]'
+fi
+STUBEOF
+chmod +x "$STUB2/gh"
+
+OUT2=$(run_policy "$STUB2")
+RC2=$?
+assert_equal "0" "$RC2" "no open PR at all: dossier-policy.sh still exits 0"
+assert_equal "" "$(get "$OUT2" existing_pr)" "no open PR at all: existing_pr is empty, not a stale value"
+
+# =============================================================================
+# 3. Only a same-repo PR exists (the ordinary case, no fork involved): it is
+#    still correctly selected -- the isCrossRepository filter must not
+#    accidentally exclude legitimate same-repo PRs.
+# =============================================================================
+_dossier_require_mktemp_dir STUB3 "policy-gh-stub-samerepo"
+STUB3_JSON='[{"number":42,"isCrossRepository":false}]'
+cat > "$STUB3/gh" <<STUBEOF
+#!/usr/bin/env bash
+FILTER=""
+HAS_HEAD=0
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    --jq) FILTER="\$2"; shift 2 ;;
+    --head) HAS_HEAD=1; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ "\$HAS_HEAD" -eq 1 ]; then
+  JSON='$STUB3_JSON'
+else
+  JSON='[]'
+fi
+if [ -n "\$FILTER" ]; then
+  printf '%s' "\$JSON" | jq "\$FILTER"
+else
+  printf '%s' "\$JSON"
+fi
+STUBEOF
+chmod +x "$STUB3/gh"
+
+OUT3=$(run_policy "$STUB3")
+RC3=$?
+assert_equal "0" "$RC3" "only a same-repo PR exists: dossier-policy.sh still exits 0"
+assert_equal "42" "$(get "$OUT3" existing_pr)" "only a same-repo PR exists: it is correctly selected"
+
+_dossier_test_summary

--- a/plugins/dossier/tests/workflow-template.test.sh
+++ b/plugins/dossier/tests/workflow-template.test.sh
@@ -135,8 +135,60 @@ assert_not_contains "docs_branch: \${{ steps.rotation.outputs" "$BODY" "no rotat
 # bundle, not a scenario from either issue's original body).
 assert_contains "existing_pr_lookup_failed: \${{ steps.decide.outputs.existing_pr_lookup_failed }}" "$BODY" "policy job exposes existing_pr_lookup_failed sourced from the decide step"
 assert_contains "EXISTING_PR_LOOKUP_FAILED: \${{ needs.policy.outputs.existing_pr_lookup_failed }}" "$BODY" "the branch-preparation step reads existing_pr_lookup_failed from the policy job"
-assert_contains 'elif [ "$EXISTING_PR_LOOKUP_FAILED" = "true" ]; then' "$BODY" "the branch-preparation step's recreate path checks existing_pr_lookup_failed before proceeding"
+# Checked against the safe value ("!= false"), never the unsafe one
+# ("= true") -- an absent/unexpected signal (e.g. a rendered workflow paired
+# with an older dossier-policy.sh that predates this field) must also refuse,
+# not silently fall through to the destructive recreate path
+# (/flow:review PR#153, security-skeptic SEC-1).
+assert_contains 'elif [ "$EXISTING_PR_LOOKUP_FAILED" != "false" ]; then' "$BODY" "the branch-preparation step's recreate path fails closed on anything but an explicit false"
+assert_not_contains 'elif [ "$EXISTING_PR_LOOKUP_FAILED" = "true" ]; then' "$BODY" "the fail-open form (checking for the unsafe value) is not present anywhere in the workflow"
 assert_contains "Refusing to delete and recreate a branch that might have review history attached" "$BODY" "a failed pull-request lookup refuses the destructive recreate path rather than guessing"
+
+# Extract only the branch-preparation step's own block, matching the
+# ROTATION_STEP_BLOCK technique above: from its own `- name:` line up to (but
+# not including) the next `- name:` line, so text elsewhere in the workflow
+# (e.g. a comment mentioning the same phrases) cannot produce a false pass.
+BRANCH_PREP_BLOCK=$(awk '
+  /- name: Prepare the documentation branch/ { f=1; print; next }
+  f && /^      - name:/ { exit }
+  f { print }
+' "$WF")
+
+# git rev-list's own exit status must be checked before its output is
+# consumed, and the failure path must refuse rather than silently treat the
+# failure as "no foreign commits" (/flow:review PR#153, error-handler
+# skeptic+verifier auto-consensus ERR-1). A plain assert_contains cannot
+# detect the check being present but unreachable (e.g. moved after the
+# consuming loop), so line order within the extracted block is verified
+# explicitly, matching the CLEANUP_LINE_NUM/UPLOAD_LINE_NUM technique above.
+assert_contains 'REV_LIST_RC=$?' "$BRANCH_PREP_BLOCK" "the branch-preparation step captures git rev-list's own exit status"
+assert_contains 'if [ "$REV_LIST_RC" -ne 0 ]; then' "$BRANCH_PREP_BLOCK" "the branch-preparation step checks the captured exit status"
+assert_contains "could not verify the documentation branch history" "$BRANCH_PREP_BLOCK" "a failed rev-list refuses with its own job-summary error block"
+
+REV_LIST_CAPTURE_LINE=$(printf '%s\n' "$BRANCH_PREP_BLOCK" | grep -n 'REV_LIST_RC=\$?' | head -1 | cut -d: -f1)
+REV_LIST_CHECK_LINE=$(printf '%s\n' "$BRANCH_PREP_BLOCK" | grep -n 'if \[ "\$REV_LIST_RC" -ne 0 \]; then' | head -1 | cut -d: -f1)
+REV_LIST_CONSUME_LINE=$(printf '%s\n' "$BRANCH_PREP_BLOCK" | grep -n 'for C in \$REV_LIST_OUT' | head -1 | cut -d: -f1)
+if [ -n "$REV_LIST_CAPTURE_LINE" ] && [ -n "$REV_LIST_CHECK_LINE" ] && [ -n "$REV_LIST_CONSUME_LINE" ] \
+  && [ "$REV_LIST_CAPTURE_LINE" -lt "$REV_LIST_CHECK_LINE" ] && [ "$REV_LIST_CHECK_LINE" -lt "$REV_LIST_CONSUME_LINE" ]; then
+  _dossier_assert_pass "git rev-list's exit status is checked before its output is consumed by the FOREIGN-commit loop"
+else
+  _dossier_assert_fail "git rev-list's exit status is not verifiably checked before its output is consumed"
+fi
+
+# The fail-closed existing_pr_lookup_failed elif must actually be reachable:
+# it must appear as its own arm of the SAME if/elif chain, strictly before
+# the chain's final `else` / `MODE=recreate` fallback -- otherwise a
+# misordering could leave the guard present in the file (satisfying a plain
+# assert_contains) but dead code that this destructive path never reaches.
+LOOKUP_FAILED_LINE=$(printf '%s\n' "$BRANCH_PREP_BLOCK" | grep -n 'elif \[ "\$EXISTING_PR_LOOKUP_FAILED" != "false" \]; then' | head -1 | cut -d: -f1)
+FOREIGN_ELIF_LINE=$(printf '%s\n' "$BRANCH_PREP_BLOCK" | grep -n 'elif \[ -n "\$FOREIGN" \]; then' | head -1 | cut -d: -f1)
+RECREATE_LINE=$(printf '%s\n' "$BRANCH_PREP_BLOCK" | grep -n 'MODE=recreate' | head -1 | cut -d: -f1)
+if [ -n "$FOREIGN_ELIF_LINE" ] && [ -n "$LOOKUP_FAILED_LINE" ] && [ -n "$RECREATE_LINE" ] \
+  && [ "$FOREIGN_ELIF_LINE" -lt "$LOOKUP_FAILED_LINE" ] && [ "$LOOKUP_FAILED_LINE" -lt "$RECREATE_LINE" ]; then
+  _dossier_assert_pass "existing_pr_lookup_failed is checked as a reachable arm of the if/elif chain, strictly before the recreate fallback"
+else
+  _dossier_assert_fail "existing_pr_lookup_failed guard is not verifiably ordered before the recreate fallback"
+fi
 
 # --- AC2: the policy job never closes a PR, deletes a branch, or creates a --
 # replacement branch, under any circumstance ---------------------------------

--- a/plugins/dossier/tests/workflow-template.test.sh
+++ b/plugins/dossier/tests/workflow-template.test.sh
@@ -85,6 +85,45 @@ assert_contains "continue-on-error: true" "$ROTATION_STEP_BLOCK" "the rotation-c
 # legitimate GitHub Actions expression that also contains `{{`.
 assert_not_contains "{{DOSSIER_" "$ROTATION_STEP_BLOCK" "the rotation-check step introduces no new template placeholder"
 
+# --- Rotation telemetry surfaced as job outputs (issue #148) -----------------
+# Without an id: and --github-output, the rotation step's fields land only in
+# stdout/the job summary -- human-readable per run, but not queryable across
+# runs, undercutting the whole point of an observation period. Both the step
+# itself and the policy job's outputs: map need updating.
+assert_contains "id: rotation" "$ROTATION_STEP_BLOCK" "the rotation-check step has its own step id"
+assert_contains "--github-output \"\$GITHUB_OUTPUT\"" "$ROTATION_STEP_BLOCK" "the rotation-check step passes --github-output so its fields land in GITHUB_OUTPUT, not just stdout/summary"
+
+# The script's own emitted keys (would_rotate/reason/age_days/age_source/
+# accumulated_files/accumulated_lines/rotation_policy) collide with two keys
+# the decide step ALREADY exposes on this same job (reason, docs_branch) --
+# confirmed by reading both the script's emit() calls and this job's existing
+# outputs: map. Every rotation-sourced output is prefixed rotation_ to avoid
+# that collision, and the redundant docs_branch (both steps resolve the
+# identical dossier.ci.rollingBranch config in the same job run) is dropped
+# rather than re-exposed under a new name.
+# Six fields keep their script-emitted name, prefixed on the output-map side
+# only. rotation_policy is the odd one out: the script itself already emits a
+# field literally named rotation_policy (see dossier-rotation-check.sh's own
+# finish()), so no further prefixing is applied there -- rotation_rotation_policy
+# would be wrong.
+for KEY in would_rotate reason age_days age_source accumulated_files accumulated_lines; do
+  assert_contains "rotation_${KEY}: \${{ steps.rotation.outputs.${KEY} }}" "$BODY" "policy job exposes rotation_${KEY} sourced from steps.rotation.outputs.${KEY}"
+done
+assert_contains "rotation_policy: \${{ steps.rotation.outputs.rotation_policy }}" "$BODY" "policy job exposes rotation_policy sourced from steps.rotation.outputs.rotation_policy"
+
+# No collision: the pre-existing decide-step-sourced reason/docs_branch
+# outputs must be completely unchanged -- this is a regression test for the
+# exact bug in this issue's own suggested fix (naming the new outputs
+# unmodified would have silently collided with these).
+assert_contains "reason: \${{ steps.decide.outputs.reason }}" "$BODY" "the pre-existing decide-step reason output is untouched"
+assert_contains "docs_branch: \${{ steps.decide.outputs.docs_branch }}" "$BODY" "the pre-existing decide-step docs_branch output is untouched"
+# Six-space indentation anchors this as its own outputs: map key rather than
+# matching as a substring of the legitimate "rotation_reason: ..." line above
+# (which also contains the literal text "reason: \${{ steps.rotation.outputs.reason }}").
+assert_not_contains "
+      reason: \${{ steps.rotation.outputs.reason }}" "$BODY" "no unprefixed rotation-sourced reason output was added (would collide with decide's own reason)"
+assert_not_contains "docs_branch: \${{ steps.rotation.outputs" "$BODY" "no rotation-sourced docs_branch output was added at all (redundant with decide's own docs_branch, dropped per design)"
+
 # --- AC2: the policy job never closes a PR, deletes a branch, or creates a --
 # replacement branch, under any circumstance ---------------------------------
 # Scoped to the policy job block ONLY (reused from above) — the publish job

--- a/plugins/dossier/tests/workflow-template.test.sh
+++ b/plugins/dossier/tests/workflow-template.test.sh
@@ -124,6 +124,20 @@ assert_not_contains "
       reason: \${{ steps.rotation.outputs.reason }}" "$BODY" "no unprefixed rotation-sourced reason output was added (would collide with decide's own reason)"
 assert_not_contains "docs_branch: \${{ steps.rotation.outputs" "$BODY" "no rotation-sourced docs_branch output was added at all (redundant with decide's own docs_branch, dropped per design)"
 
+# --- existing_pr_lookup_failed guards the publish job's recreate path -------
+# A gh pr list failure (or gh unavailable) leaves existing_pr empty, which is
+# indistinguishable from a genuine "no PR open" result unless this signal is
+# threaded through. Left unguarded, the publish job's branch-preparation step
+# would treat that emptiness as license to delete and recreate the
+# documentation branch whenever it already exists with no foreign commits --
+# exactly the steady state whenever a real docs PR IS open and the lookup
+# just failed to report it (review finding on issues #143/#146/#148's own
+# bundle, not a scenario from either issue's original body).
+assert_contains "existing_pr_lookup_failed: \${{ steps.decide.outputs.existing_pr_lookup_failed }}" "$BODY" "policy job exposes existing_pr_lookup_failed sourced from the decide step"
+assert_contains "EXISTING_PR_LOOKUP_FAILED: \${{ needs.policy.outputs.existing_pr_lookup_failed }}" "$BODY" "the branch-preparation step reads existing_pr_lookup_failed from the policy job"
+assert_contains 'elif [ "$EXISTING_PR_LOOKUP_FAILED" = "true" ]; then' "$BODY" "the branch-preparation step's recreate path checks existing_pr_lookup_failed before proceeding"
+assert_contains "Refusing to delete and recreate a branch that might have review history attached" "$BODY" "a failed pull-request lookup refuses the destructive recreate path rather than guessing"
+
 # --- AC2: the policy job never closes a PR, deletes a branch, or creates a --
 # replacement branch, under any circumstance ---------------------------------
 # Scoped to the policy job block ONLY (reused from above) — the publish job


### PR DESCRIPTION
## Summary

Bundles three hook/policy-hardening fixes for the dossier plugin, per user-approved sequencing (one PR, three atomic commits, one shared branch driven by `/flow:start` on #143):

- **#143** — `enforce-allowed-actions.sh`'s action-ceiling backstop could be bypassed via `find -exec/-execdir/-ok/-okdir`. Closed by adding `find` to the shared `WRAPPER` token-classification list — the same structural mechanism already applied to `xargs`/`env`/`sudo`/`timeout`, extended by one command name rather than by enumerating flags. `xargs -I{}` needed no code change: empirically verified it was already blocked (`xargs` was already a `WRAPPER` token).
- **#146** — `dossier-policy.sh`'s `EXISTING_PR` lookup used `gh pr list --head`, unscoped by repo, letting a same-named fork PR hijack the docs-refresh publish flow. Fixed by adding `isCrossRepository` filtering, mirroring PR #145's already-shipped SEC-1 fix (this issue is the pre-existing original that fix was copied from).
- **#148** — rotation-check telemetry (`would_rotate`/`age_days`/etc.) landed only in stdout/job-summary, not queryable across runs. Wired `id: rotation` + `--github-output` on the step, and added the 7 fields to the policy job's `outputs:` map, prefixed `rotation_*` to avoid colliding with the job's existing `reason`/`docs_branch` outputs.

Closes #143, Closes #146, Closes #148

## Review findings, fixed forward

A 5-agent parallel review (code-quality, security, convention, test-runner, error-handling) plus holdout validation ran against the full bundle diff. **1 P1, 3 P2, 2 P3** — all fixed in this PR (see commit `5f6d065`):

| # | Severity | Finding | Fix |
|---|---|---|---|
| 1 | **P1** | `dossier-policy.sh`'s `EXISTING_PR` lookup swallows `gh pr list`'s exit code. A transient failure leaves it empty, indistinguishable from a genuine no-PR result — and the publish job's branch-preparation step treats that emptiness as license to **delete and recreate** the documentation branch whenever it exists with no foreign commits, exactly the steady state whenever a real docs PR IS open. | New `existing_pr_lookup_failed` output (set on both a `gh` failure and `gh` unavailability); publish job refuses the recreate path when set, matching the existing FOREIGN-commits refusal. |
| 2 | P2 | `enforce-allowed-actions.sh`'s `jq` parse failure was indistinguishable from "no command field present" — both silently `exit 0` (allow), contradicting the file's own declared fail-closed posture. | Checks `jq`'s own exit status separately; fails closed (`exit 2`) on parse failure. |
| 3 | P2 | The find/xargs fix's own comment overclaimed "confirmed live... closed" without disclosing that quoting/backslash-escaping a denied word bypasses `BOUND`/`WRAPPER` entirely, independent of any wrapper token — a real, broader, **pre-existing** bug (predates #143; also defeats plain `curl` with no wrapper at all). | Comment scoped correctly; filed as [#152](https://github.com/synaptiai/synapti-marketplace/issues/152) for the underlying bypass (out of this PR's scope — it's a `BOUND`-wide issue, not specific to `find`/`xargs`). |
| 4 | P2 | Convention: `created:` journal timestamps were copy-pasted identically across `issue-146.md`/`issue-148.md` rather than reflecting actual authoring time. | Corrected to match the real auto-log breadcrumb timestamps. |
| 5 | P3 | `dossier-policy.sh`'s `DOCS_BRANCH` resolution lacked the empty-string-override fallback `dossier-rotation-check.sh` already has, making a comment's "can never differ" claim technically false in an edge case. | Added the matching fallback (mirrors the sibling script exactly). |
| 6 | P3 | Convention: `issue-143.md` was the schema outlier within its own bundle — missing the `## Acceptance Criteria` section its siblings (`issue-146.md`/`issue-148.md`) both have. | Added, mirroring the FlowGoal contract's 4 ACs. |

### Known cosmetic notes (documented, not fixed — out of this PR's scope)

- **`dossier-rotation-check.sh`'s `die_infra()` emits only 2 of 8 fields** before exiting, vs. `finish()`'s full 8-field emit on a transport failure — a future consumer of the new `rotation_*` outputs could read empty-string and the literal `"unknown"` as different signals for the same "we don't know" state. `dossier-rotation-check.sh` is explicitly out of scope for #148 (unmodified script, exposure-only issue), and no consumer of these fields exists yet. Documented in `.decisions/issue-148.md`.
- **Holdout validation, P3**: the claim that `policy-existing-pr.test.sh` was RED-confirmed against the unpatched script first is not independently git-verifiable (only one commit touches both the test and the fix) — standard TDD hygiene (a failing RED state is never committed on its own), not a conflict. Documented in `.decisions/issue-143.md`.

## FlowGoal

`issue-143` — **achieved** (confidence 0.8) via an independent `goal-evaluator-judge` run, all 4 acceptance criteria pass on deterministic evidence (`hooks.test.sh` 94/94 at evaluation time, now 96/96 after the fix-forward pass; structural-classification comment confirmed via `grep`).

## Verification

- Full suite: `bash plugins/dossier/tests/run.sh` — **1895/1895** (up from 1852 pre-bundle).
- `shellcheck -S warning -x` across every script in the plugin — clean, exit 0.
- `bash -n` on every modified/new file — clean.
- Each of the three original fixes TDD RED-confirmed against unpatched code first, then GREEN. The P1 fix-forward fix was also RED-confirmed (`existing_pr_lookup_failed` assertions failed against the pre-fix code) before being made GREEN.
- Decision journals: `.decisions/issue-143.md`, `.decisions/issue-146.md`, `.decisions/issue-148.md` (hand-authored for #146/#148, matching the `/flow:start`-produced schema for #143 — see the `## Bundle note` in `issue-143.md` for why).

## Bundle mechanics note

This is the first PR in this repo's history to bundle three issues under one `/flow:start`-driven branch with **three separate** decision journals rather than the repo's established one-journal-per-bundle precedent (folding secondary issues into the primary issue's journal via auto-log breadcrumbs only). This was a deliberate, user-confirmed choice (interviewed and resolved before implementation began) — flagged here for visibility since the convention-checker review pass correctly identified it as a structural deviation worth a maintainer's awareness, not something to silently normalize.
