### PR TITLE
fix(dossier): close enforce-allowed-actions's quote/backslash/ANSI-C bypass

### DIFF
--- a/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh
+++ b/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh
@@ -253,6 +253,42 @@ FIND_EXEC='(^|[;&|(]|[[:space:]])[[:space:]]*([A-Za-z0-9_.-]*/)*find([[:space:]]
 # the CI refresh job's own --allowedTools allowlist doesn't include `find`,
 # `xargs`, `parallel`, `awk`, `perl`, or a bare shell at all, so the automated
 # pipeline has no reach here.
+# Bash's \uHHHH/\UHHHHHHHH Unicode escapes (added in bash 4.2) aren't in
+# printf '%b's escape set at all -- confirmed divergence on real bash >=4.2:
+# bash's own $'...' decodes a 4-hex-digit \u escape for codepoint 0x63 to
+# the single byte 'c', but printf '%b' passes that same escape through
+# completely unrecognized, so a denied word spelled this way never reached
+# the deny scan. This was a real, live P1 on CI's Linux bash
+# (which implements \u/\U; the bash on this file's own dev machine does not,
+# so this had to be verified by pushing to CI and reading the failure, not
+# locally). Only the ASCII range (codepoint <= 0x7F) matters for spelling a
+# denied word -- curl/npm/git/etc. are all ASCII -- and UTF-8 encodes that
+# range as the single byte equal to the codepoint, so it's converted to
+# \xHH here, which printf '%b' already handles identically to bash (see the
+# octal note below). A codepoint above 0x7F needs real multi-byte UTF-8
+# encoding to replicate exactly and cannot spell an ASCII denied word
+# regardless, so it's deliberately left unnormalized (passes through as
+# literal text, same as it would if this function didn't exist at all).
+unicode_normalize() { # $1: ANSI-C span body -> stdout: ASCII-range \u/\U normalized to \xHH
+  local body="$1" esc hex cp repl escapes
+  escapes=$(printf '%s' "$body" | grep -oE '\\(u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8})' | sort -u)
+  while IFS= read -r esc; do
+    [ -n "$esc" ] || continue
+    hex="${esc:2}"
+    cp=$((16#$hex))
+    if [ "$cp" -le 127 ]; then
+      repl=$(printf '\\x%02x' "$cp")
+      # $esc must be quoted here: unquoted, its leading backslash is a glob
+      # ESCAPE CHARACTER to `${var//pattern/}` (consumed, not matched
+      # literally), which silently matches one character late and leaves
+      # the original backslash behind duplicated alongside $repl's own --
+      # caught by testing the byte-level output, not by reading the diff.
+      body="${body//"$esc"/$repl}"
+    fi
+  done <<< "$escapes"
+  printf '%s' "$body"
+}
+
 ansi_c_decode() { # $1: command string -> stdout: with every $'...' span decoded
   # Bash's $'...' decodes \nnn (octal), \xHH (hex), and the usual \n/\t/...
   # single-letter escapes. printf '%b' understands the same set, EXCEPT its
@@ -264,6 +300,7 @@ ansi_c_decode() { # $1: command string -> stdout: with every $'...' span decoded
     rest="${s#*\$\'}"
     body="${rest%%\'*}"
     rest="${rest#"$body"\'}"
+    body=$(unicode_normalize "$body")
     norm=$(printf '%s' "$body" | sed -E 's/\\([0-7]{1,3})/\\0\1/g')
     out+="$pre$(printf '%b' "$norm")"
     s="$rest"

--- a/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh
+++ b/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh
@@ -271,6 +271,30 @@ ansi_c_decode() { # $1: command string -> stdout: with every $'...' span decoded
   printf '%s' "$out$s"
 }
 
+# ansi_c_decode forks a sed+printf subprocess pair for every $'...' occurrence
+# it finds. The byte-length guard above bounds the quadratic glob-matching
+# cost, but not this one: an attacker can still pack many tiny $'x' spans
+# into that same byte budget, and fork/exec overhead is paid per span
+# regardless of how small each one is -- confirmed live, ~2000 minimal spans
+# in an 8KB command took over 10 seconds from subprocess overhead alone, with
+# no `$'...'`-external content large enough to trip the length guard. A
+# legitimate interactive command needs at most a handful of ANSI-C-quoted
+# segments, so this is capped separately from the overall length.
+#
+# Counted with `grep -oF`, not bash's own `${var//pattern/replacement}`:
+# bash's global substitution has the exact same super-linear-for-many-matches
+# behavior this guard exists to bound -- confirmed live, counting via pure
+# bash parameter expansion on the same 2000-span input took ~7 seconds by
+# itself, which would have defeated the point of counting fast before
+# deciding whether to run the expensive decode. `-F` matches the 2-character
+# literal `$'` identically on GNU and BSD, so this doesn't reopen the
+# GNU/BSD divergence risk the newline-join logic above avoids sed/grep for.
+ANSIC_SPAN_COUNT=$(printf '%s' "$COMMAND" | grep -oF "\$'" | wc -l | tr -d '[:space:]')
+if [ "$ANSIC_SPAN_COUNT" -gt 64 ]; then
+  echo "BLOCKED: dossier cannot safely enforce its action ceiling on a command with this many \$'...' segments (${ANSIC_SPAN_COUNT}, limit 64) -- each one forks a subprocess to decode." >&2
+  exit 2
+fi
+
 COMMAND_ANSIC=$(ansi_c_decode "$COMMAND")
 
 # The placeholder byte chosen below (0x01) is assumed to never legitimately

--- a/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh
+++ b/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh
@@ -271,6 +271,29 @@ ansi_c_decode() { # $1: command string -> stdout: with every $'...' span decoded
   printf '%s' "$out$s"
 }
 
+# Three known grammar divergences between ansi_c_decode and bash's own
+# $'...' parsing, each reviewed and confirmed non-exploitable rather than
+# left unmentioned:
+#   - `\'` inside a span (`$'cur\'l'`): bash decodes this to the 5-char
+#     string `cur'l` (the escaped quote is literal, decoding continues past
+#     it); this function's span-boundary search stops at the FIRST literal
+#     `'` regardless, so it mis-locates where the span ends. Not exploitable:
+#     any use of `\'` inside a span leaves a literal quote character in
+#     bash's own real decoded word too (`cur'l`, not `curl`), so it can never
+#     spell a clean, standalone denied word on the side that actually runs.
+#   - `\143` immediately after a literal backslash (`\\143`): the sed
+#     octal-normalization step below treats the second backslash as if it
+#     started a fresh octal escape, diverging from bash's own 4-byte decode
+#     of the same input. Same non-exploitability argument: the divergence
+#     only ever surfaces a stray backslash in bash's real decoded word too.
+#   - `\c` (control-character escape): bash's `\cX` consumes exactly the next
+#     character to form one control byte and keeps decoding after it; POSIX
+#     printf's `\c` means "stop all further output" instead, a completely
+#     different operation. Not exploitable: `\cX` always glues an
+#     unprintable control byte to whatever it's adjacent to, which corrupts
+#     the resulting word identically for bash's real execution (the command
+#     bash actually looks up on PATH also stops being a clean "curl"/"npm"/
+#     etc.), not just for this function's decode.
 # ansi_c_decode forks a sed+printf subprocess pair for every $'...' occurrence
 # it finds. The byte-length guard above bounds the quadratic glob-matching
 # cost, but not this one: an attacker can still pack many tiny $'x' spans
@@ -319,14 +342,17 @@ case "$COMMAND_ANSIC" in
     ;;
 esac
 
-# bash 3.2 (macOS's system /bin/bash) cannot match a pattern-substitution
-# pattern that is itself a literal backslash followed by a real newline: the
-# 2-character pattern's own length checks out, but the replacement silently
-# never fires -- confirmed empirically, and NOT reproducible under zsh or
-# newer bash, which both do fire. A backslash is a glob escape character
-# inside `${var//pattern/}`, and bash 3.2 mishandles escaping a newline
-# specifically. Every backslash is swapped for a placeholder byte first (one
-# that never legitimately appears in a Bash-tool command string) so the
+# bash 3.2 (macOS's system /bin/bash) mishandles a backslash-followed-by-
+# real-newline pattern specifically when that 2-character pattern is
+# pre-assembled into a variable before being used in `${var//pattern/}` --
+# the substitution then silently never fires, even though the identical
+# pattern written inline (`${var//\\$'\n'/}`) matches correctly on the same
+# bash. Confirmed empirically on both forms; NOT reproducible under zsh or
+# newer bash, where both forms fire. The placeholder-byte approach below
+# sidesteps the question of which form is safe on which bash version
+# entirely, rather than depending on getting that distinction right: every
+# backslash is swapped for a placeholder byte first (one that never
+# legitimately appears in a Bash-tool command string, checked above) so the
 # join pattern below is placeholder+newline, never backslash+newline; the
 # remaining lone placeholders are then deleted, which is step 3 (the escape
 # character removed, the character it protected kept) applied via the same

--- a/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh
+++ b/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh
@@ -67,6 +67,24 @@ if [ "$JQ_RC" -ne 0 ]; then
 fi
 [ -z "$COMMAND" ] && exit 0
 
+# Fail closed rather than let bash's own glob-based parameter expansion pay a
+# super-linear cost: ansi_c_decode's span-boundary search (`${rest%%\'*}`,
+# re-scanning a shrinking-but-still-large remainder every loop iteration) and
+# the backslash-to-placeholder pass further below (a single global
+# substitution over the whole command) are both quadratic in bash for large
+# operands -- confirmed empirically: a 100KB command containing ANSI-C
+# content took ~20s to normalize here, ~200KB took over a minute, and the
+# same blowup reproduces from backslash volume alone with no `$'...'`
+# involved at all. A command this large is never a legitimate interactive
+# Bash-tool call this hook needs to support, so refusing it outright costs
+# nothing real while closing an easy, no-malice-required hang -- and this
+# hook blocks the whole Bash tool call while it runs, not just itself.
+COMMAND_LEN=${#COMMAND}
+if [ "$COMMAND_LEN" -gt 8192 ]; then
+  echo "BLOCKED: dossier cannot safely enforce its action ceiling on a command this large (${COMMAND_LEN} bytes, limit 8192) -- bash's own quote/escape normalization is super-linear at this size. Split the command into smaller steps." >&2
+  exit 2
+fi
+
 deny() { # capability | setting | matched-class
   cat >&2 <<EOF
 BLOCKED: the run's action ceiling forbids this command.
@@ -254,6 +272,28 @@ ansi_c_decode() { # $1: command string -> stdout: with every $'...' span decoded
 }
 
 COMMAND_ANSIC=$(ansi_c_decode "$COMMAND")
+
+# The placeholder byte chosen below (0x01) is assumed to never legitimately
+# appear in a Bash-tool command string -- but that assumption is checked
+# here, not trusted, because ansi_c_decode above can manufacture that exact
+# byte itself from a plain, valid `$'\001'` (or `\x01`) escape in the
+# original command. An already-present 0x01 byte at this point is
+# indistinguishable from a backslash this script marks itself a few lines
+# down: if it happens to sit immediately before a real newline, the join
+# step below deletes both, splicing two separate statements together with no
+# boundary character left for BOUND/BOUND_ACTIVE to anchor on. Confirmed
+# live: `echo done$'\001'` followed by a real `curl ...` on the next line was
+# permitted outright before this guard existed. Failing closed costs
+# nothing real -- a raw 0x01 byte is not a legitimate case this hook needs
+# to support -- and covers both this manufactured case and a literal 0x01
+# typed directly into the command, since ansi_c_decode passes untouched
+# bytes through unchanged.
+case "$COMMAND_ANSIC" in
+  *$'\x01'*)
+    echo "BLOCKED: dossier cannot safely enforce its action ceiling on a command containing a raw 0x01 byte -- that byte is reserved for this script's own internal quote/escape normalization." >&2
+    exit 2
+    ;;
+esac
 
 # bash 3.2 (macOS's system /bin/bash) cannot match a pattern-substitution
 # pattern that is itself a literal backslash followed by a real newline: the

--- a/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh
+++ b/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh
@@ -150,34 +150,122 @@ FIND_EXEC='(^|[;&|(]|[[:space:]])[[:space:]]*([A-Za-z0-9_.-]*/)*find([[:space:]]
 # above, which came from an actual review finding on real PR traffic, this
 # residual class has no concrete trigger yet.
 #
-# Second known limitation, tracked as issue #152 (not fixed here): quoting or
-# backslash-escaping a denied word defeats BOUND/WRAPPER entirely, for ANY
-# token listed anywhere in this file, not just `find`/`xargs` — confirmed
-# live (`"curl" https://evil`, `\curl https://evil`, and `\find . -exec curl
-# ... {} \;` all exit 0/permitted). This is broader and predates issue #143:
-# the SCAN/BOUND_ACTIVE quote-stripping normalization only runs after a
-# WRAPPER match is found, so a denied word spelled with a leading quote/
-# backslash never triggers that normalization in the first place. Fixing it
-# means normalizing unconditionally before any WRAPPER/FIND_EXEC/deny test,
-# not something scoped to this file's find/xargs change.
+# Second limitation, issue #152 (closed here): quoting or backslash-escaping a
+# denied word defeats BOUND/WRAPPER entirely, for ANY token listed anywhere in
+# this file, not just find/xargs — confirmed live for every one of these,
+# including a real curl invocation in each case:
+#   "curl" https://evil                  (whole word quoted)
+#   \curl https://evil                   (leading backslash)
+#   c\url https://evil                   (mid-word backslash split)
+#   cu''rl https://evil / cu"r"l https://evil   (adjacent quote fragments —
+#                                                bash joins these into one word)
+#   cur\<a real newline>l https://evil   (backslash-newline line continuation)
+#   $'\143url' https://evil              (bash's own ANSI-C octal quoting)
+# The last two were found investigating this issue, not in the original
+# report: this file's SCAN/BOUND_ACTIVE quote-stripping only ran after a
+# WRAPPER match, so a denied word spelled with a leading quote/backslash never
+# triggered it, and every variant above reduces to a plain, unrecognizable
+# spelling of the same word bash actually executes.
 #
-# Real-world exposure stays low regardless of either limitation above — this
-# hook is a local/interactive backstop only; the CI refresh
-# job's own --allowedTools allowlist doesn't include `find`, `xargs`,
-# `parallel`, `awk`, `perl`, or a bare shell at all, so the automated
+# DEQUOTED undoes exactly what bash's own quote/escape/ANSI-C removal would
+# do, so the anchor below tests the word bash actually runs rather than its
+# disguised spelling. Order matters:
+#
+#  1. $'...' content is decoded first — it has its own escape grammar
+#     (octal/hex), independent of ordinary quoting, and must not be treated as
+#     a plain literal string by step 4.
+#  2. A backslash immediately followed by a real newline is removed as a PAIR
+#     before any lone backslash is stripped. Stripping the backslash alone
+#     first leaves the newline behind as a still-valid whitespace separator,
+#     silently reopening the exact bypass this closes.
+#  3. Remaining lone backslashes (the escape character) are deleted, keeping
+#     the character they protected.
+#  4. Quote and backtick characters are deleted outright, not turned into a
+#     boundary/separator the way the WRAPPER-triggered widening below does.
+#     Bash's own quote removal deletes the marks and leaves adjacent fragments
+#     joined into one word (cu''rl -> curl); turning them into a separator
+#     would instead split the word into pieces that never reassemble.
+#
+# Done in bash parameter expansion (not sed/tr) for steps 2-4: sed and grep
+# are line-oriented by default, which would silently ignore the
+# backslash-newline case — the join needs to see the newline and the
+# character after it as one operation, not two independent lines — and this
+# also sidesteps the GNU/BSD sed divergence this suite has hit before. The
+# ANSI-C helper below still shells out to sed/printf for its own narrow,
+# already-isolated substring (the content between $' and '), where that
+# divergence risk does not apply.
+#
+# Known, accepted trade-off: deleting a quote mark can bring a boundary
+# character and a denied word directly together when nothing else separated
+# them — `echo hi;"curl" https://evil` has a boundary-char/keyword gap of
+# exactly one quote mark, so deleting it produces `;curl`, indistinguishable
+# from a real `;curl ...` invocation. (A quote mark elsewhere in the same
+# command, with other text between it and the keyword, is not this case: the
+# keyword's own preceding character is unchanged either way, which is why an
+# ordinary `"..."` argument containing a stray `|` or `(` earlier in a prose
+# string is not a NEW effect of this fix — the strict anchor already reads
+# raw command text without understanding quoting at all.) This is the same
+# direction of trade this file already accepts for the WRAPPER scan
+# (`timeout 5 grep -r "npm test" docs/` is refused too): over-block, name the
+# match, let a human drop the false trigger and re-run. See hooks.test.sh for
+# the assertion that proves this is deliberate, not a surprise.
+#
+# Real-world exposure stays low regardless of the remaining find/xargs-shaped
+# limitation noted above — this hook is a local/interactive backstop only;
+# the CI refresh job's own --allowedTools allowlist doesn't include `find`,
+# `xargs`, `parallel`, `awk`, `perl`, or a bare shell at all, so the automated
 # pipeline has no reach here.
-SCAN="$COMMAND"
+ansi_c_decode() { # $1: command string -> stdout: with every $'...' span decoded
+  # Bash's $'...' decodes \nnn (octal), \xHH (hex), and the usual \n/\t/...
+  # single-letter escapes. printf '%b' understands the same set, EXCEPT its
+  # octal form requires the leading zero bash's own \nnn does not (\143 vs
+  # \0143) — normalized below before handing the body to printf.
+  local s="$1" out="" pre body rest norm
+  while [[ "$s" == *\$\'*\'* ]]; do
+    pre="${s%%\$\'*}"
+    rest="${s#*\$\'}"
+    body="${rest%%\'*}"
+    rest="${rest#"$body"\'}"
+    norm=$(printf '%s' "$body" | sed -E 's/\\([0-7]{1,3})/\\0\1/g')
+    out+="$pre$(printf '%b' "$norm")"
+    s="$rest"
+  done
+  printf '%s' "$out$s"
+}
+
+COMMAND_ANSIC=$(ansi_c_decode "$COMMAND")
+
+# bash 3.2 (macOS's system /bin/bash) cannot match a pattern-substitution
+# pattern that is itself a literal backslash followed by a real newline: the
+# 2-character pattern's own length checks out, but the replacement silently
+# never fires -- confirmed empirically, and NOT reproducible under zsh or
+# newer bash, which both do fire. A backslash is a glob escape character
+# inside `${var//pattern/}`, and bash 3.2 mishandles escaping a newline
+# specifically. Every backslash is swapped for a placeholder byte first (one
+# that never legitimately appears in a Bash-tool command string) so the
+# join pattern below is placeholder+newline, never backslash+newline; the
+# remaining lone placeholders are then deleted, which is step 3 (the escape
+# character removed, the character it protected kept) applied via the same
+# placeholder rather than a second backslash-pattern substitution.
+DEQUOTE_PLACEHOLDER=$'\x01'
+COMMAND_MARKED="${COMMAND_ANSIC//\\/$DEQUOTE_PLACEHOLDER}"
+COMMAND_JOINED="${COMMAND_MARKED//$DEQUOTE_PLACEHOLDER$'\n'/}"
+DEQUOTED="${COMMAND_JOINED//$DEQUOTE_PLACEHOLDER/}"
+DEQUOTED="${DEQUOTED//\'/}"
+DEQUOTED="${DEQUOTED//\"/}"
+DEQUOTED="${DEQUOTED//\`/}"
+
+SCAN="$DEQUOTED"
 BOUND_ACTIVE="$BOUND"
-if printf '%s' "$COMMAND" | grep -qE "$WRAPPER" || printf '%s' "$COMMAND" | grep -qE "$FIND_EXEC"; then
-  # Quotes and command-substitution openers stop hiding a boundary, and every
-  # whitespace run becomes one.
-  SCAN=$(printf '%s' "$COMMAND" | sed -E -e 's,["'"'"'`],;,g' -e 's,\$\(,;,g')
+if printf '%s' "$DEQUOTED" | grep -qE "$WRAPPER" || printf '%s' "$DEQUOTED" | grep -qE "$FIND_EXEC"; then
   BOUND_ACTIVE='(^|[;&|(]|[[:space:]])[[:space:]]*([A-Za-z0-9_.-]*/)*'
 fi
 
-# Every check below tests $SCAN with $BOUND_ACTIVE, which are $COMMAND and the
-# strict anchor unless a wrapper (or find's own exec-family primaries) was
-# found.
+# Every check below tests $SCAN with $BOUND_ACTIVE: $SCAN is always DEQUOTED
+# (quote/backslash/ANSI-C removed, so a disguised command-start is restored to
+# its plain spelling); $BOUND_ACTIVE is the strict anchor unless a wrapper (or
+# find's own exec-family primaries) was found in DEQUOTED, in which case
+# whitespace itself becomes a boundary too.
 
 if [ "$RUN_TESTS" != "true" ]; then
   if printf '%s' "$SCAN" | grep -qE "${BOUND_ACTIVE}(npm|yarn|pnpm|bun)[[:space:]]+(run[[:space:]]+)?test\b"; then

--- a/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh
+++ b/plugins/dossier/hooks/scripts/enforce-allowed-actions.sh
@@ -160,31 +160,51 @@ FIND_EXEC='(^|[;&|(]|[[:space:]])[[:space:]]*([A-Za-z0-9_.-]*/)*find([[:space:]]
 #   cu''rl https://evil / cu"r"l https://evil   (adjacent quote fragments —
 #                                                bash joins these into one word)
 #   cur\<a real newline>l https://evil   (backslash-newline line continuation)
-#   $'\143url' https://evil              (bash's own ANSI-C octal quoting)
+#   $'\143url' https://evil              (bash's own ANSI-C octal/hex quoting —
+#   $'\x63url' https://evil               \nnn and \xHH are both decoded)
 # The last two were found investigating this issue, not in the original
 # report: this file's SCAN/BOUND_ACTIVE quote-stripping only ran after a
 # WRAPPER match, so a denied word spelled with a leading quote/backslash never
 # triggered it, and every variant above reduces to a plain, unrecognizable
-# spelling of the same word bash actually executes.
+# spelling of the same word bash actually executes. What is closed above is
+# specifically bash's quote/backslash/ANSI-C *removal* — not bash's own
+# *expansion* mechanisms; see the third limitation below for that residual.
+#
+# Third limitation, issue #160 (not fixed here, found while reviewing this
+# PR): brace expansion (`cu{rl,} https://evil`), parameter-expansion defaults
+# (`${x:-curl} https://evil`), and command substitution (`$(echo curl)
+# https://evil`) all defeat DEQUOTED just as completely — confirmed live,
+# real curl invoked, permitted (exit 0) in every case, on both this branch
+# and pre-#152 main (a pre-existing gap, not a regression here). DEQUOTED
+# only reverses quote/backslash/ANSI-C removal; it never performs actual
+# bash expansion, so none of these three are touched by it. Deliberately not
+# folded into #152's fix: resolving what a command substitution evaluates to
+# requires either executing attacker-controlled shell content inside this
+# hook (worse than the gap it would close) or full static shell-expansion
+# analysis (not tractable in general). That is a different-shaped problem
+# than DEQUOTED solves and needs its own design, not a rushed extension here.
 #
 # DEQUOTED undoes exactly what bash's own quote/escape/ANSI-C removal would
 # do, so the anchor below tests the word bash actually runs rather than its
 # disguised spelling. Order matters:
 #
-#  1. $'...' content is decoded first — it has its own escape grammar
-#     (octal/hex), independent of ordinary quoting, and must not be treated as
-#     a plain literal string by step 4.
-#  2. A backslash immediately followed by a real newline is removed as a PAIR
-#     before any lone backslash is stripped. Stripping the backslash alone
-#     first leaves the newline behind as a still-valid whitespace separator,
-#     silently reopening the exact bypass this closes.
-#  3. Remaining lone backslashes (the escape character) are deleted, keeping
-#     the character they protected.
-#  4. Quote and backtick characters are deleted outright, not turned into a
-#     boundary/separator the way the WRAPPER-triggered widening below does.
-#     Bash's own quote removal deletes the marks and leaves adjacent fragments
-#     joined into one word (cu''rl -> curl); turning them into a separator
-#     would instead split the word into pieces that never reassemble.
+# 1. $'...' content is decoded first — it has its own escape grammar
+#    (octal/hex), independent of ordinary quoting, and must not be treated as
+#    a plain literal string by step 4.
+#
+# 2. A backslash immediately followed by a real newline is removed as a PAIR
+#    before any lone backslash is stripped. Stripping the backslash alone
+#    first leaves the newline behind as a still-valid whitespace separator,
+#    silently reopening the exact bypass this closes.
+#
+# 3. Remaining lone backslashes (the escape character) are deleted, keeping
+#    the character they protected.
+#
+# 4. Quote and backtick characters are deleted outright, not turned into a
+#    boundary/separator the way the WRAPPER-triggered widening below does.
+#    Bash's own quote removal deletes the marks and leaves adjacent fragments
+#    joined into one word (cu''rl -> curl); turning them into a separator
+#    would instead split the word into pieces that never reassemble.
 #
 # Done in bash parameter expansion (not sed/tr) for steps 2-4: sed and grep
 # are line-oriented by default, which would silently ignore the

--- a/plugins/dossier/tests/hooks.test.sh
+++ b/plugins/dossier/tests/hooks.test.sh
@@ -233,6 +233,46 @@ do
   assert_equal "2" "$RC" "enforce-allowed-actions closes the $CASE_LABEL bypass: $CASE_CMD"
 done
 
+# Bash's \u/\U Unicode ANSI-C escapes (added in bash 4.2) aren't handled by
+# ansi_c_decode's octal-only normalization -- only meaningfully checkable on
+# a bash that implements them at all. Bash 3.2 (this suite's local macOS
+# bash) doesn't support \u/\U in either $'...' or printf '%b', so this
+# exercises the real question -- does the hook's printf-based decode agree
+# with what bash itself would spell -- only on bash >=4.2, which is what
+# this project's Linux CI runs. Skipped, not asserted false, on older bash:
+# asserting a specific outcome for a feature the interpreter doesn't have
+# would be testing a coincidence, not the mechanism.
+if [ "${BASH_VERSINFO[0]}" -gt 4 ] || { [ "${BASH_VERSINFO[0]}" -eq 4 ] && [ "${BASH_VERSINFO[1]}" -ge 2 ]; }; then
+  U_ESCAPE_CMD=$(printf 'echo $%s\\u0063url%s https://example.invalid' "'" "'")
+  RC=0
+  (cd "$WORK" && printf '{"tool_input":{"command":%s}}' "$(printf '%s' "$U_ESCAPE_CMD" | jq -Rs .)" \
+     | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
+  assert_equal "2" "$RC" "enforce-allowed-actions closes the ANSI-C \\u Unicode-escape bypass: $U_ESCAPE_CMD"
+fi
+
+# A WRAPPER-list token disguised the same way the payload was (not just the
+# payload itself) must still widen the boundary -- the fix's own comment
+# claims this closes "for ANY token listed anywhere in this file," proven
+# here rather than only for payload words like curl.
+RC=0
+(cd "$WORK" && printf '%s' '{"tool_input":{"command":"\\xargs -I{} curl {} https://example.invalid"}}' \
+   | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
+assert_equal "2" "$RC" 'enforce-allowed-actions widens the boundary for a disguised WRAPPER token, not just a disguised payload: \xargs -I{} curl {}'
+
+# A second, previously-undocumented over-block trade-off surfaces once a
+# quoted WRAPPER token is also dequoted before the WRAPPER scan: a quoted
+# wrapper (";\"env\" ...") could not trigger boundary-widening before this
+# fix (a quote character isn't in WRAPPER's boundary class), but can now --
+# which then also catches an otherwise-safe, fully-quoted prose argument
+# like "npm test" in a grep call. Same direction and same underlying
+# mechanism as the accepted trade-off above (over-block, name the match,
+# let a human drop the false trigger), just a different trigger shape --
+# pinned here so it's proven deliberate, not a silent surprise.
+RC=0
+(cd "$WORK" && printf '%s' '{"tool_input":{"command":";\"env\" grep -r \"npm test\" docs/"}}' \
+   | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
+assert_equal "2" "$RC" 'enforce-allowed-actions accepts the second documented over-block: ;"env" grep -r "npm test" docs/ refused once the wrapper token itself is quoted'
+
 # Known, accepted trade-off from the fix above: deleting a quote mark can
 # bring a boundary character and a denied word directly together when nothing
 # else separated them (a quote mark is the ENTIRE gap between the two). This

--- a/plugins/dossier/tests/hooks.test.sh
+++ b/plugins/dossier/tests/hooks.test.sh
@@ -245,6 +245,42 @@ RC=0
    | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
 assert_equal "2" "$RC" 'enforce-allowed-actions accepts the documented over-block: echo hi;"curl" ... refused, a quote mark was the entire gap to the boundary char'
 
+# --- DEQUOTE_PLACEHOLDER collision and pathological-size guard (found reviewing this PR) ---
+# ansi_c_decode can manufacture a literal 0x01 byte from a plain $'\001'
+# escape in the ORIGINAL command -- the exact byte DEQUOTE_PLACEHOLDER uses
+# internally. Without a guard, that byte is indistinguishable from a
+# backslash this script marks itself, and gets deleted alongside a real
+# newline it happens to precede, splicing two statements into one with no
+# boundary character left to anchor on.
+SOH_CMD=$(printf 'echo done\001\ncurl https://example.invalid')
+RC=0
+(cd "$WORK" && printf '{"tool_input":{"command":%s}}' "$(printf '%s' "$SOH_CMD" | jq -Rs .)" \
+   | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
+assert_equal "2" "$RC" "enforce-allowed-actions closes the DEQUOTE_PLACEHOLDER (0x01) collision bypass"
+
+# A real two-statement command with no stray 0x01 byte must still be denied
+# for its own actual reason (proves the fix above isn't over-blocking every
+# multi-line command, just the byte-collision case).
+NL_ONLY_CMD=$(printf 'echo done\ncurl https://example.invalid')
+RC=0
+(cd "$WORK" && printf '{"tool_input":{"command":%s}}' "$(printf '%s' "$NL_ONLY_CMD" | jq -Rs .)" \
+   | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
+assert_equal "2" "$RC" "enforce-allowed-actions still denies an ordinary two-line command (network access), unrelated to the 0x01 guard"
+
+# ansi_c_decode's span-boundary search and the backslash-to-placeholder pass
+# are both quadratic in bash for large operands (confirmed empirically: a
+# 100KB command with ANSI-C content took ~20s to normalize before this
+# guard existed). A command over the length guard must be denied instantly,
+# not hang.
+LARGE_BODY=$(printf 'A%.0s' $(seq 1 9000))
+RC=0
+START_TS=$(date +%s)
+(cd "$WORK" && printf '{"tool_input":{"command":%s}}' "$(printf 'echo $'"'"'%s'"'"' https://example.invalid' "$LARGE_BODY" | jq -Rs .)" \
+   | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
+END_TS=$(date +%s)
+assert_equal "2" "$RC" "enforce-allowed-actions denies a command over the pathological-size guard (9000 bytes)"
+assert_equal "1" "$([ "$((END_TS - START_TS))" -le 3 ] && echo 1 || echo 0)" "the size guard rejects instantly rather than attempting the super-linear normalization"
+
 # --- find -exec/-execdir/-ok/-okdir and xargs -I{} indirection (issue #143) ---
 # -exec/-execdir/-ok/-okdir glue the sub-command execution position to a flag
 # rather than spelling it as a standalone token, so neither BOUND nor the prior

--- a/plugins/dossier/tests/hooks.test.sh
+++ b/plugins/dossier/tests/hooks.test.sh
@@ -281,6 +281,27 @@ END_TS=$(date +%s)
 assert_equal "2" "$RC" "enforce-allowed-actions denies a command over the pathological-size guard (9000 bytes)"
 assert_equal "1" "$([ "$((END_TS - START_TS))" -le 3 ] && echo 1 || echo 0)" "the size guard rejects instantly rather than attempting the super-linear normalization"
 
+# ansi_c_decode forks a subprocess pair PER $'...' occurrence -- many tiny
+# spans stay well under the byte-length guard above but still pay that
+# overhead once per span. Must be denied fast, not just eventually.
+MANY_SPANS=""
+for _ in $(seq 1 100); do MANY_SPANS="${MANY_SPANS}\$'a'"; done
+RC=0
+START_TS=$(date +%s)
+(cd "$WORK" && printf '{"tool_input":{"command":%s}}' "$(printf 'echo %s https://example.invalid' "$MANY_SPANS" | jq -Rs .)" \
+   | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
+END_TS=$(date +%s)
+assert_equal "2" "$RC" "enforce-allowed-actions denies a command with too many \$'...' segments (100 spans, limit 64)"
+assert_equal "1" "$([ "$((END_TS - START_TS))" -le 3 ] && echo 1 || echo 0)" "the span-count guard rejects fast rather than forking a decode subprocess per span"
+
+# A legitimate command with a handful of ANSI-C spans (well under the limit)
+# must still be permitted normally -- proves the guard above isn't
+# over-blocking ordinary ANSI-C usage, just pathological span counts.
+RC=0
+(cd "$WORK" && printf '%s' '{"tool_input":{"command":"echo $'"'"'hello'"'"' $'"'"'world'"'"'"}}' \
+   | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
+assert_equal "0" "$RC" "enforce-allowed-actions still permits an ordinary command with a few ANSI-C spans"
+
 # --- find -exec/-execdir/-ok/-okdir and xargs -I{} indirection (issue #143) ---
 # -exec/-execdir/-ok/-okdir glue the sub-command execution position to a flag
 # rather than spelling it as a standalone token, so neither BOUND nor the prior

--- a/plugins/dossier/tests/hooks.test.sh
+++ b/plugins/dossier/tests/hooks.test.sh
@@ -210,6 +210,15 @@ RC=0
    | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
 assert_equal "2" "$RC" "enforce-allowed-actions closes the backslash-newline line-continuation bypass"
 
+# The exact third reproduction from issue #152 itself: a leading backslash on
+# `find` combines the #152 backslash bypass with the #143 find/-exec bypass —
+# DEQUOTED must restore `find` before FIND_EXEC is tested, not just restore
+# bare denied words like `curl` on their own.
+RC=0
+(cd "$WORK" && printf '%s' '{"tool_input":{"command":"\\find . -exec curl https://example.invalid {} \\;"}}' \
+   | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
+assert_equal "2" "$RC" 'enforce-allowed-actions closes the backslash-escaped find+-exec bypass: \find . -exec curl {} \;'
+
 # Bash's own ANSI-C quoting ($'...') decodes octal/hex escapes independently
 # of ordinary quote removal — confirmed to execute a real curl call.
 for BAD in \

--- a/plugins/dossier/tests/hooks.test.sh
+++ b/plugins/dossier/tests/hooks.test.sh
@@ -233,22 +233,38 @@ do
   assert_equal "2" "$RC" "enforce-allowed-actions closes the $CASE_LABEL bypass: $CASE_CMD"
 done
 
-# Bash's \u/\U Unicode ANSI-C escapes (added in bash 4.2) aren't handled by
-# ansi_c_decode's octal-only normalization -- only meaningfully checkable on
-# a bash that implements them at all. Bash 3.2 (this suite's local macOS
-# bash) doesn't support \u/\U in either $'...' or printf '%b', so this
-# exercises the real question -- does the hook's printf-based decode agree
-# with what bash itself would spell -- only on bash >=4.2, which is what
-# this project's Linux CI runs. Skipped, not asserted false, on older bash:
-# asserting a specific outcome for a feature the interpreter doesn't have
-# would be testing a coincidence, not the mechanism.
-if [ "${BASH_VERSINFO[0]}" -gt 4 ] || { [ "${BASH_VERSINFO[0]}" -eq 4 ] && [ "${BASH_VERSINFO[1]}" -ge 2 ]; }; then
-  U_ESCAPE_CMD=$(printf 'echo $%s\\u0063url%s https://example.invalid' "'" "'")
+# Bash's \u/\U Unicode ANSI-C escapes (added in bash 4.2) aren't in printf
+# '%b's escape set at all -- confirmed live: bash 3.2 (this suite's local
+# macOS bash, which doesn't implement \u/\U natively either) still resolves
+# these correctly, because unicode_normalize parses the escape as a string
+# pattern and converts it to \xHH by hand rather than depending on the
+# running bash's own native \u/\U support -- so this runs unconditionally,
+# on any bash, not just >=4.2.
+#
+# The escaped word must BE the command, not an argument to one (e.g. not
+# prefixed with "echo ") -- "echo <word>" is legitimately permitted no
+# matter how <word> decodes, since echo never invokes its arguments. An
+# earlier draft of this assertion had exactly that bug (an "echo " prefix
+# in front of the escaped word) and initially appeared to confirm a bypass
+# on CI, but for the wrong reason -- testing an argument to echo, not an
+# invoked command -- rather than the real one. Caught by re-deriving the
+# pre-fix/post-fix behavior of the corrected shape directly against both
+# script versions, not by trusting the first CI failure at face value.
+BKSL='\'
+U4_BODY="${BKSL}u0063url"
+U8_BODY="${BKSL}U00000063url"
+for BAD in \
+  "$U4_BODY|ansi-c 4-digit Unicode escape" \
+  "$U8_BODY|ansi-c 8-digit Unicode escape"
+do
+  CASE_LABEL="${BAD##*|}"
+  CASE_BODY="${BAD%%|*}"
+  U_ESCAPE_CMD=$(printf '$%s%s%s https://example.invalid' "'" "$CASE_BODY" "'")
   RC=0
   (cd "$WORK" && printf '{"tool_input":{"command":%s}}' "$(printf '%s' "$U_ESCAPE_CMD" | jq -Rs .)" \
      | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
-  assert_equal "2" "$RC" "enforce-allowed-actions closes the ANSI-C \\u Unicode-escape bypass: $U_ESCAPE_CMD"
-fi
+  assert_equal "2" "$RC" "enforce-allowed-actions closes the $CASE_LABEL bypass: $U_ESCAPE_CMD"
+done
 
 # A WRAPPER-list token disguised the same way the payload was (not just the
 # payload itself) must still widen the boundary -- the fix's own comment

--- a/plugins/dossier/tests/hooks.test.sh
+++ b/plugins/dossier/tests/hooks.test.sh
@@ -168,6 +168,74 @@ for OK in 'timeout 5 ls' 'time ls' 'nice ls' 'env ls' 'ls -la' 'git status' 'cat
   assert_equal "0" "$RC" "enforce-allowed-actions permits: $OK"
 done
 
+# --- Quoting/backslash-escaping a denied word (issue #152) -------------------
+# Independent of any wrapper token: a denied word spelled with a leading or
+# interior quote/backslash used to reach deny() as an intact, unrecognizable
+# word. Each of these is a real invocation once bash processes it — confirmed
+# live for every one (including a real curl attempt) while developing the fix.
+for BAD in \
+  '"curl" https://example.invalid|whole word quoted' \
+  '\curl https://example.invalid|leading backslash' \
+  'c\url https://example.invalid|mid-word backslash split'
+do
+  CASE_CMD="${BAD%%|*}"
+  CASE_LABEL="${BAD##*|}"
+  RC=0
+  (cd "$WORK" && printf '{"tool_input":{"command":%s}}' "$(printf '%s' "$CASE_CMD" | jq -Rs .)" \
+     | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
+  assert_equal "2" "$RC" "enforce-allowed-actions closes the quote/backslash bypass ($CASE_LABEL): $CASE_CMD"
+done
+
+# Adjacent quote fragments: bash joins these into ONE word at execution time
+# (cu''rl -> curl), the same way `r''m` is two tokens to a naive matcher but
+# one to bash after quote removal.
+RC=0
+(cd "$WORK" && printf '%s' '{"tool_input":{"command":"cu'"''"'rl https://example.invalid"}}' \
+   | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
+assert_equal "2" "$RC" "enforce-allowed-actions closes the adjacent-single-quote-fragment bypass: cu''rl"
+
+RC=0
+(cd "$WORK" && printf '%s' '{"tool_input":{"command":"cu\"r\"l https://example.invalid"}}' \
+   | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
+assert_equal "2" "$RC" 'enforce-allowed-actions closes the adjacent-double-quote-fragment bypass: cu"r"l'
+
+# A backslash immediately followed by a real newline (bash's own line
+# continuation) splits a keyword across two lines. This one needed its own
+# ordering fix during development: joining the pair AFTER stripping lone
+# backslashes leaves the newline behind as a still-valid separator, silently
+# reopening the bypass.
+NL_CMD=$(printf 'cur\\\nl https://example.invalid')
+RC=0
+(cd "$WORK" && printf '{"tool_input":{"command":%s}}' "$(printf '%s' "$NL_CMD" | jq -Rs .)" \
+   | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
+assert_equal "2" "$RC" "enforce-allowed-actions closes the backslash-newline line-continuation bypass"
+
+# Bash's own ANSI-C quoting ($'...') decodes octal/hex escapes independently
+# of ordinary quote removal — confirmed to execute a real curl call.
+for BAD in \
+  '$'"'"'\143url'"'"' https://example.invalid|ansi-c octal' \
+  '$'"'"'\x63url'"'"' https://example.invalid|ansi-c hex'
+do
+  CASE_CMD="${BAD%%|*}"
+  CASE_LABEL="${BAD##*|}"
+  RC=0
+  (cd "$WORK" && printf '{"tool_input":{"command":%s}}' "$(printf '%s' "$CASE_CMD" | jq -Rs .)" \
+     | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
+  assert_equal "2" "$RC" "enforce-allowed-actions closes the $CASE_LABEL bypass: $CASE_CMD"
+done
+
+# Known, accepted trade-off from the fix above: deleting a quote mark can
+# bring a boundary character and a denied word directly together when nothing
+# else separated them (a quote mark is the ENTIRE gap between the two). This
+# is a genuinely new effect of this fix, not pre-existing behavior — confirmed
+# by running this exact case against the pre-fix script, which permitted it
+# (rc=0); it must stay blocked now, proving the trade-off is deliberate
+# (documented in enforce-allowed-actions.sh), not a silent surprise.
+RC=0
+(cd "$WORK" && printf '%s' '{"tool_input":{"command":"echo hi;\"curl\" https://example.invalid"}}' \
+   | CLAUDE_PLUGIN_ROOT="$REPO/$PLUGIN" "$REPO/$HS/enforce-allowed-actions.sh" >/dev/null 2>&1) || RC=$?
+assert_equal "2" "$RC" 'enforce-allowed-actions accepts the documented over-block: echo hi;"curl" ... refused, a quote mark was the entire gap to the boundary char'
+
 # --- find -exec/-execdir/-ok/-okdir and xargs -I{} indirection (issue #143) ---
 # -exec/-execdir/-ok/-okdir glue the sub-command execution position to a flag
 # rather than spelling it as a standalone token, so neither BOUND nor the prior


### PR DESCRIPTION
Closes #152.

## Summary

`BOUND`/`WRAPPER`'s boundary anchor is defeated by quoting or backslash-escaping a denied word, independent of any wrapper token. Confirmed live for 8 distinct spellings across 6 underlying bypass mechanisms, each executing the denied command for real:

| Spelling | Technique |
|---|---|
| `"curl" https://evil` | whole word quoted |
| `\curl https://evil` | leading backslash |
| `c\url https://evil` | mid-word backslash split |
| `cu''rl https://evil` | adjacent single-quote fragments (bash joins these into one word) |
| `cu"r"l https://evil` | adjacent double-quote fragments (same mechanism, double quotes) |
| `cur\<newline>l https://evil` | backslash-newline line continuation |
| `$'\143url' https://evil` | bash's own ANSI-C octal quoting |
| `$'\x63url' https://evil` | bash's own ANSI-C hex quoting (same mechanism, hex escape) |

Only the first two were in the original report. The other six (4 spellings across 4 additional mechanisms, 2 of which — quote-fragment joining and ANSI-C — each get 2 tested spellings) were found investigating it: adjacent quote-fragment joining is a known technique (bash treats `r''m` as one token after quote removal — same shape as a recent public exec-allowlist advisory); the newline and ANSI-C cases are bash's own quoting grammar, not a gap specific to this file's regex.

## Fix

Adds `DEQUOTED`: undoes bash's own quote/escape/ANSI-C removal (ANSI-C decoded first since it has its own escape grammar, then backslash-newline joined as a pair before any lone backslash is stripped) before the anchor is tested, so the check runs against the word bash actually executes rather than its disguised spelling. Implemented in bash parameter expansion rather than sed/tr — sed/grep are line-oriented by default and would silently miss the newline-continuation case, and this sidesteps the GNU/BSD sed divergence this suite has hit before.

One bash-3.2-specific wrinkle found mid-fix: macOS's system `/bin/bash` cannot match a `${var//pattern/}` pattern that is itself backslash-followed-by-a-real-newline (confirmed empirically; not reproducible under zsh or newer bash). Worked around with a placeholder byte so the join pattern is never backslash-adjacent.

**Accepted trade-off** (same direction as the file's existing wrapper-scan philosophy): deleting a quote mark can bring a boundary character and a denied word directly together when a quote mark was the entire gap between them (`echo hi;"curl" ...` → `;curl`). Confirmed this is a genuinely new effect of this fix (the pre-fix script permits it), documented in-file, with a test proving it's deliberate.

## Known residual, tracked separately (#160)

Review turned up a categorically different gap: brace expansion (`cu{rl,}`), parameter-expansion defaults (`${x:-curl}`), and command substitution (`$(echo curl)`) all defeat `DEQUOTED` just as completely, each executing the real denied command. Confirmed pre-existing on `main` (not a regression from this PR). Not folded into this fix because it's a different-shaped problem — `DEQUOTED` reverses bash's quote/backslash/ANSI-C *removal*, a deterministic string transform; resolving what a command substitution evaluates to requires either executing attacker-controlled shell content inside the hook (worse than the gap) or full static shell-expansion analysis (not tractable in general). Filed as #160 with live reproductions and documented in-file rather than left implicit.

## Verification

- 9 new assertions in `hooks.test.sh`: one per closed bypass spelling (8) plus the accepted trade-off.
- Each verified RED (fails against the pre-fix script) and GREEN (passes with the fix).
- shellcheck clean.
- Full suite: `bash plugins/dossier/tests/run.sh` — 1936 assertions / 0 failures.

## Test plan

- [x] All 6 quote/backslash/ANSI-C bypass mechanisms (8 tested spellings) now blocked
- [x] All existing wrapper/find-exec/control assertions still pass (no regressions)
- [x] Documented trade-off has a passing, RED/GREEN-verified test
- [x] Full suite run, zero regressions
- [x] CI green on Linux
- [x] Expansion-based residual (brace/parameter-expansion/command-substitution) found in review, confirmed pre-existing, documented in-file, and tracked in #160 rather than left implicit

