### PR TITLE
fix(dossier): authenticate rotation-check's git network calls on private repos

### DIFF
--- a/.decisions/issue-147.md
+++ b/.decisions/issue-147.md
@@ -352,3 +352,5 @@ rotation-check.test.sh` — 96/96. `shellcheck -S warning -x` — clean.
 <!-- auto-log: 2026-08-03 19:51 Edit /Users/danielbentes/synapti-marketplace/.flow/goals/issue-147.goal.yaml -->
 
 <!-- auto-log: 2026-08-03 19:53 commit "fix(dossier): scope git_auth's credential to origin's own host, fix silent-failure edge cases" -->
+
+<!-- auto-log: 2026-08-03 19:54 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/pr-147-body.md -->

--- a/.decisions/issue-147.md
+++ b/.decisions/issue-147.md
@@ -1,0 +1,241 @@
+---
+issue: 147
+created: '2026-08-03T16:00:00Z'
+artifacts:
+- type: specification
+  captured_at: '2026-08-03T16:00:11Z'
+  by: direct-interview
+  elements:
+  - non-goals
+  - failure-modes
+  - interface-contracts
+- type: goal-created
+  captured_at: '2026-08-03T16:00:11Z'
+  goal_id: issue-147
+  source: github_issue:147
+- type: workflow-run
+  captured_at: '2026-08-03T16:00:33Z'
+  workflow: start-issue
+  run_id: 2026-08-03T160000Z-issue-147
+  status: active
+---
+# Issue #147 — dossier-rotation-check.sh: git network calls are silently inert on private repos
+
+**Title**: dossier: policy job's persist-credentials: false makes rotation-check (and any git network op) silently inert on private repos
+**Labels**: bug, plugin
+
+## Specification
+
+_Captured directly from a pre-implementation interview with the user (three rounds, six
+sub-decisions total), each grounded in direct codebase verification rather than the issue
+body's claims alone. See below for what was verified._
+
+### Non-goals
+
+- Not changing `persist-credentials: false` on the `policy` job's checkout step, and not
+  flipping it to `true` for the whole job. The fix is scoped to authenticating three specific
+  git invocations inside `dossier-rotation-check.sh`, not broadening the job's credential
+  footprint.
+- Not using `gh auth setup-git` — confirmed during the interview that this would install a
+  persistent git credential helper for the rest of that step's process, a broader footprint
+  than the 2-3 calls that actually need authentication, and one that would need independent
+  duplication at any future call site rather than being self-contained to this script.
+- Not treating an empty/absent `GH_TOKEN` as a hard configuration error. The script must remain
+  usable in contexts where `GH_TOKEN` is legitimately unset (local runs, a future caller that
+  doesn't export it, public repos where it was never needed) — falling back to today's
+  unauthenticated behavior, never regressing the working public-repo case.
+- Not building new test infrastructure (an HTTP server, a git daemon) to exercise the
+  authenticated request end-to-end. The existing `rotation-check.test.sh` harness uses a local
+  filesystem bare-repo remote, against which an HTTP-only `extraheader` is inert (git ignores
+  `http.*` config for non-HTTP transports) — verified this is harmless, not a blocker, and
+  scoped testing to argv-inspection instead (see Interface contracts).
+
+### Failure modes
+
+- **Timeouts** — none — no new network call is introduced; the existing `git ls-remote`/
+  `git fetch` calls are the same calls, now carrying an additional header when authenticated.
+- **Partial failures** — none — the fix is confined to how the git commands are invoked
+  (an added `-c` flag), not a multi-step operation that could partially complete.
+- **Invalid input** — `GH_TOKEN` containing shell metacharacters must never be interpolated into
+  a command string that reaches a shell (matching the script's existing documented principle,
+  header line 15: "GH_TOKEN passed through to `gh`, never interpolated into a command"). **Note
+  on the shipped shape**: the original plan below (a `-c http.extraheader=...` argv value) was
+  superseded during self-review by `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_0`/`GIT_CONFIG_VALUE_0`
+  environment variables instead (process-listing exposure, see Self-review fix-forward below) —
+  the "never reaches a shell" property holds identically either way, since env vars set via the
+  `VAR=val cmd` prefix form are not shell-interpolated any more than an argv entry is.
+- **Missing context** — `GH_TOKEN` empty or absent: falls back to today's unauthenticated
+  behavior (see Non-goals above) rather than failing loudly, since a public-repo caller that
+  never needed a token must not regress.
+
+### Interface contracts
+
+- **Superseded during self-review** (final shipped shape — see below): `dossier-rotation-check.sh`'s
+  `git_auth()` wrapper conditionally sets `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=http.extraheader
+  GIT_CONFIG_VALUE_0="AUTHORIZATION: basic base64(x-access-token:$GH_TOKEN)"` (not the `-c
+  ...bearer...` form originally planned here) before every `git ls-remote --exit-code --heads
+  origin "$DOCS_BRANCH"` (line 223) and `git fetch --no-tags [--prune] origin ...` call (lines
+  267, 269), added only when `GH_TOKEN` is non-empty.
+- No change to the script's `--github-output`/`--summary` output contract, its documented exit
+  codes, or any of its 8 emitted fields (`would_rotate`/`reason`/`age_days`/`age_source`/
+  `accumulated_files`/`accumulated_lines`/`docs_branch`/`rotation_policy`).
+- No change to `dossier-docs-refresh.yml` — `GH_TOKEN: ${{ github.token }}` is already present
+  in the "Check whether the documentation branch would rotate" step's `env:` block
+  (confirmed: line 239), so no new wiring is needed there.
+- Test additions land in `plugins/dossier/tests/rotation-check.test.sh`, using a PATH-stub `git`
+  wrapper that logs its own argv to a file then execs the real `git` binary found via
+  `command -v` before the stub is placed on `PATH` — preserving the existing bare-repo
+  fixture's real git behavior while making the constructed command line assertable. Scoped
+  narrowly: the stub sits ahead of real `git` on `PATH` only for the invocation of
+  `dossier-rotation-check.sh` under test, not for the surrounding fixture-setup code (which
+  needs real git to build the bare repo and push branches).
+- The script's usage header (currently line 15: "GH_TOKEN passed through to `gh`, never
+  interpolated into a command") is revised to state GH_TOKEN now also authenticates the
+  script's own `git` network calls, not just `gh`.
+
+## Decision on approach
+
+Of the three options the issue itself named:
+
+1. Authenticate via the existing `GH_TOKEN` — **selected**.
+2. Better diagnostics only (name "private repo, no credentials" instead of a generic transport
+   failure), leaving the feature permanently inert on private repos — rejected: doesn't fix the
+   underlying gap, only its symptom.
+3. Accept and document the limitation — rejected: leaves a real functional gap for exactly the
+   private/proprietary codebases dossier's investor-grade documentation use case most likely
+   targets.
+
+Confirmed before deciding: `GH_TOKEN` is already threaded into the exact workflow step that
+invokes this script, unused for git's own network calls (only used implicitly for the script's
+existing `gh pr list` call, which already works correctly because `gh` auto-detects `GH_TOKEN`
+from the environment). The `policy` job's declared permissions (`contents: read`,
+`pull-requests: read`) are already minimal, so reusing that same token for read-only git
+`ls-remote`/`fetch` introduces no privilege escalation.
+
+## Self-review fix-forward
+
+A self-review pass (Agent(code-reviewer)) on the initial implementation found 1 P1 and 2 P2
+findings, all fixed before commit:
+
+- **P1**: the script's `--help` flag prints `sed -n '2,24p' "$0"`, a range sized for the
+  pre-diff header comment. This diff grew the `GH_TOKEN` doc line from 1 line to 5, pushing the
+  `# Exit:` section past line 24 — `--help` silently dropped the exit-code documentation.
+  Fixed: range corrected to `2,28p`, verified by running `--help` directly.
+- **P2, security**: the original implementation passed the auth header via `git -c
+  http.extraheader=...`, visible in process listings (`ps aux`, `/proc/<pid>/cmdline`) for the
+  life of the subprocess — a real exposure `actions/checkout` itself deliberately avoids (it
+  writes a placeholder via `-c`, then patches the real credential into the on-disk git config).
+  Fixed: switched to `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_0`/`GIT_CONFIG_VALUE_0` (git >= 2.31),
+  scoped to the one subprocess via the `VAR=val cmd` prefix form, never exported globally.
+- **P2, no live verification**: the reviewer correctly noted that `rotation-check.test.sh`'s
+  fixture uses a local filesystem remote, against which `http.*` config is inert (git ignores it
+  for non-HTTP transports) — so unit tests alone cannot prove the header format actually
+  authenticates against real GitHub. See below: this manual verification caught a genuine bug
+  the unit tests could not have found.
+- **P3, defense-in-depth**: `GH_TOKEN` is untrusted input per this script's own header, but the
+  original implementation embedded it into the header value with no control-character stripping,
+  unlike `sanitize_md()`/`emit()` elsewhere in the same file. Fixed: stripped via the same `tr`
+  idiom before use.
+
+## Manual verification against a real private repo (P2 finding, caught a real bug)
+
+Per the self-review's P2 finding, ran `git_auth`'s exact mechanism directly against a real
+private repository (`danielbentes/epic`, read-only `git ls-remote`, non-mutating) before
+considering this issue done — not the local bare-repo fixture, which cannot exercise HTTP auth
+at all.
+
+**Baseline** (no auth, credential helper disabled): `git -c credential.helper= ls-remote --heads
+https://github.com/danielbentes/epic.git` → `fatal: could not read Username for
+'https://github.com': Device not configured`, exit 128. Confirms no ambient credential on this
+machine masks the test, and reproduces the original bug's exact symptom.
+
+**First attempt — Bearer, matching the issue's own suggested syntax** (`AUTHORIZATION: bearer
+$GH_TOKEN`, the exact format from the issue body's "Options to consider" section and the
+original implementation): **REJECTED** — identical `fatal: could not read Username` failure as
+the unauthenticated baseline. The issue's own suggested header format does not work with a
+personal access token.
+
+**Fix — Basic auth** (`AUTHORIZATION: basic base64(x-access-token:$GH_TOKEN)`, the same
+credential shape `actions/checkout` constructs internally): **SUCCEEDED** — real branch refs
+returned, exit 0. Reproduced twice for confidence. `git_auth()` was corrected to this format
+before commit; the corrected version was re-verified against the same repo with the exact
+production code path (not a manual replica), succeeding identically.
+
+This means the original implementation (matching the issue's own suggested Bearer syntax) would
+have shipped completely non-functional — the exact "looks fixed, still silently degrades to
+age_source=unknown" failure mode this issue exists to close, just relocated one layer deeper.
+Caught only because the self-review's P2 finding was taken seriously enough to verify against a
+real private repo rather than accepting the local fixture's structural inability to test HTTP
+auth as sufficient coverage.
+
+**Residual limitation, accepted**: this verification used a personal access token
+(`gh auth token`), not GitHub Actions' `github.token` (an ephemeral, differently-scoped
+installation token) — the actual credential this script receives in production. Both are
+documented to authenticate via the same `x-access-token` Basic-auth convention GitHub's git
+servers accept, and this is the same mechanism `actions/checkout` itself uses for `github.token`
+specifically, so there is no reason to expect divergent behavior — but this was not verified
+against a live GitHub Actions run with a real `github.token`, since that token only exists for
+the duration of an actual job. If a future CI run of `dossier-docs-refresh.yml` against a real
+private repo shows a different result, that is the next signal to act on.
+
+<!-- auto-log: 2026-08-03 17:58 Write /Users/danielbentes/synapti-marketplace/.decisions/issue-147.md -->
+
+<!-- auto-log: 2026-08-03 17:58 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/issue-147.goal.yaml -->
+
+<!-- auto-log: 2026-08-03 17:59 Edit /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/issue-147.goal.yaml -->
+
+<!-- auto-log: 2026-08-03 17:59 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/issue-147-lifecycle-active.yaml -->
+
+<!-- auto-log: 2026-08-03 18:00 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/issue-147-lifecycle-active.yaml -->
+
+<!-- auto-log: 2026-08-03 18:00 Write /Users/danielbentes/synapti-marketplace/.flow/runs/2026-08-03T160000Z-issue-147/run.yaml -->
+
+<!-- auto-log: 2026-08-03 18:02 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 18:02 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 18:02 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 18:04 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 18:04 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 18:06 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 18:06 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 18:06 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 18:06 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 18:08 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 18:08 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 18:11 commit "fix(dossier): authenticate rotation-check's git network calls via GH_TOKEN" -->
+
+<!-- auto-log: 2026-08-03 18:28 commit "fix(dossier): authenticate rotation-check's git network calls via GH_TOKEN" -->
+
+<!-- auto-log: 2026-08-03 18:28 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 18:28 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 18:29 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 18:29 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 18:30 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 18:31 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 18:33 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 18:33 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 18:36 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-147.md -->
+
+<!-- auto-log: 2026-08-03 18:39 commit "fix(dossier): self-review fix-forward on rotation-check's git_auth" -->
+
+<!-- auto-log: 2026-08-03 18:39 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-147.md -->
+
+<!-- auto-log: 2026-08-03 18:39 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-147.md -->

--- a/.decisions/issue-147.md
+++ b/.decisions/issue-147.md
@@ -192,6 +192,67 @@ against a live GitHub Actions run with a real `github.token`, since that token o
 the duration of an actual job. If a future CI run of `dossier-docs-refresh.yml` against a real
 private repo shows a different result, that is the next signal to act on.
 
+## Parallel review fix-forward (P1 + P2s, fixed before merge)
+
+The `/flow:pr` review pass (5 agents: code-quality, convention, security, error-handling,
+test-runner) converged on one confirmed P1 and several P2/P3 findings, all fixed:
+
+- **P1 (code-reviewer, live-reproduced)**: `GIT_CONFIG_KEY_0=http.extraheader` was unscoped —
+  it applies to every HTTPS request the `git` invocation makes, not just requests to `origin`.
+  Verified live: an unscoped key sent the Basic-auth header to an unrelated third-party host
+  (gitlab.com) when the script's origin was github.com. The security-reviewer initially
+  dismissed a similar-sounding concern citing CVE-2020-11008 (git no longer resends
+  `extraheader` across a mid-request host-changing redirect, fixed in git >= 2.26) — but that
+  citation addresses a different threat model (redirect-following within one HTTP transaction),
+  not static config-key scoping across separate git invocations, which is what the code-reviewer
+  actually reproduced. Fixed: `git_auth()` now derives `origin`'s own scheme+host via
+  `git remote get-url origin` and scopes the key to
+  `http.<scheme>://<host>/.extraheader`, matching `actions/checkout`'s own narrower scoping (not
+  just its header-value shape, which was already matched). Non-HTTP(S) origins (ssh://,
+  `git@host:path`, `git://`) fall through unauthenticated entirely, since Basic-over-HTTP
+  doesn't apply to those transports and there's no host to scope to. Re-verified against the
+  real private repo with the exact corrected function (not a hand-written replica): still
+  authenticates correctly against origin, and — new — confirmed the same credential no longer
+  reaches an explicitly-targeted different host (gitlab.com) in the same test session.
+- **P2 (error-handler-inspector)**: the base64-encoding pipeline's exit status was never
+  checked; a broken/missing `base64` would silently produce an empty credential, sent as
+  `AUTHORIZATION: basic ` — rejected by the remote, which is worse than no credential at all for
+  a public repo. Fixed: falls through unauthenticated if the encoding pipeline produces an empty
+  result.
+- **P2 (error-handler-inspector)**: `GIT_CONFIG_COUNT=1` unconditionally claims the whole
+  `GIT_CONFIG_*` namespace for the subprocess, silently overriding any ambient
+  `GIT_CONFIG_COUNT`/`KEY_N`/`VALUE_N` a caller might have set (nothing in this repo does today
+  — confirmed via grep — but noted as a latent gap). Documented explicitly in `git_auth()`'s own
+  comment as an intentional exclusive claim, not fixed with speculative append-logic for a
+  scenario with no current reachable caller.
+- **P2 (docs, code-reviewer + security-reviewer, independently)**: `.flow/goals/issue-147.goal.yaml`
+  still described the superseded `-c http.extraheader=...bearer...` design in AC1's text and
+  `interface_contracts`, and AC3's verification command spuriously still passed against the
+  shipped code (the substring `http.extraheader` survives incidentally as a config key-name
+  fragment). Fixed: goal file text updated to describe the shipped mechanism.
+- **P3 (security-reviewer + error-handler-inspector, independently)**: `_clean_token`/
+  `_b64_creds` were plain global assignments, not `local`, unnecessarily widening the
+  credential's exposure window in the shell's namespace after `git_auth` returns. Fixed: added
+  `local`.
+- **P3 (security-reviewer)**: `git_auth()`'s docstring didn't state the caller contract that
+  makes its own credential-transform safe (every call site must redirect stdout+stderr, since
+  the base64-transformed credential is not GitHub's literal secret string and Actions' log
+  masking would not catch it). Fixed: added to the docstring.
+- **P3 (error-handler-inspector)**: the transport-failure `note()` text at both sites didn't
+  record whether `GH_TOKEN` was set, so an operator couldn't distinguish "no token, private
+  repo, expected" from "token set and rejected." Fixed: both notes now include `GH_TOKEN set:
+  yes/no`.
+- **P2 (convention-checker, test-integrity)**: scenario 22's `DIRTY_TOKEN` was built as
+  `"...$(printf '\r\n')"` — a `$(...)` substitution strips all of its own trailing newlines
+  regardless of where the result is later concatenated, so the token only ever carried a
+  trailing `\r`, never a surviving embedded `\n`, contradicting the test's own comment and the
+  commit message that introduced it. Fixed: rebuilt via ANSI-C quoting (`$'...\r\n...'`), which
+  embeds real control characters with no such stripping.
+
+Test suite grew from 93 to 96 assertions (new scenario 21C: non-HTTP(S) origin falls through
+unauthenticated; two new scoping assertions in 21A). Final: `bash plugins/dossier/tests/run.sh
+rotation-check.test.sh` — 96/96. `shellcheck -S warning -x` — clean.
+
 <!-- auto-log: 2026-08-03 17:58 Write /Users/danielbentes/synapti-marketplace/.decisions/issue-147.md -->
 
 <!-- auto-log: 2026-08-03 17:58 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/issue-147.goal.yaml -->
@@ -263,3 +324,31 @@ private repo shows a different result, that is the next signal to act on.
 <!-- auto-log: 2026-08-03 19:30 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/issue-147-lifecycle-achieved.yaml -->
 
 <!-- auto-log: 2026-08-03 19:30 Edit /Users/danielbentes/synapti-marketplace/.flow/runs/2026-08-03T160000Z-issue-147/run.yaml -->
+
+<!-- auto-log: 2026-08-03 19:34 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/test_redir.sh -->
+
+<!-- auto-log: 2026-08-03 19:34 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/propagation_test.sh -->
+
+<!-- auto-log: 2026-08-03 19:39 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/gitconfig_clobber_test.sh -->
+
+<!-- auto-log: 2026-08-03 19:42 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 19:43 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 19:43 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/bin/dossier-rotation-check.sh -->
+
+<!-- auto-log: 2026-08-03 19:46 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 19:47 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 19:47 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 19:48 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 19:51 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-147.md -->
+
+<!-- auto-log: 2026-08-03 19:51 Edit /Users/danielbentes/synapti-marketplace/.flow/goals/issue-147.goal.yaml -->
+
+<!-- auto-log: 2026-08-03 19:51 Edit /Users/danielbentes/synapti-marketplace/.flow/goals/issue-147.goal.yaml -->
+
+<!-- auto-log: 2026-08-03 19:53 commit "fix(dossier): scope git_auth's credential to origin's own host, fix silent-failure edge cases" -->

--- a/.decisions/issue-147.md
+++ b/.decisions/issue-147.md
@@ -18,6 +18,20 @@ artifacts:
   workflow: start-issue
   run_id: 2026-08-03T160000Z-issue-147
   status: active
+- type: verdict
+  captured_at: '2026-08-03T17:30:05Z'
+  result: PASS
+- type: goal-evaluation
+  captured_at: '2026-08-03T17:30:22Z'
+  goal_id: issue-147
+  result: achieved
+  evidence_bundle: verdict-judge-inline
+  failures: none
+- type: workflow-run
+  captured_at: '2026-08-03T17:30:38Z'
+  workflow: start-issue
+  run_id: 2026-08-03T160000Z-issue-147
+  status: completed
 ---
 # Issue #147 — dossier-rotation-check.sh: git network calls are silently inert on private repos
 
@@ -239,3 +253,13 @@ private repo shows a different result, that is the next signal to act on.
 <!-- auto-log: 2026-08-03 18:39 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-147.md -->
 
 <!-- auto-log: 2026-08-03 18:39 Edit /Users/danielbentes/synapti-marketplace/.decisions/issue-147.md -->
+
+<!-- auto-log: 2026-08-03 19:16 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 19:19 Edit /Users/danielbentes/synapti-marketplace/plugins/dossier/tests/rotation-check.test.sh -->
+
+<!-- auto-log: 2026-08-03 19:20 commit "test(dossier): cover git_auth's control-character stripping and base64 line-wrap collapse" -->
+
+<!-- auto-log: 2026-08-03 19:30 Write /private/tmp/claude-501/-Users-danielbentes-synapti-marketplace/8c76ed85-3c0c-4a32-8924-be0cf2c7bc2d/scratchpad/issue-147-lifecycle-achieved.yaml -->
+
+<!-- auto-log: 2026-08-03 19:30 Edit /Users/danielbentes/synapti-marketplace/.flow/runs/2026-08-03T160000Z-issue-147/run.yaml -->

--- a/.flow/goals/issue-147.goal.yaml
+++ b/.flow/goals/issue-147.goal.yaml
@@ -19,9 +19,16 @@ objective:
       (and any git network op) silently inert on private repos'
   acceptance_criteria:
   - id: AC1
-    text: dossier-rotation-check.sh's git ls-remote and both git fetch calls authenticate
-      against origin using GH_TOKEN when it is non-empty, via a scoped -c http.extraheader="AUTHORIZATION
-      bearer $GH_TOKEN" applied per-invocation.
+    text: 'Superseded during review, shipped shape (original text below is the
+      pre-implementation plan, disproved live -- see .decisions/issue-147.md):
+      dossier-rotation-check.sh''s git ls-remote and both git fetch calls authenticate
+      against origin using GH_TOKEN when it is non-empty, via GIT_CONFIG_COUNT/KEY_0/VALUE_0
+      env vars carrying "AUTHORIZATION basic base64(x-access-token GH_TOKEN)", scoped
+      to origin''s own resolved scheme+host, applied per-invocation. Original plan
+      (-c http.extraheader="AUTHORIZATION bearer GH_TOKEN") was live-verified rejected
+      by GitHub; the unscoped-key variant of the env-var shape was also found, live,
+      to leak the header to unrelated HTTPS hosts, and was fixed to scope by origin''s
+      host before merge.'
     verification_command: bash plugins/dossier/tests/run.sh rotation-check.test.sh
     must_pass: true
     status: pending
@@ -87,9 +94,11 @@ specification:
   - 'Missing context: GH_TOKEN empty or absent falls back to today''s unauthenticated
     behavior rather than failing loudly.'
   interface_contracts:
-  - dossier-rotation-check.sh's git ls-remote and both git fetch calls gain a conditional
-    -c http.extraheader="AUTHORIZATION bearer $GH_TOKEN" prefix, added only when GH_TOKEN
-    is non-empty.
+  - 'Superseded during review, shipped shape (see .decisions/issue-147.md): dossier-rotation-check.sh''s
+    git ls-remote and both git fetch calls gain a conditional GIT_CONFIG_COUNT/KEY_0/VALUE_0
+    env-var prefix carrying "AUTHORIZATION basic base64(x-access-token GH_TOKEN)", scoped
+    to origin''s own resolved scheme plus host, added only when GH_TOKEN is non-empty
+    and origin resolves to an http(s) URL.'
   - No change to the script's --github-output/--summary output contract, exit codes,
     or any of its 8 emitted fields.
   - No change to dossier-docs-refresh.yml — GH_TOKEN is already present in the rotation-check

--- a/.flow/goals/issue-147.goal.yaml
+++ b/.flow/goals/issue-147.goal.yaml
@@ -1,0 +1,136 @@
+apiVersion: flow.synapti.ai/v1
+kind: FlowGoal
+metadata:
+  id: issue-147
+  created_at: '2026-08-03T16:00:00Z'
+  created_by: /flow:start
+  owner: daniel.bentes@synapti.ai
+scope:
+  repo: synaptiai/synapti-marketplace
+  branch: feature/issue-147-rotation-check-private-repo-auth
+  issue: 147
+  journal: .decisions/issue-147.md
+objective:
+  outcome: 'Issue #147 is implemented and verified.'
+  source:
+    type: github_issue
+    number: 147
+    title: 'dossier: policy job''s persist-credentials: false makes rotation-check
+      (and any git network op) silently inert on private repos'
+  acceptance_criteria:
+  - id: AC1
+    text: dossier-rotation-check.sh's git ls-remote and both git fetch calls authenticate
+      against origin using GH_TOKEN when it is non-empty, via a scoped -c http.extraheader="AUTHORIZATION
+      bearer $GH_TOKEN" applied per-invocation.
+    verification_command: bash plugins/dossier/tests/run.sh rotation-check.test.sh
+    must_pass: true
+    status: pending
+    evidence_ref: null
+    last_evaluated_at: null
+    last_result: null
+  - id: AC2
+    text: When GH_TOKEN is empty or absent, behavior is unchanged from today (unauthenticated
+      git calls, working on public repos, degrading to age_source=unknown on private
+      repos without a token). No regression to the public-repo path.
+    verification_command: bash plugins/dossier/tests/run.sh rotation-check.test.sh
+    must_pass: true
+    status: pending
+    evidence_ref: null
+    last_evaluated_at: null
+    last_result: null
+  - id: AC3
+    text: The auth logic lives inside dossier-rotation-check.sh itself, not the calling
+      workflow YAML.
+    verification_command: grep -n "http.extraheader" plugins/dossier/bin/dossier-rotation-check.sh
+    must_pass: true
+    status: pending
+    evidence_ref: null
+    last_evaluated_at: null
+    last_result: null
+  - id: AC4
+    text: New test coverage in rotation-check.test.sh using a PATH-stub git wrapper
+      that logs its own argv then execs the real git, asserting the auth header is
+      present when GH_TOKEN is set and absent when empty.
+    verification_command: bash plugins/dossier/tests/run.sh rotation-check.test.sh
+    must_pass: true
+    status: pending
+    evidence_ref: null
+    last_evaluated_at: null
+    last_result: null
+  - id: AC5
+    text: The script's usage header comment is updated to document that GH_TOKEN now
+      also authenticates the script's own git network calls, not just gh.
+    verification_command: grep -n "GH_TOKEN" plugins/dossier/bin/dossier-rotation-check.sh
+    must_pass: true
+    status: pending
+    evidence_ref: null
+    last_evaluated_at: null
+    last_result: null
+specification:
+  non_goals:
+  - Not changing persist-credentials false on the policy job's checkout step, and
+    not flipping it to true for the whole job.
+  - Not using gh auth setup-git — it would install a persistent git credential helper
+    for the rest of that step's process, a broader footprint than the 2-3 calls that
+    actually need authentication.
+  - Not treating an empty or absent GH_TOKEN as a hard configuration error — must
+    fall back to today's unauthenticated behavior.
+  - Not building new test infrastructure (an HTTP server, a git daemon) to exercise
+    the authenticated request end-to-end. Scoped testing to argv-inspection instead.
+  failure_modes:
+  - 'Timeouts: none — no new network call is introduced.'
+  - 'Partial failures: none — the fix is confined to how the git commands are invoked,
+    not a multi-step operation.'
+  - 'Invalid input: GH_TOKEN must never be interpolated into a command string that
+    reaches a shell — passed as a single argv entry to git, matching the script''s
+    existing documented principle.'
+  - 'Missing context: GH_TOKEN empty or absent falls back to today''s unauthenticated
+    behavior rather than failing loudly.'
+  interface_contracts:
+  - dossier-rotation-check.sh's git ls-remote and both git fetch calls gain a conditional
+    -c http.extraheader="AUTHORIZATION bearer $GH_TOKEN" prefix, added only when GH_TOKEN
+    is non-empty.
+  - No change to the script's --github-output/--summary output contract, exit codes,
+    or any of its 8 emitted fields.
+  - No change to dossier-docs-refresh.yml — GH_TOKEN is already present in the rotation-check
+    step's env block.
+  - Test additions land in rotation-check.test.sh using a PATH-stub git wrapper scoped
+    narrowly to the invocation under test, not the surrounding fixture-setup code.
+constraints:
+  tdd_required: true
+  require_all_pass: true
+  no_calendar_estimates: true
+  no_tier3_without_confirmation: true
+  allowed_paths:
+  - plugins/dossier/bin/dossier-rotation-check.sh
+  - plugins/dossier/tests/rotation-check.test.sh
+  - .decisions/issue-147.md
+evaluator:
+  type: flow_verdict_judge
+  command: /flow:goal evaluate
+  judge_agent: goal-evaluator-judge
+  evidence_bundle_format: plugins/flow/references/evidence-bundle-format.md
+  denied_context:
+  - implementation_rationale
+  - self_review_findings
+continuation:
+  mode: flow_managed
+  on_incomplete: continue_next_activity
+  on_blocked: six_field_escalation
+  on_complete: mark_achieved
+  max_iterations: 20
+lifecycle:
+  status: achieved
+  current_phase: verify
+  current_activity: complete
+  turns_evaluated: 1
+  last_evaluation:
+    result: pass
+    reason: 4/5 acceptance criteria PASS via independent verdict-judge; AC1 (does
+      the auth header actually authenticate against origin) returned NEEDS-HUMAN-REVIEW
+      because the local test fixture cannot exercise real HTTP auth, and the only
+      evidence is a manual verification against a real private repo documented in
+      the decision journal, which the judge's independence protocol correctly excludes
+      as inadmissible. User approved AC1 as met after reviewing the manual verification
+      directly.
+    at: '2026-08-03T19:15:00Z'

--- a/plugins/dossier/bin/dossier-rotation-check.sh
+++ b/plugins/dossier/bin/dossier-rotation-check.sh
@@ -159,9 +159,46 @@ cfg() { "$CASCADE" --default "$2" "${1#.}" 2>/dev/null; }
 # on-disk git config). Environment variables set via the `VAR=val cmd` prefix
 # form are scoped to this one subprocess only, not exported globally, and
 # match this file's own "never interpolated into a string that reaches a
-# shell" principle for GH_TOKEN just as well as -c did.
+# shell" principle for GH_TOKEN just as well as -c did. This function claims
+# exclusive ownership of the GIT_CONFIG_* namespace for that one subprocess --
+# it does not compose with a caller that has already populated GIT_CONFIG_*
+# in its own environment (nothing in this repo does today).
+#
+# Callers MUST redirect this function's stdout and stderr (every call site
+# below does, via `>/dev/null 2>&1`) -- the constructed Basic-auth header is
+# a transform of GH_TOKEN, not GitHub Actions' literal secret string, so
+# Actions' automatic log-masking will not catch it if it ever reaches an
+# unredirected log.
 git_auth() {
   if [ -n "${GH_TOKEN:-}" ]; then
+    # Scoped to origin's own scheme+host, not the bare `http.extraheader` key
+    # -- an unscoped key applies to every HTTPS request the git invocation
+    # makes, not just requests to origin. Verified live during review: an
+    # unscoped key sent this credential to an unrelated third-party HTTPS
+    # host. This script documents itself as standalone and locally callable
+    # (see below), where origin is not guaranteed to be github.com -- a
+    # mirror, a self-hosted GitLab/GHE, a vendor remote. Matches
+    # actions/checkout's own narrower http.<url>.extraheader scoping, not
+    # just its header-value shape.
+    local _origin_url _scheme_host _clean_token _b64_creds
+    _origin_url=$(git remote get-url origin 2>/dev/null)
+    case "$_origin_url" in
+      https://*|http://*)
+        _scheme_host=$(printf '%s' "$_origin_url" | LC_ALL=C sed -E 's#^(https?://[^/]+)/?.*#\1#')
+        ;;
+      *)
+        # Not an HTTP(S) remote (ssh://, git@host:path, git://) -- Basic auth
+        # over HTTP does not apply to those transports, so this credential
+        # has nowhere safe to be scoped to. Fall through unauthenticated
+        # rather than guess a key that could apply too broadly.
+        _scheme_host=""
+        ;;
+    esac
+    if [ -z "$_scheme_host" ]; then
+      git "$@"
+      return $?
+    fi
+
     # Basic, not Bearer -- verified directly against a real private GitHub
     # repo before shipping (see .decisions/issue-147.md): "AUTHORIZATION:
     # bearer $GH_TOKEN" was REJECTED (fatal: could not read Username), while
@@ -181,8 +218,18 @@ git_auth() {
     # newline into the header value.
     _clean_token=$(printf '%s' "$GH_TOKEN" | LC_ALL=C tr -d '\r\n\000-\037')
     _b64_creds=$(printf 'x-access-token:%s' "$_clean_token" | base64 | LC_ALL=C tr -d '\r\n')
+    if [ -z "$_b64_creds" ]; then
+      # The encoding pipeline itself failed (missing/broken base64) or
+      # GH_TOKEN was pure control characters that stripped to nothing --
+      # either way, sending an empty/malformed credential would get rejected
+      # by the remote, which is a *worse* outcome than no credential at all
+      # for a public repo that would otherwise have worked unauthenticated.
+      # Fall through rather than send a header known to be broken.
+      git "$@"
+      return $?
+    fi
     GIT_CONFIG_COUNT=1 \
-      GIT_CONFIG_KEY_0=http.extraheader \
+      GIT_CONFIG_KEY_0="http.${_scheme_host}/.extraheader" \
       GIT_CONFIG_VALUE_0="AUTHORIZATION: basic ${_b64_creds}" \
       git "$@"
   else
@@ -294,7 +341,12 @@ if [ "$LS_REMOTE_RC" -ne 0 ]; then
   AGE_DAYS=""
   ACC_FILES=""
   ACC_LINES=""
-  note "could not reach the remote to check for ${DOCS_BRANCH} (git ls-remote exited ${LS_REMOTE_RC}); treating this as a transport failure, not a missing branch."
+  # GH_TOKEN set/unset is named explicitly so an operator reading the job
+  # summary can distinguish "no token, private repo, expected" from "token
+  # was set and got rejected" -- both currently collapse into an identical
+  # transport-failure result, and a rejected token is otherwise
+  # indistinguishable from a genuine network problem.
+  note "could not reach the remote to check for ${DOCS_BRANCH} (git ls-remote exited ${LS_REMOTE_RC}; GH_TOKEN set: $([ -n "${GH_TOKEN:-}" ] && echo yes || echo no)); treating this as a transport failure, not a missing branch."
   if [ "$ROTATION_POLICY" = "none" ]; then
     WOULD_ROTATE="false"
     REASON="rotation is disabled (dossier.ci.rollingBranchRotation=none); the remote was also unreachable, so no metrics could be gathered"
@@ -322,7 +374,7 @@ else
   FETCH_DOCS_RC=$?
   if [ "$FETCH_BASE_RC" -ne 0 ] || [ "$FETCH_DOCS_RC" -ne 0 ]; then
     FETCH_OK=0
-    note "could not fetch ${BASE_REF} and/or ${DOCS_BRANCH} from origin (base rc=${FETCH_BASE_RC}, docs rc=${FETCH_DOCS_RC}); treating this as a transport failure."
+    note "could not fetch ${BASE_REF} and/or ${DOCS_BRANCH} from origin (base rc=${FETCH_BASE_RC}, docs rc=${FETCH_DOCS_RC}; GH_TOKEN set: $([ -n "${GH_TOKEN:-}" ] && echo yes || echo no)); treating this as a transport failure."
   fi
 fi
 

--- a/plugins/dossier/bin/dossier-rotation-check.sh
+++ b/plugins/dossier/bin/dossier-rotation-check.sh
@@ -57,7 +57,7 @@ while [ $# -gt 0 ]; do
       [ $# -lt 2 ] && { echo "dossier-rotation-check: --summary requires a value" >&2; exit 2; }
       SUMMARY_FILE="$2"; shift 2 ;;
     -h|--help)
-      sed -n '2,24p' "$0"; exit 0 ;;
+      sed -n '2,28p' "$0"; exit 0 ;;
     *)
       echo "dossier-rotation-check: unknown argument: $1" >&2; exit 2 ;;
   esac
@@ -148,13 +148,43 @@ cfg() { "$CASCADE" --default "$2" "${1#.}" 2>/dev/null; }
 # auth on a private one (issue #147). A conditional branch, not an array
 # expansion: an empty array under `set -u` is an unbound-variable error on
 # bash 3.2 (macOS's shipped /bin/bash), and this function's whole point is
-# to be safe to call whether or not GH_TOKEN is set. The token reaches git
-# as a single argv entry to -c, never interpolated into a string that
-# reaches a shell (same principle as GH_TOKEN's existing use with `gh`,
-# documented in this script's own header).
+# to be safe to call whether or not GH_TOKEN is set.
+#
+# The header is passed via GIT_CONFIG_COUNT/KEY/VALUE (git >= 2.31, both
+# ubuntu-latest and Homebrew macOS ship well past this), not `-c` on the
+# command line: a `-c` value is visible in process listings (`ps aux`,
+# /proc/<pid>/cmdline) for the life of the subprocess, which actions/checkout
+# itself deliberately avoids for the same credential-exposure reason (it
+# writes a placeholder via -c, then patches the real value directly into the
+# on-disk git config). Environment variables set via the `VAR=val cmd` prefix
+# form are scoped to this one subprocess only, not exported globally, and
+# match this file's own "never interpolated into a string that reaches a
+# shell" principle for GH_TOKEN just as well as -c did.
 git_auth() {
   if [ -n "${GH_TOKEN:-}" ]; then
-    git -c "http.extraheader=AUTHORIZATION: bearer ${GH_TOKEN}" "$@"
+    # Basic, not Bearer -- verified directly against a real private GitHub
+    # repo before shipping (see .decisions/issue-147.md): "AUTHORIZATION:
+    # bearer $GH_TOKEN" was REJECTED (fatal: could not read Username), while
+    # "AUTHORIZATION: basic base64(x-access-token:$GH_TOKEN)" succeeded --
+    # the same credential shape actions/checkout itself constructs
+    # internally. The issue's own suggested Bearer syntax does not work.
+    #
+    # Both the token and the base64 output are stripped the same way
+    # emit()/sanitize_md() strip other untrusted environment values before
+    # they reach a structured sink: an embedded CR/LF would malform the HTTP
+    # header (or, for the token, corrupt the base64 payload) rather than
+    # grant any new privilege -- whoever controls GH_TOKEN's bytes already
+    # holds the credential either way. The tr pass on the base64 output also
+    # collapses GNU base64's default 76-column line-wrapping (BSD/macOS
+    # base64 does not wrap by default, but Linux CI's GNU coreutils does for
+    # longer tokens) -- without it, a wrapped credential would embed a raw
+    # newline into the header value.
+    _clean_token=$(printf '%s' "$GH_TOKEN" | LC_ALL=C tr -d '\r\n\000-\037')
+    _b64_creds=$(printf 'x-access-token:%s' "$_clean_token" | base64 | LC_ALL=C tr -d '\r\n')
+    GIT_CONFIG_COUNT=1 \
+      GIT_CONFIG_KEY_0=http.extraheader \
+      GIT_CONFIG_VALUE_0="AUTHORIZATION: basic ${_b64_creds}" \
+      git "$@"
   else
     git "$@"
   fi

--- a/plugins/dossier/bin/dossier-rotation-check.sh
+++ b/plugins/dossier/bin/dossier-rotation-check.sh
@@ -12,7 +12,11 @@
 #
 # Untrusted inputs arrive through the environment, never as arguments:
 #   BASE_REF   base branch name (falls back to the origin default branch)
-#   GH_TOKEN   passed through to `gh`, never interpolated into a command
+#   GH_TOKEN   passed through to `gh`, and to this script's own git
+#              ls-remote/fetch calls (git_auth, issue #147) so both stay
+#              functional on private repos -- never interpolated into a
+#              command that reaches a shell in either case. Falls back to
+#              today's unauthenticated git behavior when empty/absent.
 #
 # Output (stdout, and --github-output when given):
 #   would_rotate  reason  age_days  age_source
@@ -138,6 +142,24 @@ git rev-parse --git-dir >/dev/null 2>&1 || die_infra "not inside a git repositor
 # only terminate the command-substitution subshell, not the script.
 cfg() { "$CASCADE" --default "$2" "${1#.}" 2>/dev/null; }
 
+# `gh` already authenticates automatically via GH_TOKEN detection (see the
+# gh pr list call below), but raw `git` does not -- ls-remote/fetch against
+# origin run as unauthenticated HTTPS, which works on a public repo and fails
+# auth on a private one (issue #147). A conditional branch, not an array
+# expansion: an empty array under `set -u` is an unbound-variable error on
+# bash 3.2 (macOS's shipped /bin/bash), and this function's whole point is
+# to be safe to call whether or not GH_TOKEN is set. The token reaches git
+# as a single argv entry to -c, never interpolated into a string that
+# reaches a shell (same principle as GH_TOKEN's existing use with `gh`,
+# documented in this script's own header).
+git_auth() {
+  if [ -n "${GH_TOKEN:-}" ]; then
+    git -c "http.extraheader=AUTHORIZATION: bearer ${GH_TOKEN}" "$@"
+  else
+    git "$@"
+  fi
+}
+
 write_summary() {
   [ -n "$SUMMARY_FILE" ] || return 0
   {
@@ -220,7 +242,7 @@ NOW_EPOCH=$(date -u +%s)
 # ---------------------------------------------------------------------------
 # Step 1 — does the rolling branch exist at all?
 # ---------------------------------------------------------------------------
-git ls-remote --exit-code --heads origin "$DOCS_BRANCH" >/dev/null 2>&1
+git_auth ls-remote --exit-code --heads origin "$DOCS_BRANCH" >/dev/null 2>&1
 LS_REMOTE_RC=$?
 
 if [ "$LS_REMOTE_RC" -eq 2 ]; then
@@ -264,9 +286,9 @@ if [ -z "$BASE_REF" ]; then
   FETCH_OK=0
   note "BASE_REF could not be resolved (no env var and no origin/HEAD symbolic ref); age and size cannot be measured against a base."
 else
-  git fetch --no-tags --prune origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}" >/dev/null 2>&1
+  git_auth fetch --no-tags --prune origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}" >/dev/null 2>&1
   FETCH_BASE_RC=$?
-  git fetch --no-tags origin "+refs/heads/${DOCS_BRANCH}:refs/remotes/origin/${DOCS_BRANCH}" >/dev/null 2>&1
+  git_auth fetch --no-tags origin "+refs/heads/${DOCS_BRANCH}:refs/remotes/origin/${DOCS_BRANCH}" >/dev/null 2>&1
   FETCH_DOCS_RC=$?
   if [ "$FETCH_BASE_RC" -ne 0 ] || [ "$FETCH_DOCS_RC" -ne 0 ]; then
     FETCH_OK=0

--- a/plugins/dossier/tests/rotation-check.test.sh
+++ b/plugins/dossier/tests/rotation-check.test.sh
@@ -639,10 +639,12 @@ assert_contains "docs_branch=docs/dossierfake_output=INJECTEDreal=" "$(cat "$GHO
 # 21. Private-repo credential gap (issue #147): git ls-remote/fetch must
 #     authenticate via GH_TOKEN when present, so the script produces a real
 #     determination on private repos instead of silently degrading to
-#     age_source=unknown. A PATH-stub `git` wrapper logs its own argv then
-#     execs the real git (resolved once, outside the stub, before it goes on
-#     PATH) -- preserving the fixture's real git behavior against the local
-#     bare-repo remote while making the constructed command line assertable.
+#     age_source=unknown. A PATH-stub `git` wrapper logs its own argv AND the
+#     GIT_CONFIG_* env vars it sees (the auth header travels via env, not
+#     argv -- see git_auth()'s own comment for why) then execs the real git
+#     (resolved once, outside the stub, before it goes on PATH) -- preserving
+#     the fixture's real git behavior against the local bare-repo remote
+#     while making the constructed invocation assertable.
 # =============================================================================
 REAL_GIT=$(command -v git)
 
@@ -655,40 +657,52 @@ push_docs_branch_commit "$F21A" "docs/dossier" "$(day_offset 1)"
 _dossier_require_mktemp_dir STUB21A "git-stub-with-token"
 cat > "$STUB21A/git" <<STUBEOF
 #!/usr/bin/env bash
-printf '%s\n' "\$*" >> "$STUB21A/argv.log"
+printf 'ARGV=%s GIT_CONFIG_COUNT=%s GIT_CONFIG_KEY_0=%s GIT_CONFIG_VALUE_0=%s\n' "\$*" "\${GIT_CONFIG_COUNT:-}" "\${GIT_CONFIG_KEY_0:-}" "\${GIT_CONFIG_VALUE_0:-}" >> "$STUB21A/argv.log"
 exec "$REAL_GIT" "\$@"
 STUBEOF
 chmod +x "$STUB21A/git"
 ( cd "$F21A" && env PATH="$STUB21A:$PATH" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier GH_TOKEN=test-token-abc123 "$SCRIPT" ) >/dev/null 2>&1
 RC21A=$?
 assert_equal "0" "$RC21A" "GH_TOKEN set: script still exits 0 (correctness of ls-remote/fetch is unaffected)"
-# Argv is logged as a single space-joined line; -c precedes the subcommand
-# when authenticated ("-c http.extraheader=... ls-remote ..."), so matching
-# must find "ls-remote"/"fetch" as a substring, not anchor on line start.
-LSREMOTE_LINE21A=$(grep 'ls-remote --exit-code' "$STUB21A/argv.log" | head -1)
-assert_contains "http.extraheader=AUTHORIZATION: bearer test-token-abc123" "$LSREMOTE_LINE21A" "GH_TOKEN set: the ls-remote invocation carries the auth header"
-FETCH_LINES21A=$(grep 'fetch --no-tags' "$STUB21A/argv.log")
-FETCH_COUNT21A=$(printf '%s\n' "$FETCH_LINES21A" | grep -c 'fetch --no-tags')
-FETCH_WITH_AUTH21A=$(printf '%s\n' "$FETCH_LINES21A" | grep -c 'http.extraheader=AUTHORIZATION: bearer test-token-abc123')
+# Basic, not Bearer -- verified directly against a real private GitHub repo
+# (see .decisions/issue-147.md) that Bearer is rejected and this exact
+# base64(x-access-token:<token>) shape is accepted. Computed here, not
+# hardcoded, so the assertion tracks the implementation rather than a
+# magic string.
+EXPECTED_B64_21=$(printf 'x-access-token:%s' "test-token-abc123" | base64 | tr -d '\r\n')
+LSREMOTE_LINE21A=$(grep 'ARGV=ls-remote --exit-code' "$STUB21A/argv.log" | head -1)
+assert_contains "GIT_CONFIG_VALUE_0=AUTHORIZATION: basic ${EXPECTED_B64_21}" "$LSREMOTE_LINE21A" "GH_TOKEN set: the ls-remote invocation carries the Basic-auth header via GIT_CONFIG_VALUE_0"
+assert_contains "GIT_CONFIG_KEY_0=http.extraheader" "$LSREMOTE_LINE21A" "GH_TOKEN set: the ls-remote invocation sets GIT_CONFIG_KEY_0=http.extraheader"
+FETCH_LINES21A=$(grep 'ARGV=fetch --no-tags' "$STUB21A/argv.log")
+FETCH_COUNT21A=$(printf '%s\n' "$FETCH_LINES21A" | grep -c 'ARGV=fetch --no-tags')
+FETCH_WITH_AUTH21A=$(printf '%s\n' "$FETCH_LINES21A" | grep -c "GIT_CONFIG_VALUE_0=AUTHORIZATION: basic ${EXPECTED_B64_21}")
 assert_equal "2" "$FETCH_COUNT21A" "GH_TOKEN set: both fetch invocations (base ref + docs branch) were captured"
 assert_equal "$FETCH_COUNT21A" "$FETCH_WITH_AUTH21A" "GH_TOKEN set: every fetch invocation carries the auth header, not just ls-remote"
+# The token must never additionally leak into argv itself (the whole point
+# of moving off -c) -- isolate just the ARGV=... field (everything before
+# " GIT_CONFIG_COUNT=") and confirm the token is absent from it specifically,
+# even though the full log line legitimately contains it (in VALUE_0).
+ARGV_ONLY21A=$(awk -F' GIT_CONFIG_COUNT=' '{print $1}' "$STUB21A/argv.log")
+assert_not_contains "test-token-abc123" "$ARGV_ONLY21A" "GH_TOKEN set: the token never appears in the ARGV portion of any logged invocation (process-listing exposure)"
 
 setup_fixture F21B
 push_docs_branch_commit "$F21B" "docs/dossier" "$(day_offset 1)"
 _dossier_require_mktemp_dir STUB21B "git-stub-no-token"
 cat > "$STUB21B/git" <<STUBEOF
 #!/usr/bin/env bash
-printf '%s\n' "\$*" >> "$STUB21B/argv.log"
+printf 'ARGV=%s GIT_CONFIG_COUNT=%s GIT_CONFIG_KEY_0=%s GIT_CONFIG_VALUE_0=%s\n' "\$*" "\${GIT_CONFIG_COUNT:-}" "\${GIT_CONFIG_KEY_0:-}" "\${GIT_CONFIG_VALUE_0:-}" >> "$STUB21B/argv.log"
 exec "$REAL_GIT" "\$@"
 STUBEOF
 chmod +x "$STUB21B/git"
 ( cd "$F21B" && env -u GH_TOKEN PATH="$STUB21B:$PATH" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier "$SCRIPT" ) >/dev/null 2>&1
 RC21B=$?
 assert_equal "0" "$RC21B" "GH_TOKEN empty/absent: script still exits 0 (today's public-repo behavior unchanged)"
-LSREMOTE_LINE21B=$(grep 'ls-remote --exit-code' "$STUB21B/argv.log" | head -1)
-assert_not_contains "http.extraheader" "$LSREMOTE_LINE21B" "GH_TOKEN empty/absent: the ls-remote invocation carries no auth header (no regression to the working public-repo case)"
-FETCH_LINES21B=$(grep 'fetch --no-tags' "$STUB21B/argv.log")
-if printf '%s\n' "$FETCH_LINES21B" | grep -q 'http.extraheader'; then
+LSREMOTE_LINE21B=$(grep 'ARGV=ls-remote --exit-code' "$STUB21B/argv.log" | head -1)
+# Unset vars render as empty strings after "=" in the printf format above, so
+# an unauthenticated invocation's line ends in this literal, value-less form.
+assert_contains "GIT_CONFIG_COUNT= GIT_CONFIG_KEY_0= GIT_CONFIG_VALUE_0=" "$LSREMOTE_LINE21B" "GH_TOKEN empty/absent: the ls-remote invocation sets none of the GIT_CONFIG_* vars (no regression to the working public-repo case)"
+FETCH_LINES21B=$(grep 'ARGV=fetch --no-tags' "$STUB21B/argv.log")
+if printf '%s\n' "$FETCH_LINES21B" | grep -q 'GIT_CONFIG_VALUE_0=[^ ]'; then
   _dossier_assert_fail "GH_TOKEN empty/absent: at least one fetch invocation unexpectedly carries an auth header"
 else
   _dossier_assert_pass "GH_TOKEN empty/absent: no fetch invocation carries an auth header"

--- a/plugins/dossier/tests/rotation-check.test.sh
+++ b/plugins/dossier/tests/rotation-check.test.sh
@@ -708,4 +708,42 @@ else
   _dossier_assert_pass "GH_TOKEN empty/absent: no fetch invocation carries an auth header"
 fi
 
+# =============================================================================
+# 22. A "dirty" GH_TOKEN (embedded CR/LF, long enough that its base64 form
+#     would exceed GNU base64's default 76-column wrap) must still produce a
+#     single-line, correctly-cleaned header -- git_auth() strips both the raw
+#     token and the base64 output for exactly this reason, but nothing in
+#     scenario 21 (a short, clean token) exercises either code path.
+# =============================================================================
+setup_fixture F22
+push_docs_branch_commit "$F22" "docs/dossier" "$(day_offset 1)"
+_dossier_require_mktemp_dir STUB22 "git-stub-dirty-token"
+cat > "$STUB22/git" <<STUBEOF
+#!/usr/bin/env bash
+printf 'ARGV=%s GIT_CONFIG_COUNT=%s GIT_CONFIG_KEY_0=%s GIT_CONFIG_VALUE_0=%s\n' "\$*" "\${GIT_CONFIG_COUNT:-}" "\${GIT_CONFIG_KEY_0:-}" "\${GIT_CONFIG_VALUE_0:-}" >> "$STUB22/argv.log"
+exec "$REAL_GIT" "\$@"
+STUBEOF
+chmod +x "$STUB22/git"
+# 60 'a's + a trailing CRLF -- long enough (with the 15-char "x-access-token:"
+# prefix) that base64(x-access-token:<token>) exceeds 76 columns, and dirty
+# enough to exercise the raw-token CR/LF strip too.
+DIRTY_TOKEN="$(printf 'a%.0s' $(seq 1 60))$(printf '\r\n')"
+CLEAN_TOKEN="$(printf 'a%.0s' $(seq 1 60))"
+EXPECTED_B64_22=$(printf 'x-access-token:%s' "$CLEAN_TOKEN" | base64 | tr -d '\r\n')
+( cd "$F22" && env PATH="$STUB22:$PATH" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier GH_TOKEN="$DIRTY_TOKEN" "$SCRIPT" ) >/dev/null 2>&1
+RC22=$?
+assert_equal "0" "$RC22" "dirty long GH_TOKEN: script still exits 0"
+LSREMOTE_LINE22=$(grep 'ARGV=ls-remote --exit-code' "$STUB22/argv.log" | head -1)
+assert_contains "GIT_CONFIG_VALUE_0=AUTHORIZATION: basic ${EXPECTED_B64_22}" "$LSREMOTE_LINE22" "dirty long GH_TOKEN: the header carries the base64 of the CLEANED token (embedded CR/LF stripped before encoding), not the dirty raw token"
+# The stub logs every git subcommand this run makes (rev-list/show/diff on
+# already-fetched local refs too, not just the 3 network calls), so a fixed
+# line count would be brittle. Well-formedness is the real property under
+# test: an embedded raw newline surviving into GIT_CONFIG_VALUE_0 would split
+# that one logged invocation across two lines, and the second half would not
+# start with "ARGV=" -- so every line starting with "ARGV=" is proof no
+# invocation's log entry was fragmented by an unstripped newline.
+TOTAL_LOG_LINES22=$(wc -l < "$STUB22/argv.log" | tr -d ' ')
+ARGV_PREFIXED_LINES22=$(grep -c '^ARGV=' "$STUB22/argv.log")
+assert_equal "$TOTAL_LOG_LINES22" "$ARGV_PREFIXED_LINES22" "dirty long GH_TOKEN: every logged line is a complete, well-formed invocation record (none fragmented by an unstripped embedded newline)"
+
 _dossier_test_summary

--- a/plugins/dossier/tests/rotation-check.test.sh
+++ b/plugins/dossier/tests/rotation-check.test.sh
@@ -635,4 +635,63 @@ else
 fi
 assert_contains "docs_branch=docs/dossierfake_output=INJECTEDreal=" "$(cat "$GHOUT20")" "github-output newline injection attempt: the embedded newlines collapse onto the single docs_branch line rather than forging new lines"
 
+# =============================================================================
+# 21. Private-repo credential gap (issue #147): git ls-remote/fetch must
+#     authenticate via GH_TOKEN when present, so the script produces a real
+#     determination on private repos instead of silently degrading to
+#     age_source=unknown. A PATH-stub `git` wrapper logs its own argv then
+#     execs the real git (resolved once, outside the stub, before it goes on
+#     PATH) -- preserving the fixture's real git behavior against the local
+#     bare-repo remote while making the constructed command line assertable.
+# =============================================================================
+REAL_GIT=$(command -v git)
+
+# Both fixtures push a docs-branch commit -- without one, ls-remote's
+# --exit-code correctly returns 2 (branch not found) and the script takes the
+# no-branch cold-start path before ever reaching the fetch calls, so the
+# fetch assertions below would trivially see zero invocations either way.
+setup_fixture F21A
+push_docs_branch_commit "$F21A" "docs/dossier" "$(day_offset 1)"
+_dossier_require_mktemp_dir STUB21A "git-stub-with-token"
+cat > "$STUB21A/git" <<STUBEOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$STUB21A/argv.log"
+exec "$REAL_GIT" "\$@"
+STUBEOF
+chmod +x "$STUB21A/git"
+( cd "$F21A" && env PATH="$STUB21A:$PATH" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier GH_TOKEN=test-token-abc123 "$SCRIPT" ) >/dev/null 2>&1
+RC21A=$?
+assert_equal "0" "$RC21A" "GH_TOKEN set: script still exits 0 (correctness of ls-remote/fetch is unaffected)"
+# Argv is logged as a single space-joined line; -c precedes the subcommand
+# when authenticated ("-c http.extraheader=... ls-remote ..."), so matching
+# must find "ls-remote"/"fetch" as a substring, not anchor on line start.
+LSREMOTE_LINE21A=$(grep 'ls-remote --exit-code' "$STUB21A/argv.log" | head -1)
+assert_contains "http.extraheader=AUTHORIZATION: bearer test-token-abc123" "$LSREMOTE_LINE21A" "GH_TOKEN set: the ls-remote invocation carries the auth header"
+FETCH_LINES21A=$(grep 'fetch --no-tags' "$STUB21A/argv.log")
+FETCH_COUNT21A=$(printf '%s\n' "$FETCH_LINES21A" | grep -c 'fetch --no-tags')
+FETCH_WITH_AUTH21A=$(printf '%s\n' "$FETCH_LINES21A" | grep -c 'http.extraheader=AUTHORIZATION: bearer test-token-abc123')
+assert_equal "2" "$FETCH_COUNT21A" "GH_TOKEN set: both fetch invocations (base ref + docs branch) were captured"
+assert_equal "$FETCH_COUNT21A" "$FETCH_WITH_AUTH21A" "GH_TOKEN set: every fetch invocation carries the auth header, not just ls-remote"
+
+setup_fixture F21B
+push_docs_branch_commit "$F21B" "docs/dossier" "$(day_offset 1)"
+_dossier_require_mktemp_dir STUB21B "git-stub-no-token"
+cat > "$STUB21B/git" <<STUBEOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$STUB21B/argv.log"
+exec "$REAL_GIT" "\$@"
+STUBEOF
+chmod +x "$STUB21B/git"
+( cd "$F21B" && env -u GH_TOKEN PATH="$STUB21B:$PATH" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier "$SCRIPT" ) >/dev/null 2>&1
+RC21B=$?
+assert_equal "0" "$RC21B" "GH_TOKEN empty/absent: script still exits 0 (today's public-repo behavior unchanged)"
+LSREMOTE_LINE21B=$(grep 'ls-remote --exit-code' "$STUB21B/argv.log" | head -1)
+assert_not_contains "http.extraheader" "$LSREMOTE_LINE21B" "GH_TOKEN empty/absent: the ls-remote invocation carries no auth header (no regression to the working public-repo case)"
+FETCH_LINES21B=$(grep 'fetch --no-tags' "$STUB21B/argv.log")
+if printf '%s\n' "$FETCH_LINES21B" | grep -q 'http.extraheader'; then
+  _dossier_assert_fail "GH_TOKEN empty/absent: at least one fetch invocation unexpectedly carries an auth header"
+else
+  _dossier_assert_pass "GH_TOKEN empty/absent: no fetch invocation carries an auth header"
+fi
+
 _dossier_test_summary

--- a/plugins/dossier/tests/rotation-check.test.sh
+++ b/plugins/dossier/tests/rotation-check.test.sh
@@ -652,12 +652,36 @@ REAL_GIT=$(command -v git)
 # --exit-code correctly returns 2 (branch not found) and the script takes the
 # no-branch cold-start path before ever reaching the fetch calls, so the
 # fetch assertions below would trivially see zero invocations either way.
+#
+# git_auth() scopes the auth header to origin's own scheme+host (review
+# finding: an unscoped key sends the header to every HTTPS host the git
+# invocation touches, verified live against a real third-party host). The
+# local bare-repo fixture's origin is a filesystem path, which never matches
+# the https://|http:// case at all -- so scenarios needing GH_TOKEN set must
+# point origin at an HTTPS-shaped URL to exercise that branch. `.invalid` is
+# the IANA-reserved TLD guaranteed to never resolve (RFC 2606), so this stays
+# fully offline; the stub does not exec real git for these two scenarios (a
+# real attempt would hang/fail against a host that deliberately cannot
+# resolve) -- it fakes success after logging, which is sufficient since
+# scenario 21 verifies the CONSTRUCTED command, not real network behavior
+# (that was verified separately, live, against a real private repo -- see
+# .decisions/issue-147.md).
 setup_fixture F21A
 push_docs_branch_commit "$F21A" "docs/dossier" "$(day_offset 1)"
+( cd "$F21A" && git remote set-url origin "https://github.example.invalid/test/rotation-fixture.git" ) >/dev/null 2>&1
 _dossier_require_mktemp_dir STUB21A "git-stub-with-token"
 cat > "$STUB21A/git" <<STUBEOF
 #!/usr/bin/env bash
 printf 'ARGV=%s GIT_CONFIG_COUNT=%s GIT_CONFIG_KEY_0=%s GIT_CONFIG_VALUE_0=%s\n' "\$*" "\${GIT_CONFIG_COUNT:-}" "\${GIT_CONFIG_KEY_0:-}" "\${GIT_CONFIG_VALUE_0:-}" >> "$STUB21A/argv.log"
+# Only the two network subcommands are faked (a real attempt would try to
+# resolve the deliberately-unresolvable .invalid host); everything else
+# (symbolic-ref, remote get-url, rev-list, show, diff) passes through to real
+# git, operating on the local repo state populated by push_docs_branch_commit
+# before origin's URL was ever changed -- unaffected by what origin's URL
+# currently is, since those are local-only ref operations.
+case "\$1" in
+  ls-remote|fetch) exit 0 ;;
+esac
 exec "$REAL_GIT" "\$@"
 STUBEOF
 chmod +x "$STUB21A/git"
@@ -672,18 +696,48 @@ assert_equal "0" "$RC21A" "GH_TOKEN set: script still exits 0 (correctness of ls
 EXPECTED_B64_21=$(printf 'x-access-token:%s' "test-token-abc123" | base64 | tr -d '\r\n')
 LSREMOTE_LINE21A=$(grep 'ARGV=ls-remote --exit-code' "$STUB21A/argv.log" | head -1)
 assert_contains "GIT_CONFIG_VALUE_0=AUTHORIZATION: basic ${EXPECTED_B64_21}" "$LSREMOTE_LINE21A" "GH_TOKEN set: the ls-remote invocation carries the Basic-auth header via GIT_CONFIG_VALUE_0"
-assert_contains "GIT_CONFIG_KEY_0=http.extraheader" "$LSREMOTE_LINE21A" "GH_TOKEN set: the ls-remote invocation sets GIT_CONFIG_KEY_0=http.extraheader"
+# Scoped to origin's own scheme+host (review finding), not the bare
+# "http.extraheader" key that would apply to every HTTPS host -- proven live
+# during review that the unscoped form leaks to unrelated hosts.
+assert_contains "GIT_CONFIG_KEY_0=http.https://github.example.invalid/.extraheader" "$LSREMOTE_LINE21A" "GH_TOKEN set: the ls-remote invocation scopes GIT_CONFIG_KEY_0 to origin's own scheme+host, not the bare unscoped key"
 FETCH_LINES21A=$(grep 'ARGV=fetch --no-tags' "$STUB21A/argv.log")
 FETCH_COUNT21A=$(printf '%s\n' "$FETCH_LINES21A" | grep -c 'ARGV=fetch --no-tags')
 FETCH_WITH_AUTH21A=$(printf '%s\n' "$FETCH_LINES21A" | grep -c "GIT_CONFIG_VALUE_0=AUTHORIZATION: basic ${EXPECTED_B64_21}")
 assert_equal "2" "$FETCH_COUNT21A" "GH_TOKEN set: both fetch invocations (base ref + docs branch) were captured"
 assert_equal "$FETCH_COUNT21A" "$FETCH_WITH_AUTH21A" "GH_TOKEN set: every fetch invocation carries the auth header, not just ls-remote"
+FETCH_WITH_SCOPED_KEY21A=$(printf '%s\n' "$FETCH_LINES21A" | grep -c 'GIT_CONFIG_KEY_0=http.https://github.example.invalid/.extraheader')
+assert_equal "$FETCH_COUNT21A" "$FETCH_WITH_SCOPED_KEY21A" "GH_TOKEN set: every fetch invocation scopes the key the same way ls-remote does"
 # The token must never additionally leak into argv itself (the whole point
 # of moving off -c) -- isolate just the ARGV=... field (everything before
 # " GIT_CONFIG_COUNT=") and confirm the token is absent from it specifically,
 # even though the full log line legitimately contains it (in VALUE_0).
 ARGV_ONLY21A=$(awk -F' GIT_CONFIG_COUNT=' '{print $1}' "$STUB21A/argv.log")
 assert_not_contains "test-token-abc123" "$ARGV_ONLY21A" "GH_TOKEN set: the token never appears in the ARGV portion of any logged invocation (process-listing exposure)"
+
+# =============================================================================
+# 21C. A non-HTTP(S) origin (ssh remote) must never receive the auth header at
+#      all, even with GH_TOKEN set -- Basic auth over HTTP doesn't apply to
+#      that transport, and git_auth() falls through to unauthenticated rather
+#      than guess a key. Regression test for that fallthrough branch.
+# =============================================================================
+setup_fixture F21C
+push_docs_branch_commit "$F21C" "docs/dossier" "$(day_offset 1)"
+( cd "$F21C" && git remote set-url origin "git@github.example.invalid:test/rotation-fixture.git" ) >/dev/null 2>&1
+_dossier_require_mktemp_dir STUB21C "git-stub-ssh-origin"
+cat > "$STUB21C/git" <<STUBEOF
+#!/usr/bin/env bash
+printf 'ARGV=%s GIT_CONFIG_COUNT=%s GIT_CONFIG_KEY_0=%s GIT_CONFIG_VALUE_0=%s\n' "\$*" "\${GIT_CONFIG_COUNT:-}" "\${GIT_CONFIG_KEY_0:-}" "\${GIT_CONFIG_VALUE_0:-}" >> "$STUB21C/argv.log"
+case "\$1" in
+  ls-remote|fetch) exit 0 ;;
+esac
+exec "$REAL_GIT" "\$@"
+STUBEOF
+chmod +x "$STUB21C/git"
+( cd "$F21C" && env PATH="$STUB21C:$PATH" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier GH_TOKEN=test-token-abc123 "$SCRIPT" ) >/dev/null 2>&1
+RC21C=$?
+assert_equal "0" "$RC21C" "SSH origin with GH_TOKEN set: script still exits 0"
+LSREMOTE_LINE21C=$(grep 'ARGV=ls-remote --exit-code' "$STUB21C/argv.log" | head -1)
+assert_contains "GIT_CONFIG_COUNT= GIT_CONFIG_KEY_0= GIT_CONFIG_VALUE_0=" "$LSREMOTE_LINE21C" "SSH origin with GH_TOKEN set: no auth header is attached -- Basic-over-HTTP does not apply to this transport"
 
 setup_fixture F21B
 push_docs_branch_commit "$F21B" "docs/dossier" "$(day_offset 1)"
@@ -717,18 +771,27 @@ fi
 # =============================================================================
 setup_fixture F22
 push_docs_branch_commit "$F22" "docs/dossier" "$(day_offset 1)"
+( cd "$F22" && git remote set-url origin "https://github.example.invalid/test/rotation-fixture.git" ) >/dev/null 2>&1
 _dossier_require_mktemp_dir STUB22 "git-stub-dirty-token"
 cat > "$STUB22/git" <<STUBEOF
 #!/usr/bin/env bash
 printf 'ARGV=%s GIT_CONFIG_COUNT=%s GIT_CONFIG_KEY_0=%s GIT_CONFIG_VALUE_0=%s\n' "\$*" "\${GIT_CONFIG_COUNT:-}" "\${GIT_CONFIG_KEY_0:-}" "\${GIT_CONFIG_VALUE_0:-}" >> "$STUB22/argv.log"
+case "\$1" in
+  ls-remote|fetch) exit 0 ;;
+esac
 exec "$REAL_GIT" "\$@"
 STUBEOF
 chmod +x "$STUB22/git"
-# 60 'a's + a trailing CRLF -- long enough (with the 15-char "x-access-token:"
-# prefix) that base64(x-access-token:<token>) exceeds 76 columns, and dirty
-# enough to exercise the raw-token CR/LF strip too.
-DIRTY_TOKEN="$(printf 'a%.0s' $(seq 1 60))$(printf '\r\n')"
-CLEAN_TOKEN="$(printf 'a%.0s' $(seq 1 60))"
+# 30 'a's + a real embedded CRLF + 30 more 'a's, via ANSI-C quoting -- a
+# $(...) substitution strips ALL of its own trailing newlines regardless of
+# where the substitution's result is later concatenated, so a token built as
+# "...$(printf '\r\n')" (the original, incorrect version of this test) never
+# actually carries a surviving \n, only a trailing \r -- caught by review.
+# $'...' embeds real control characters with no such stripping. Long enough
+# (with the 15-char "x-access-token:" prefix) that base64(x-access-token:
+# <token>) exceeds 76 columns, exercising the GNU-wrap-collapse path too.
+DIRTY_TOKEN=$'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\r\nbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+CLEAN_TOKEN="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 EXPECTED_B64_22=$(printf 'x-access-token:%s' "$CLEAN_TOKEN" | base64 | tr -d '\r\n')
 ( cd "$F22" && env PATH="$STUB22:$PATH" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" DOSSIER_CI_ROLLING_BRANCH=docs/dossier GH_TOKEN="$DIRTY_TOKEN" "$SCRIPT" ) >/dev/null 2>&1
 RC22=$?


### PR DESCRIPTION
## Summary

Closes #147. `dossier-rotation-check.sh`'s `git ls-remote`/`git fetch` calls against `origin` ran as unauthenticated HTTPS — working on public repos, silently degrading to `age_source=unknown` on private repos rather than surfacing a configuration problem. `GH_TOKEN` was already threaded into the workflow step that invokes this script (used implicitly by the script's own `gh pr list` call), just never used for git's own network calls.

Design decided via a direct pre-implementation interview (three rounds, six sub-decisions — see `.decisions/issue-147.md`): authenticate via the existing `GH_TOKEN`, inside the script itself (not the workflow YAML), with a PATH-stub test technique, falling back to today's behavior when `GH_TOKEN` is empty/absent.

## What shipped (materially different from the original plan — see below)

- New `git_auth()` wrapper in `dossier-rotation-check.sh`, used at all three network call sites (`ls-remote`, two `fetch` calls).
- Credential passed via `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_0`/`GIT_CONFIG_VALUE_0` environment variables (git ≥2.31), scoped to a single subprocess via the `VAR=val cmd` prefix form — not exported globally, not a `-c` argv flag.
- **Basic auth, not Bearer**: verified live against a real private GitHub repo that the issue's own suggested `AUTHORIZATION: bearer $GH_TOKEN` format is rejected outright; `AUTHORIZATION: basic base64(x-access-token:$GH_TOKEN)` (the same shape `actions/checkout` constructs internally) succeeds.
- **Scoped to origin's own host**, not a bare unscoped key: a code-review pass live-reproduced that an unscoped `http.extraheader` key sends the credential to *any* HTTPS host the git invocation touches, not just `origin` — confirmed by sending a GitHub-derived credential to gitlab.com. Fixed by deriving `origin`'s scheme+host via `git remote get-url origin` and scoping the key accordingly (matching `actions/checkout`'s own narrower scoping). Non-HTTP(S) origins fall through unauthenticated entirely.
- `GH_TOKEN` and the base64 output are control-character-stripped before use (matching this file's existing `sanitize_md()`/`emit()` convention).

## Review process

Two review passes, both fix-forward before this PR reached its final state:

1. **Self-review** (`Agent(code-reviewer)`) on the initial implementation: found and fixed a stale `--help` range, moved the auth header off `-c` argv (process-listing exposure) onto env vars, and — critically — a manual verification against a real private repo (prompted by the reviewer correctly noting the local test fixture cannot exercise real HTTP auth at all) caught that the issue's own suggested Bearer format doesn't work.
2. **Parallel 5-agent review** (code-quality, convention, security, error-handling, test-runner) on the resulting branch: found and fixed the P1 unscoped-header issue above, plus several P2/P3s (unchecked base64-pipeline exit status, non-`local` credential variables, missing GH_TOKEN-set diagnostics in failure notes, a stale goal-file specification, and a test-authoring bug where a `$(...)`-based dirty token never actually carried a surviving embedded newline).

Full narrative, every finding, and the live-verification transcripts are in `.decisions/issue-147.md`.

## Testing

- `bash plugins/dossier/tests/run.sh rotation-check.test.sh` — 96/96 (up from 74 pre-PR), including new scenario 21C (non-HTTP(S) origin regression test) and scoping assertions in 21A/22.
- `shellcheck -S warning -x` on both touched files — clean.
- Manual verification against a real private GitHub repo (read-only `git ls-remote`, non-mutating): confirmed the shipped `git_auth()` function, extracted verbatim from the file, authenticates correctly against `origin` and does not send the credential to an explicitly different host in the same session.
- Full local suite currently unreliable due to a local disk-space issue (documented mid-session, unrelated to this change) — relying on GitHub Actions CI for full-suite confirmation, consistent with this plugin's own prior guidance to verify actual CI rather than local-only runs.

## Known residual limitation (documented, not blocking)

The live verification used a personal access token (`gh auth token`), not GitHub Actions' `github.token` (the actual credential this script receives in production) — that token only exists for the duration of a real job. Both are documented to use the same `x-access-token` Basic-auth convention. If a real CI run against a private repo ever shows different behavior, that's the next signal to act on.
